### PR TITLE
Fix margins on archive page.

### DIFF
--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -386,6 +386,10 @@ section#main {
 section#main-archive {
     background-color: #fff;
     padding: 0px;
+
+    .row{
+        margin: 0;
+    }
 }
 
 


### PR DESCRIPTION
Here's a sample of the current bug:

http://perma-stage.law.harvard.edu/8XCZ-43V9

The correct fix involves upgrading bootstrap and reorganizing most of the landing page, so in the meantime let's just patch the margin for that one page.
