### PR TITLE
DRY group permission checks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ perma_web/static/generated/*
 *.pyc
 perma_web/lib/phantomjs
 perma_web/perma/settings/settings.py
+.idea

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -122,6 +122,16 @@ class LinkUser(AbstractBaseUser):
         # Simplest possible answer: All admins are staff
         return self.is_admin
 
+    def has_group(self, group):
+        """
+            Return true if user is in the named group.
+            If group is a list, user must be in one of the groups in the list.
+        """
+        if hasattr(group, '__iter__'):
+            return self.groups.filter(name__in=group).exists()
+        else:
+            return self.groups.filter(name=group).exists()
+
 class Link(models.Model):
     """
     This is the core of the Perma link.

--- a/perma_web/perma/templates/admin-layout.html
+++ b/perma_web/perma/templates/admin-layout.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% load startswith %}
+{% load startswith has_group %}
 {% block row %}
 
 <!-- TODO: dashboard blurb and accompanying JS? -->
@@ -56,8 +56,8 @@
         <li{% if this_page == 'created_links' %} class="active"{% endif %}><a href="{% url 'user_management_created_links' %}" id="dashboard-library">Links</a></li>
 
         <!-- Vested links -->
-        {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' or user.groups.all.0.name == 'vesting_member' or user.groups.all.0.name == 'vesting_manager' %}
-        <li{% if this_page == 'vested_links' %} class="active"{% endif %}><a href="{% url 'user_management_vested_links' %}" id="dashboard-vested">Vested Links</a></li>
+        {% if user|has_group:'registrar_member,registry_member,vesting_member,vesting_manager' %}
+            <li{% if this_page == 'vested_links' %} class="active"{% endif %}><a href="{% url 'user_management_vested_links' %}" id="dashboard-vested">Vested Links</a></li>
         {% endif %}<!-- FIXME change icon -->
 		
 		{% comment %}
@@ -78,27 +78,27 @@
         <li{% if this_page == 'settings' %} class="active"{% endif %}><a href="{% url 'user_management_manage_account' %}" id="dashboard-settings">Settings</a></li>
 
         <!-- Manage users -->
-        {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' or user.groups.all.0.name == 'vesting_manager' %}
+        {% if user|has_group:'registrar_member,registry_member,vesting_manager' %}
         <li{% if this_page|startswith:"users" %} class="active"{% endif %}><a href="javascript:void(0);" id="dashboard-users">Manage Users</a></li>
         {% endif %}
 
         <!-- Registrars and registrar users -->
-        {% if user.groups.all.0.name == 'registry_member' %}
+        {% if user|has_group:'registry_member' %}
         <li class="dashboard-secondary users-secondary"{% if this_page|startswith:"users" %} style="display: list-item;"{% endif %}><a {% if this_page == "users_registrars" %}class="active"{% endif %}href="{% url 'user_management_manage_registrar' %}">Registrars</a></li>
         <li class="dashboard-secondary users-secondary"{% if this_page|startswith:"users" %} style="display: list-item;"{% endif %}><a {% if this_page == "users_registrar_members" %}class="active"{% endif %}href="{% url 'user_management_manage_registrar_member' %}">Registrar Users</a></li>{% endif %}
         
         <!-- Vesting managers aka journal managers -->
-        {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' %}
+        {% if user|has_group:'registrar_member,registry_member' %}
         <li class="dashboard-secondary users-secondary"{% if this_page|startswith:"users" %} style="display: list-item;"{% endif %}><a {% if this_page == "users_vesting_managers" %}class="active"{% endif %}href="{% url 'user_management_manage_journal_manager' %}">Vesting Managers</a></li>
         {% endif %}
 
         <!-- Vesting users -->
-        {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' or user.groups.all.0.name == 'vesting_manager' %}
+        {% if user|has_group:'registrar_member,registry_member,vesting_manager' %}
         <li class="dashboard-secondary users-secondary"{% if this_page|startswith:"users" %} style="display: list-item;"{% endif %}><a {% if this_page == "users_vesting_users" %}class="active"{% endif %}href="{% url 'user_management_manage_journal_member' %}">Vesting Users</a></li>
         {% endif %}
         
         <!-- Regular users -->
-        {% if user.groups.all.0.name == 'registry_member' %}
+        {% if user|has_group:'registry_member' %}
         <li class="dashboard-secondary users-secondary"{% if this_page|startswith:"users" %} style="display: list-item;"{% endif %}><a {% if this_page == "users_users" %}class="active"{% endif %}href="{% url 'user_management_manage_user' %}">Users</a></li>{% endif %}
         
   
@@ -122,26 +122,26 @@
       {% if user.is_authenticated %}
       {% block manage-created-links %}<li><a href="{% url 'user_management_created_links' %}">Created links</a></li>{% endblock %}
       {% endif %}
-      {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' or user.groups.all.0.name == 'vesting_member' %}
+      {% if user|has_group:'registrar_member,registry_member,vesting_member' %}
       {% block manage-nav-links %}<li><a href="{% url 'user_management_vested_links' %}">Vested links</a></li>{% endblock %}
       {% endif %}
-      {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' %}
+      {% if user|has_group:'registrar_member,registry_member' %}
       <li><h3><small>Manage users</small><h3></li>
       {% endif %}
-      {% if user.groups.all.0.name == 'registry_member' %}
+      {% if user|has_group:'registry_member' %}
       {% block manage-nav-registrar %}<li><a href="{% url 'user_management_manage_registrar' %}">Registrars</a></li>{% endblock %}
       {% block manage-nav-registry %}<li><a href="{% url 'user_management_manage_registrar_member' %}">Registrar users</a></li>{% endblock %}
       {% endif %}
       
-      {% if user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' %}
+      {% if user|has_group:'registrar_member,registry_member' %}
       {% block manage-nav-journal %}<li><a href="{% url 'user_management_manage_journal_member' %}">Vesting users</a></li>{% endblock %}
       {% endif %}
           
-      {% if user.groups.all.0.name == 'vesting_member' %}
+      {% if user|has_group:'vesting_member' %}
       {% block manage-nav-sponsor %}<li><a href="{% url 'user_management_sponsoring_library' %}">Sponsoring library</a></li>{% endblock %}
       {% endif %}
           
-      {% if user.groups.all.0.name == 'vesting_member' or user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'registry_member' %}
+      {% if user|has_group:'vesting_member,registrar_member,registry_member' %}
       <!--<li class="divider"></li>-->
       {% endif %}
           

--- a/perma_web/perma/templates/single-link.html
+++ b/perma_web/perma/templates/single-link.html
@@ -1,7 +1,5 @@
 {% extends "layout-archive.html" %}
-{% load file_exists %}
-{% load truncatesmart %}
-{% load diff %}
+{% load file_exists  truncatesmart diff has_group %}
 {% block title %} | {{linky.submitted_title}}{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -32,7 +30,7 @@
 				
 				<div class="span1">
 				 {% if not linky.vested %}
-					  {% if user.groups.all.0.name == 'registry_member' or user.groups.all.0.name == 'registrar_member' or user.groups.all.0.name == 'vesting_member' or user.groups.all.0.name == 'vesting_manager' %}
+					  {% if user|has_group:'registry_member,registrar_member,vesting_member,vesting_manager' %}
 						<form action="" method="post">
 						  {% csrf_token %}
 						  <input type="submit" value="vest" name="vet" class="btn">

--- a/perma_web/perma/templates/user_management/landing.html
+++ b/perma_web/perma/templates/user_management/landing.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | Admin{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -7,7 +8,7 @@
 {% block content %}
 
     <h3>Admin</h3>
-    {% if user.groups.all.0.name == 'registry_member' %}
+    {% if user|has_group:'registry_member' %}
     <!--<h3>You are a registry member at {{user.get_profile.registrar.name}} </h3>-->
     {% endif %}
 

--- a/perma_web/perma/templates/user_management/manage-account.html
+++ b/perma_web/perma/templates/user_management/manage-account.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | Settings{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -9,7 +10,7 @@
 {% block content %}
 
 	  <h3>Account settings</h3>
-	  {% if user.groups.all.0.name == 'vesting_member' or user.groups.all.0.name == 'vesting_manager' %}
+	  {% if user|has_group:'vesting_member,vesting_manager' %}
 		  <div class="sponsoring-library-info">
         <h4>Your sponsoring library</h4>
         {% if no_registrar %}

--- a/perma_web/perma/templates/user_management/manage_journal_managers.html
+++ b/perma_web/perma/templates/user_management/manage_journal_managers.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | Vesting managers{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -41,7 +42,7 @@
         <!--<th><input type="checkbox"></th>-->
         <th>Name<a href="?sort=last_name"> <i class="icon-chevron-up"></i></a><a href="?sort=-last_name"> <i class="icon-chevron-down"></i></a></th>
         <th>Email<a href="?sort=email"> <i class="icon-chevron-up"></i></a><a href="?sort=-email"> <i class="icon-chevron-down"></i></a></th>
-        {% if user.groups.all.0.name == 'registry_member' %}<th>Registrar<a href="?sort=registrar__name"> <i class="icon-chevron-up"></i></a><a href="?sort=-registrar__name"> <i class="icon-chevron-down"></i></a></th>{% endif %}
+        {% if user|has_group:'registry_member' %}<th>Registrar<a href="?sort=registrar__name"> <i class="icon-chevron-up"></i></a><a href="?sort=-registrar__name"> <i class="icon-chevron-down"></i></a></th>{% endif %}
         <th>Admin<a href="?sort=admin"> <i class="icon-chevron-up"></i></a><a href="?sort=-admin"> <i class="icon-chevron-down"></i></a></th>
       </tr>
     </thead>
@@ -55,7 +56,7 @@
           <!--<td><input type="checkbox"></td>-->
           <td>{{ manager.first_name }} {{ manager.last_name }}</td>
           <td>{{ manager.email }}</td>
-		  {% if user.groups.all.0.name == 'registry_member' %}<td>{{manager.registrar.name}}</td>{% endif %}
+		  {% if user|has_group:'registry_member' %}<td>{{manager.registrar.name}}</td>{% endif %}
 		    <td>
 		    {% if manager.is_active %}
           <a href="{% url 'user_management_manage_single_journal_manager' manager.id %}">edit/delete</a></td>

--- a/perma_web/perma/templates/user_management/manage_journal_members.html
+++ b/perma_web/perma/templates/user_management/manage_journal_members.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | Vesting members{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -41,7 +42,7 @@
         <!--<th><input type="checkbox"></th>-->
         <th>Name<a href="?sort=last_name"> <i class="icon-chevron-up"></i></a><a href="?sort=-last_name"> <i class="icon-chevron-down"></i></a></th>
         <th>Email<a href="?sort=email"> <i class="icon-chevron-up"></i></a><a href="?sort=-email"> <i class="icon-chevron-down"></i></a></th>
-        {% if user.groups.all.0.name == 'registry_member' %}<th>Registrar<a href="?sort=registrar__name"> <i class="icon-chevron-up"></i></a><a href="?sort=-registrar__name"> <i class="icon-chevron-down"></i></a></th>{% endif %}
+        {% if user|has_group:'registry_member' %}<th>Registrar<a href="?sort=registrar__name"> <i class="icon-chevron-up"></i></a><a href="?sort=-registrar__name"> <i class="icon-chevron-down"></i></a></th>{% endif %}
         <th>Admin<a href="?sort=admin"> <i class="icon-chevron-up"></i></a><a href="?sort=-admin"> <i class="icon-chevron-down"></i></a></th>
       </tr>
     </thead>
@@ -55,7 +56,7 @@
           <!--<td><input type="checkbox"></td>-->
           <td>{{ member.first_name }} {{ member.last_name }}</td>
           <td>{{ member.email }}</td>
-		  {% if user.groups.all.0.name == 'registry_member' %}<td>{{member.registrar.name}}</td>{% endif %}
+		  {% if user|has_group:'registry_member' %}<td>{{member.registrar.name}}</td>{% endif %}
           <td>
 			{% if member.is_active %}
 			<a href="{% url 'user_management_manage_single_journal_member' member.id%}">edit/delete</a>

--- a/perma_web/perma/templates/user_management/manage_registrar_members.html
+++ b/perma_web/perma/templates/user_management/manage_registrar_members.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | Registrar members{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -14,7 +15,7 @@
     <div class="alert alert-success alert-block"><h4>Account created!</h4> <strong>{{ added_user }}</strong> will receive an email with instructions on how to activate the account and create a password.</div>
   {% endif %}
 	
-	{% ifequal user.groups.all.0.name 'registry_member' %}
+	{% if user|has_group:'registry_member' %}
 	<div id="add-member" class="collapse {% if add_error %}in{% endif %}">
     <form method="post">
       {% csrf_token %}
@@ -34,7 +35,7 @@
       <button type="submit" class="btn">Add registrar member</button>
     </form>
   </div>
-	{% endifequal %}
+	{% endif %}
 		
 	<table class="table">
     <thead>

--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | User{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -19,7 +20,7 @@
     {% else %}
       <select name="a-group" id="id_a-group">
       {% for x,y in form.fields.group.choices %}
-      <option value="{{ x }}" {% if x == target_user.groups.all.0.id %} selected {% endif %} >{{ y }}</option>
+      <option value="{{ x }}" {% if target_user|has_group_by_id:x %} selected {% endif %} >{{ y }}</option>
       {% endfor %}
       </select>
     {% endif %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -1,4 +1,5 @@
 {% extends "admin-layout.html" %}
+{% load has_group %}
 {% block title %} | Users{% endblock %}
 {% block styles %}
 <link rel="stylesheet" href="{{ STATIC_PREFIX }}css/font-awesome.min.css">
@@ -14,7 +15,7 @@
     <div class="alert alert-success alert-block"><h4>Account created!</h4> <strong>{{ added_user }}</strong> will receive an email with instructions on how to activate the account and create a password.</div>
   {% endif %}
 	
-	{% ifequal user.groups.all.0.name 'registry_member' %}
+	{% if user|has_group:'registry_member' %}
 	<div id="add-member" class="collapse {% if add_error %}in{% endif %}">
     <form method="post">
       {% csrf_token %}
@@ -34,7 +35,7 @@
       <button type="submit" class="btn">Add user</button>
     </form>
   </div>
-	{% endifequal %}
+	{% endif %}
 		
 	<table class="table">
     <thead>

--- a/perma_web/perma/templatetags/has_group.py
+++ b/perma_web/perma/templatetags/has_group.py
@@ -1,0 +1,16 @@
+from django import template
+
+register = template.Library()
+
+@register.filter()
+def has_group(user, group_name):
+    """Usage: {% if user|has_group:"group_name,another_group_name" %}"""
+    if "," in group_name:
+        group_name = [n.strip() for n in group_name.split(',')]
+    return user.has_group(group_name)
+
+
+@register.filter()
+def has_group_by_id(user, group_id):
+    """Usage: {% if user|has_group:1 %}"""
+    return user.groups.filter(pk=int(group_id)).exists()

--- a/perma_web/perma/tests.py
+++ b/perma_web/perma/tests.py
@@ -13,6 +13,11 @@ class ViewsTestCase(TestCase):
     def setUp(self):
         pass
 
+    def log_in_user(self, username, password='pass'):
+        user_obj = LinkUser.objects.get(email=username)
+        resp = self.client.post(reverse('user_management_limited_login'), {'username':username,'password':password})
+        # TODO: check resp to see if login worked
+
     def test_public_views(self):
         """Test all public, static views, both logged in and logged out."""
 
@@ -28,18 +33,13 @@ class ViewsTestCase(TestCase):
         ]
 
         # try each view while logged in as each of these users
-        user_logins = [
-            None,
-            {'username':'test_registry_member@example.com','password':'pass'},
-        ]
+        user_logins = [None, 'test_registry_member@example.com']
 
         for user_login in user_logins:
 
             # user login
             if user_login:
-                user_obj = LinkUser.objects.get(email=user_login['username'])
-                resp = self.client.post(reverse('user_management_limited_login'),user_login)
-                # TODO: check resp to see if login worked
+                self.log_in_user(user_login)
             else:
                 user_obj = None
 
@@ -54,3 +54,79 @@ class ViewsTestCase(TestCase):
                     self.assertEqual(resp.context[-1]['user'], user_obj)
 
             self.client.logout()
+
+    def test_permissions(self):
+        """Test who can log into restricted pages."""
+        views = [
+            {
+                'urls': (
+                    reverse('user_management_manage_registrar'),
+                    reverse('user_management_manage_single_registrar', kwargs={'registrar_id': 1}),
+                    reverse('user_management_manage_registrar_member'),
+                    reverse('user_management_manage_single_registrar_member', kwargs={'user_id': 2}),
+                    reverse('user_management_manage_single_registrar_member_delete', kwargs={'user_id': 2}),
+                    reverse('user_management_manage_single_registrar_member_reactivate', kwargs={'user_id': 2}),
+                    reverse('user_management_manage_user'),
+                    reverse('user_management_manage_single_user', kwargs={'user_id': 4}),
+                    reverse('user_management_manage_single_user_delete', kwargs={'user_id': 4}),
+                    reverse('user_management_manage_single_user_reactivate', kwargs={'user_id': 4}),
+
+                ),
+                'allowed': ('test_registry_member@example.com',),
+                'denied': (
+                    'test_registrar_member@example.com', 'test_vesting_member@example.com', 'test_user@example.com',
+                    'test_vesting_manager@example.com')
+            },
+            {
+                'urls': (
+                    reverse('user_management_manage_journal_manager'),
+                    reverse('user_management_manage_single_journal_manager', kwargs={'user_id': 5}),
+                    reverse('user_management_manage_single_journal_manager_delete', kwargs={'user_id': 5}),
+                    reverse('user_management_manage_single_journal_manager_reactivate', kwargs={'user_id': 5}),
+                ),
+                'allowed': ('test_registry_member@example.com', 'test_registrar_member@example.com',),
+                'denied': (
+                    'test_vesting_member@example.com', 'test_user@example.com', 'test_vesting_manager@example.com')
+            },
+            {
+                'urls': (
+                    reverse('user_management_manage_journal_member'),
+                    reverse('user_management_manage_single_journal_member', kwargs={'user_id': 3}),
+                    reverse('user_management_manage_single_journal_member_delete', kwargs={'user_id': 3}),
+                    reverse('user_management_manage_single_journal_member_reactivate', kwargs={'user_id': 3}),
+                ),
+                'allowed': ('test_registry_member@example.com', 'test_registrar_member@example.com',
+                            'test_vesting_manager@example.com'
+                ),
+                'denied': ('test_vesting_member@example.com', 'test_user@example.com',)
+            },
+            {
+                'urls': (
+                    reverse('user_management_vested_links'),
+                ),
+                'allowed': ('test_registry_member@example.com', 'test_registrar_member@example.com',
+                            'test_vesting_manager@example.com', 'test_vesting_member@example.com',
+                ),
+                'denied': ('test_user@example.com',)
+            },
+        ]
+
+        for view in views:
+            for url in view['urls']:
+                # try while logged out
+                self.client.logout()
+                resp = self.client.get(url)
+                self.assertRedirects(resp, settings.LOGIN_URL+"?next="+url)
+
+                # try with valid users
+                for user in view['allowed']:
+                    self.log_in_user(user)
+                    resp = self.client.get(url)
+                    #import pdb; pdb.set_trace()
+                    self.assertEqual(resp.status_code, 200)
+
+                # try with invalid users
+                for user in view['denied']:
+                    self.log_in_user(user)
+                    resp = self.client.get(url)
+                    self.assertRedirects(resp, settings.LOGIN_REDIRECT_URL)

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -118,3 +118,28 @@ class favicon:
 
 
         return False
+
+
+
+### require_group decorator ###
+
+from functools import wraps
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.conf import settings
+
+def require_group(group, redirect_url=settings.LOGIN_REDIRECT_URL):
+    """
+        Require user to be logged in and belong to group with given name.
+        If group is a list, user must have one of the named groups.
+        If user does not belong to group, they will be sent to redirect_url.
+    """
+    def require_group_decorator(wrapped_func):
+        @login_required
+        @wraps(wrapped_func)
+        def wrapper(request, *args, **kwargs):
+            if not request.user.has_group(group):
+                return HttpResponseRedirect(redirect_url)
+            return wrapped_func(request, *args, **kwargs)
+        return wrapper
+    return require_group_decorator


### PR DESCRIPTION
This update adds a user.has_group() function, @require_group()
decorator and user|has_group template filter to allow for prettier
permissions checks. A side benefit is that permissions checks
will now work properly even if a user belongs to multiple groups,
if we decide we want to do things that way.

It also adds a unit test to ensure that all the user management views
accept who they should accept and reject who they should reject.

There are also a few style tweaks in user_management.py (normalize
indents, remove semicolons, reorganize imports).
