### PR TITLE
Fix wombat.js include on pywb playback.

### DIFF
--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -37,7 +37,7 @@ gevent==1.0.1
 
 # PyWB-related stuff
 surt==0.2						# our simple CDX server to canonicalize URL
-pywb==0.6.0
+pywb==0.6.3
 warcprox==1.2
 
 # alternate storages

--- a/perma_web/static/js/wombat.js
+++ b/perma_web/static/js/wombat.js
@@ -1,7 +1,7 @@
 /*
 Copyright(c) 2013-2014 Ilya Kreymer. Released under the GNU General Public License.
 
-This file is part of pywb.
+This file is part of pywb, https://github.com/ikreymer/pywb
 
     pywb is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -280,7 +280,6 @@ WB_wombat_init = (function() {
         var href = extract_orig(this._orig_href);
         parser.href = href;
         
-        //console.log(this._orig_href + " -> " + tmp_href);
         this._autooverride = false;
         
         var _set_hash = function(hash) {
@@ -495,7 +494,7 @@ WB_wombat_init = (function() {
     }
 
     //============================================
-    function rewrite_attr(elem, name) {
+    function rewrite_attr(elem, name, func) {
         if (!elem || !elem.getAttribute) {
             return;
         }
@@ -510,17 +509,31 @@ WB_wombat_init = (function() {
             return;
         }
 
-        //var orig_value = value;        
-        value = rewrite_url(value);
+        value = func(value);
 
         elem.setAttribute(name, value);
     }
-    
+
+    //============================================
+    function rewrite_style(value)
+    {
+        //console.log("style rewrite: " + value);
+
+        STYLE_REGEX = /(url\s*\(\s*[\\"']*)([^)'"]+)([\\"']*\s*\))/g;
+
+        function style_replacer(match, n1, n2, n3, offset, string) {
+            return n1 + rewrite_url(n2) + n3;
+        }
+
+        return value.replace(STYLE_REGEX, style_replacer);
+    }
+
     //============================================
     function rewrite_elem(elem)
     {
-        rewrite_attr(elem, "src");
-        rewrite_attr(elem, "href");
+        rewrite_attr(elem, "src", rewrite_url);
+        rewrite_attr(elem, "href", rewrite_url);
+        rewrite_attr(elem, "style", rewrite_style);
         
         if (elem && elem.getAttribute && elem.getAttribute("crossorigin")) {
             elem.removeAttribute("crossorigin");
@@ -699,7 +712,7 @@ WB_wombat_init = (function() {
         wb_replay_prefix = replay_prefix;
         
         if (wb_replay_prefix) {
-            wb_replay_date_prefix = replay_prefix + capture_date + "em_/";
+            wb_replay_date_prefix = replay_prefix + capture_date + "/";
             
             if (capture_date.length > 0) {
                 wb_capture_date_part = "/" + capture_date + "/";

--- a/perma_web/warc_server/head_insert.html
+++ b/perma_web/warc_server/head_insert.html
@@ -1,0 +1,34 @@
+{# copied/modified from pywb/ui/head_insert.html #}
+<!-- WB Insert -->
+{% if rule.js_rewrite_location and include_wombat %}
+<script src='{{ static_path }}js/wombat.js'> </script>
+<script>
+  {% set urlsplit = cdx.original | urlsplit %}
+  WB_wombat_init("{{ wbrequest.wb_prefix}}",
+                 "{{ cdx['timestamp'] if include_ts else ''}}",
+                 "{{ urlsplit.scheme }}",
+                 "{{ urlsplit.netloc }}",
+                 "{{ cdx.timestamp | format_ts('%s') }}");
+</script>
+{% endif %}
+<script>
+  wbinfo = {}
+  wbinfo.url = "{{ cdx.original }}";
+  wbinfo.timestamp = "{{ cdx.timestamp }}";
+  wbinfo.prefix = "{{ wbrequest.wb_prefix }}";
+  wbinfo.mod = "{{ wbrequest.wb_url.mod }}";
+  wbinfo.top_url = "{{ top_url }}";
+  wbinfo.is_live = {{ "true" if cdx.is_live else "false" }};
+  wbinfo.coll = "{{ wbrequest.coll }}";
+  wbinfo.proxy_magic = "{{ wbrequest.env.pywb_proxy_magic }}";
+</script>
+{#
+<script src='{{ static_path }}js/wb.js'> </script>
+
+{% include banner_html ignore missing %}
+
+<!-- load banner -->
+<script> if (_wb_js) { _wb_js.load(); }</script>
+ #}
+<!-- End WB Insert -->
+

--- a/services/heroku/extra_requirements.txt
+++ b/services/heroku/extra_requirements.txt
@@ -3,4 +3,3 @@
 
 dj_database_url==0.3.0
 dj-static==0.0.5
-redis==2.9.0


### PR DESCRIPTION
Pywb includes wombat.js to fix up URLs that are missed on the server-side. We have it in static/js, but pywb uses a different path. This fixes the path so it'll actually include properly.

DEPLOYMENT NOTES:
- run pip install -r requirements.txt to upgrade pywb to the latest version
- this requires changing the nginx config to add the /static/ route to user-content.perma.cc
