### PR TITLE
Looser accept-encoding in header check.

### DIFF
--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -191,7 +191,9 @@ def single_linky(request, guid):
         display_iframe = False
         if serve_type == 'live':
             try:
-                response = requests.head(link.submitted_url)
+                response = requests.head(link.submitted_url,
+                                         headers={'User-Agent': request.META['HTTP_USER_AGENT'], 'Accept-Encoding': '*'},
+                                         timeout=5)
                 display_iframe = 'X-Frame-Options' not in response.headers
                 # TODO actually check if X-Frame-Options specifically allows requests from us
             except:

--- a/perma_web/perma/views/link_management.py
+++ b/perma_web/perma/views/link_management.py
@@ -79,7 +79,7 @@ def create_link(request):
             target_url_headers = requests.head(
                 target_url,
                 verify=False, # don't check SSL cert?
-                headers={'User-Agent': request.META['HTTP_USER_AGENT']},
+                headers={'User-Agent': request.META['HTTP_USER_AGENT'], 'Accept-Encoding':'*'},
                 timeout=HEADER_CHECK_TIMEOUT
             ).headers
         except (requests.ConnectionError, requests.Timeout):


### PR DESCRIPTION
Fixes #628

Apparently some sites don't like the `requests` library's default Accept-Encoding header ("gzip, deflate, compress") for HEAD requests. Setting it to '*' works.

(Today I learned how to enable logging for the requests library -- see http://stackoverflow.com/questions/10588644/how-can-i-see-the-entire-request-thats-being-sent-to-paypal-in-my-python-applic )
