### PR TITLE
Fix robots.txt and noarchive uppercase; add tests.

### DIFF
--- a/perma_web/perma/tests/utils.py
+++ b/perma_web/perma/tests/utils.py
@@ -1,6 +1,5 @@
 import json
-from django.conf import settings
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 
@@ -8,7 +7,7 @@ from perma.models import Registrar, VestingOrg
 
 
 @override_settings(RUN_TASKS_ASYNC=False)
-class PermaTestCase(TestCase):
+class PermaTestCase(TransactionTestCase):
     fixtures = ['fixtures/groups.json','fixtures/users.json',
                 'fixtures/archive.json']
 


### PR DESCRIPTION
It looks like there were bugs in our auto-darchive logic -- "noarchive" was missed if it wasn't lowercase, and robots.txt was missed if the mime type was wrong. This fixes those cases and adds some test cases to ensure proper darchiving.
