### PR TITLE
force ssl

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -163,6 +163,7 @@ MIDDLEWARE_CLASSES = (
     'mirroring.middleware.MirrorAuthenticationMiddleware',
     'mirroring.middleware.MirrorForwardingMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
+    'sslify.middleware.SSLifyMiddleware',   #Add SSL
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -48,3 +48,6 @@ WARC_HOST = 'user-content.perma.cc'
 THUMBNAIL_KVSTORE = 'sorl.thumbnail.kvstores.redis_kvstore.KVStore'
 THUMBNAIL_REDIS_HOST = 'localhost'
 THUMBNAIL_REDIS_PORT = '6379'
+
+# force SSL on heroku deployments
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -47,3 +47,6 @@ boto==2.29.1
 # sauce integration testing
 sauceclient==0.1.0
 pytest-xdist==1.10
+
+# SSL
+django-sslify>=0.2


### PR DESCRIPTION
I noticed that perma.cc doesn't force to https. I know that there _may_ be reasons not to have HTTPS, given the concern about authoritativeness, it seems that https should be default. So, I recommend using the sslify (https://github.com/rdegges/django-sslify) middleware.

Because it's using a redirect, it's not perfect, but it's better.
