### PR TITLE
Tweak guid handling.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -233,15 +233,15 @@ class Link(models.Model):
         if '-' not in guid and (len(guid) == 10 or len(guid) == 11):
             return guid
 
-        canonical_guid = guid.replace('-', '')
-
+        # uppercase and remove non-alphanumerics
+        canonical_guid = re.sub('[^0-9A-Z]+', '', guid.upper())
 
         # split guid into 4-char chunks, starting from the end
         guid_parts = [canonical_guid[max(i - 4, 0):i] for i in
                       range(len(canonical_guid), 0, -4)]
 
         # stick together parts with '-'
-        return "-".join(reversed(guid_parts)).upper()
+        return "-".join(reversed(guid_parts))
 
     def move_to_folder_for_user(self, folder, user):
         """

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -117,7 +117,7 @@ urlpatterns = patterns('perma.views',
     url(r'^cdx$', 'common.cdx', name='cdx'),
 
     # Our Perma ID catchall
-    url(r'^%s/?$' % r'(?P<guid>.+)', 'common.single_linky', name='single_linky'),
+    url(r'^%s/?$' % r'(?P<guid>[^\./]+)', 'common.single_linky', name='single_linky'),
     
 )
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -129,12 +129,8 @@ def single_linky(request, guid):
 
         return HttpResponseRedirect(reverse('single_linky', args=[guid]))
 
-    # Replace all non-[a-zA-Z0-9] chars with a single hyphen
-    # We want to translate em-dashes, double hyphens and the like and redirect
-    if guid != re.sub('[^0-9a-zA-Z]+', '-', guid):
-        return HttpResponsePermanentRedirect(reverse('single_linky',
-            args=[re.sub('[^0-9a-zA-Z]+', '-', guid)]))
-
+    # Create a canonical version of guid (non-alphanumerics removed, hyphens every 4 characters, uppercase),
+    # and forward to that if it's different from current guid.
     canonical_guid = Link.get_canonical_guid(guid)
     if canonical_guid != guid:
         return HttpResponsePermanentRedirect(reverse('single_linky', args=[canonical_guid]))


### PR DESCRIPTION
I noticed our more-flexible code to handle mdashes in guids was also pulling in stuff like /robots.txt (which should just 404) and /media/foo in the dev server. So this refuses to match guids with . or / in them. I also stuck the mdash handling code into the get_canonical_guid function since it seemed to make sense there.
