### PR TITLE
Change permissions on archive page.

### DIFF
--- a/perma_web/perma/templates/archive-error.html
+++ b/perma_web/perma/templates/archive-error.html
@@ -1,5 +1,5 @@
 {# called from pywb when a requested asset doesn't exist in the warc #}
-{% extends "layout-archive-responsive.html" %}
+{% extends "base-archive-responsive.html" %}
 
 {% block styles %}
 <style>

--- a/perma_web/perma/templates/base-archive-confirm.html
+++ b/perma_web/perma/templates/base-archive-confirm.html
@@ -1,4 +1,4 @@
-{% extends "layout-archive-responsive.html" %}
+{% extends "base-archive-responsive.html" %}
 
 {% block title %} | {{link.submitted_title}}{% endblock %}
 
@@ -40,11 +40,9 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
-        <div class="col-sm-6 col-sm-offset-3 centered">
-            <div class="yahowza">
-                 {% block confirm %}{% endblock %}
-            </div>
+    <div class="col-sm-6 col-sm-offset-3 centered">
+        <div class="yahowza">
+             {% block confirm %}{% endblock %}
         </div>
-    </div><!--row-->
+    </div>
 {% endblock %}

--- a/perma_web/perma/templates/base-archive-responsive.html
+++ b/perma_web/perma/templates/base-archive-responsive.html
@@ -22,9 +22,10 @@
     <body>
 		{% block header %}{% endblock header %}
 		<section id="main-archive">
-			<div id="main-content">
+			<div id="main-content" class="container-fluid">
 				<div class="row">
-			{% block row %}{% endblock row %}
+                    {% block content %}
+                    {% endblock content %}
 				</div><!--/.row-fluid-->
 			</div><!--/.main-container #main-content"-->
 		</section><!--/#main-->

--- a/perma_web/perma/templates/layout-archive-responsive.html
+++ b/perma_web/perma/templates/layout-archive-responsive.html
@@ -1,8 +1,0 @@
-{% extends "base-archive-responsive.html" %}
-{% block row %}
-
-<div class="row">
-{% block content %}
-{% endblock content %}
-</div><!--/.row-fluid-->
-{% endblock row %}

--- a/perma_web/perma/templates/single-link-header.html
+++ b/perma_web/perma/templates/single-link-header.html
@@ -1,4 +1,4 @@
-{% extends "layout-archive-responsive.html" %}
+{% extends "base-archive-responsive.html" %}
 {% load has_group is_darchive local_datetime mirror_tags count_archives %}
 {% block title %} | {{archive.submitted_title}}{% endblock %}
 {% block meta-head %}
@@ -164,9 +164,6 @@
 {% endblock %}
 
 {% block content %}
-
-
-<div class="row">
     <div class="overlay" onClick="style.pointerEvents='none'"></div>
 
     {% if archive.dark_archived and request.user|has_group:'registry_user,registrar_user,vesting_user' %}
@@ -234,7 +231,6 @@
    	    </div>
    	{% endif %}
    	{% endif %}
-</div><!--row-->
 <script>
 	var status_url = "{% main_url 'service_link_status' archive.guid %}";
 </script>

--- a/perma_web/perma/templates/single-link.html
+++ b/perma_web/perma/templates/single-link.html
@@ -1,4 +1,4 @@
-{% extends "layout-archive-responsive.html" %}
+{% extends "base-archive-responsive.html" %}
 {% load file_exists  truncatesmart has_group is_darchive local_datetime mirror_tags local_datetime %}
 
 {% block title %} | {{linky.submitted_title}}{% endblock %}
@@ -13,213 +13,209 @@
 {% endblock %}
 
 {% block header %}
-        <!-- Served up by Perma mirror, {{ request.META.HTTP_HOST }} -->
-<header>
-    	    <div class="navbar navbar-default navbar-static-top tab-border">
-				<div class="container">
-				 <div class="row">
-				 	<div class="col-sm-3 logo">
-				 		<a href="{% url 'landing' %}">perma.cc<img class="infinity-logo" src="{{ STATIC_URL }}img/infinity-logo2.png"></a>
-				 	</div><!--end span 3 -->
-				 	{% if linky.user_deleted %}
-				 	</div>
-				 	{% else %}
-				 	<div class="col-sm-6 meta-data">
-						<a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_title}}</a><br/>
-						
-						<!--<a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a>-->
-						<span class="light-grey">created {{ linky.creation_timestamp|local_datetime }} | {{ linky.view_count }} view{% if linky.view_count > 1 %}s{% endif %} </span>
-					</div><!--end span 6 -->
-					<div class="col-sm-offset-1 col-sm-1 button-set">
-					<ul class="vesting">
-						<li><a class="btn vest none" href="">hidden button</a></li><!-- to keep vertical spacing and layout simpler across states when there are and aren't buttons -->
-						{% if request.user.is_authenticated %}
-                        	{% if request.user|has_group:'registry_user,registrar_user,vesting_user' and not linky.vested %}
-                            	<li><form action="{% main_url 'vest_link' linky.guid %}" method="post">
-                                	{% csrf_token %}
-                                		<input type="submit" value="Vest site" name="vest" class="btn vest">
-                                	</form>
-                            	</li>	
-							{% endif %}
-							{% if request.user|has_group:'registry_user' %}
-								<a class="btn vest" href="{% url 'dark_archive_link' linky.guid %}">Dark archive</a>
-							{% endif %}
-							{% if request.user == linky.created_by and not linky.vested and not linky.dark_archive %}
-                        	 <a class="btn user-delete" href="{% url 'user_delete_link' linky.guid %}"><i class="icon-trash"></i> Delete</a>
-                        	{% endif %}
-                        {% endif %}
+    <!-- Served up by Perma mirror, {{ request.META.HTTP_HOST }} -->
+    <header>
+        <div class="navbar navbar-default navbar-static-top tab-border">
+            <div class="container">
+                <div class="row">
+                    <div class="col-sm-3 logo">
+                        <a href="{% url 'landing' %}">perma.cc<img class="infinity-logo" src="{{ STATIC_URL }}img/infinity-logo2.png"></a>
+                    </div><!--end span 3 -->
+                    <div class="col-sm-6 meta-data">
+                        {% if not linky.user_deleted or request.user == linky.created_by %}
+                            <a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_title}}</a><br/>
 
-						{% if request.user.is_authenticated %}
-                            <li><a class="btn dashboard" href="{% url 'create_link' %}" id="nav-button">Dashboard</a></li>
-                        {% else %}
-							
-							<!--Do we ever want a Log in Button?-->
-							{% comment %}
-                            <li><a class="btn vest" href="{% url 'user_management_limited_login' %}">Log in</a></li>
-                            {% endcomment %}
-                        
+                            <!--<a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a>-->
+                            <span class="light-grey">created {{ linky.creation_timestamp|local_datetime }} | {{ linky.view_count }} view{% if linky.view_count > 1 %}s{% endif %} </span>
                         {% endif %}
+                    </div><!--end span 6 -->
+                    <div class="col-sm-offset-1 col-sm-1 button-set">
+                        <ul class="vesting">
+                            <li><a class="btn vest none" href="">hidden button</a></li><!-- to keep vertical spacing and layout simpler across states when there are and aren't buttons -->
+                            {% if request.user.is_authenticated %}
+                                {% if not linky.user_deleted %}
+                                    {% if request.user|has_group:'registry_user,registrar_user,vesting_user' and not linky.vested %}
+                                        <li><form action="{% main_url 'vest_link' linky.guid %}" method="post">
+                                            {% csrf_token %}
+                                                <input type="submit" value="Vest site" name="vest" class="btn vest">
+                                            </form>
+                                        </li>
+                                    {% endif %}
+                                    {% if request.user|has_group:'registry_user' and not linky|is_darchive %}
+                                        <a class="btn vest" href="{% url 'dark_archive_link' linky.guid %}">Dark archive</a>
+                                    {% endif %}
+                                    {% if request.user == linky.created_by and not linky.vested %}
+                                        <a class="btn user-delete" href="{% url 'user_delete_link' linky.guid %}"><i class="icon-trash"></i> Delete</a>
+                                    {% endif %}
+                                {% endif %}
+
+                                <li><a class="btn dashboard" href="{% url 'create_link' %}" id="nav-button">Dashboard</a></li>
+                            {% endif %}
                         </ul>
-					</div><!--end span 3-->
-				 </div><!--end row -->
-				 <div class="row">
-				 
-				 	<div class="col-sm-10 col-sm-offset-1">	
-						<div class="navbar-header">
-						  <button type="button" class="navbar-toggle menu-adjust" data-toggle="collapse" data-target=".navbar-collapse">
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-							<span class="icon-bar"></span>
-						  </button>  
-						</div>
-						
-						<div class="navbar-collapse collapse" id="collapse-refresh">
-						  						  
-							{% if not linky|is_darchive or request.user|has_group:'registry_user,registrar_user,vesting_user' %}
+                    </div><!--end span 3-->
+                </div><!--end row -->
+                {% if not linky.user_deleted %}
+                    <div class="row">
 
-							<ul class="nav navbar-nav tabbed">
-								<li>
-									<a  class="tab-styling{% if serve_type == 'live' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=live">Live page view</a>
-								</li>
+                        <div class="col-sm-10 col-sm-offset-1">
+                            <div class="navbar-header">
+                              <button type="button" class="navbar-toggle menu-adjust" data-toggle="collapse" data-target=".navbar-collapse">
+                                <span class="icon-bar"></span>
+                                <span class="icon-bar"></span>
+                                <span class="icon-bar"></span>
+                              </button>
+                            </div>
 
-								{% if asset.image_capture and asset.image_capture != 'failed' and not asset.pdf_capture%}
-								<li>
-								{% if asset.image_capture == 'pending' %}
-									<span id="image_cap_container_loading" class="tab-styling">Screen capture</span>
-									<a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image" style="display:none;">Screen capture</a>
-								{% else %}
-									<span id="image_cap_container_loading" class="tab-styling" style="display:none;">Screen capture</span>
-									<a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image">Screen capture</a>
-								{% endif %}
-								</li>
-								{% endif %}
+                            <div class="navbar-collapse collapse" id="collapse-refresh">
 
-								{% if asset.warc_capture and asset.warc_capture != 'failed' %}
-								<li>
-								{% if asset.warc_capture == 'pending' %}	
-									<span id="warc_cap_container_loading" class="tab-styling">Archiving page</span>
-									<a id="warc_cap_container_complete" class="tab-styling{% if serve_type == 'source' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=source" style="display:none;">Archived page</a>
-								{% else %}
-									<span id="warc_cap_container_loading" class="tab-styling" style="display:none;">Archiving page</span> 
-									<!--<img src="{{ STATIC_URL }}img/dots.gif" alt="Archiving...">-->
-									<a id="warc_cap_container_complete" class="tab-styling{% if serve_type == 'source' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=source">Archived page</a>
-								{% endif %}
-								</li>
-								{% endif %}
-								
-								{% if asset.pdf_capture and asset.pdf_capture != 'failed' %}
-								<li>
-								{% if asset.pdf_capture == 'pending' %}	
-									<span id="pdf_cap_container_loading" class="tab-styling">Archiving PDF</span>
-									<a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf" style="display:none;">PDF</a>
-								{% else %}
-									<span id="pdf_cap_container_loading" class="tab-styling" style="display:none;">Archiving PDF</span> 
-									<a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf">PDF</a>
-								{% endif %}
-								</li>
-								{% endif %}
-							</ul>
-						{% endif %}
-						</div><!--/.nav-collapse -->
-					
-					</div><!--/.row -->
-					{% endif %}
-				</div><!--/container -->
-			</div><!--/navbar -->
-		</header>
+                                <ul class="nav navbar-nav tabbed">
+                                    <li>
+                                        <a  class="tab-styling{% if serve_type == 'live' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=live">Live page view</a>
+                                    </li>
+
+                                    {% if asset.image_capture and asset.image_capture != 'failed' and not asset.pdf_capture%}
+                                        <li>
+                                            {% if asset.image_capture == 'pending' %}
+                                                <span id="image_cap_container_loading" class="tab-styling">Screen capture</span>
+                                                <a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image" style="display:none;">Screen capture</a>
+                                            {% else %}
+                                                <span id="image_cap_container_loading" class="tab-styling" style="display:none;">Screen capture</span>
+                                                <a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image">Screen capture</a>
+                                            {% endif %}
+                                        </li>
+                                    {% endif %}
+
+                                    {% if asset.warc_capture and asset.warc_capture != 'failed' %}
+                                        <li>
+                                            {% if asset.warc_capture == 'pending' %}
+                                                <span id="warc_cap_container_loading" class="tab-styling">Archiving page</span>
+                                                <a id="warc_cap_container_complete" class="tab-styling{% if serve_type == 'source' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=source" style="display:none;">Archived page</a>
+                                            {% else %}
+                                                <span id="warc_cap_container_loading" class="tab-styling" style="display:none;">Archiving page</span>
+                                                <!--<img src="{{ STATIC_URL }}img/dots.gif" alt="Archiving...">-->
+                                                <a id="warc_cap_container_complete" class="tab-styling{% if serve_type == 'source' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=source">Archived page</a>
+                                            {% endif %}
+                                        </li>
+                                    {% endif %}
+
+                                    {% if asset.pdf_capture and asset.pdf_capture != 'failed' %}
+                                        <li>
+                                            {% if asset.pdf_capture == 'pending' %}
+                                                <span id="pdf_cap_container_loading" class="tab-styling">Archiving PDF</span>
+                                                <a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf" style="display:none;">PDF</a>
+                                            {% else %}
+                                                <span id="pdf_cap_container_loading" class="tab-styling" style="display:none;">Archiving PDF</span>
+                                                <a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf">PDF</a>
+                                            {% endif %}
+                                        </li>
+                                    {% endif %}
+                                </ul>
+                            </div>
+                        </div><!--/.nav-collapse -->
+
+                    </div><!--/.row -->
+                {% endif %}
+            </div><!--/container -->
+        </div><!--/navbar -->
+    </header>
 {% endblock %}
 
 {% block content %}
-   		
-			<div class="row">
-    {% if linky.dark_archived and request.user|has_group:'registry_user,registrar_user,vesting_user' %}
-    	<div class="col-sm-6 col-sm-offset-3 yahowza-small">
-			<div class="darchive">	
-				<img class="dark-bulb-small" src="{{ STATIC_URL }}img/dark-bulb.png">
-				<h2 class="orange">This link is in the <span class="dark">dark archive</span> because Perma.cc has complied with a takedown notice.</h2>
-			</div>
-		</div>
-	{% elif linky.dark_archived_robots_txt_blocked and request.user|has_group:'registry_user,registrar_user,vesting_user' %}
-    	<div class="col-sm-6 col-sm-offset-3 yahowza-small">
-    		<img class="dark-bulb-small" src="{{ STATIC_URL }}img/dark-bulb.png">
-			<h2>This link is in the <span class="dark">dark archive</span> because Perma.cc has <a href="{% url 'faq' %}#robots-text">respected the content creator's request to not share this archive publicly</a.>.</h2>
-		</div>
-	{% endif %}
-    {% if not linky|is_darchive or request.user|has_group:'registry_user,registrar_user,vesting_user' %}
-        {% if not linky.user_deleted %}
-	<div class="linky-view center">
-  		<div class="watermark center">
-			{% if not linky.vested and serve_type != 'live' %}
-				<div class="watermark-container">
-					<class ="row">
-						<div class="col-sm-4 col-sm-offset-1 col-xs-12">
-							<img src="{{ STATIC_URL }}img/stopwatch.png" class="img-responsive">
-						</div>
-						<div class="col-sm-6 col-xs-12">
-							<h2>Temporary Archive</h2>
-							<p>This archive is temporary and will expire on <span class="highlight">{{ linky.get_expiration_date|local_datetime:"M. j, Y" }}</span> unless <a href="{% url 'docs_perma_link_vesting' %}" target="_blank">vested</a>.</p>
-						</div>
-					</div>
-						
-				</div>
-			{% endif %}
+    {# deleted unvested link #}
+    {% if linky.user_deleted %}
+        <div class="col-sm-6 col-sm-offset-3 yahowza text-center">
+            {% if request.user == linky.created_by %}
+                <h2>You deleted this link.</h2>
+            {% else %}
+                <h1 class="cyan">Apologies.</h1><h2>This unvested link was deleted by the user who created it.</h2>
+            {% endif %}
+        </div>
 
-			{% if serve_type == 'live' %}
-				{% if display_iframe %}
-                    <iframe src="{{linky.submitted_url}}"{% if not asset.pdf_capture %} sandbox="allow-forms allow-scripts" {% endif %}>
-                        <p>You can access the archives using the tabs above or you open <a href="{{linky.submitted_url}}" target="_blank">{{linky.submitted_url}}</a> in a new browser window.</p>
+    {% else %}
+
+        {# message for a darchived link that user has permission to access #}
+        {% if linky|is_darchive and request.user|has_group:'registry_user,registrar_user,vesting_user' %}
+            <div class="col-sm-6 col-sm-offset-3 yahowza text-center">
+                <img class="dark-bulb center" src="{{ STATIC_URL }}img/dark-bulb.png">
+                {% if linky.dark_archived %}
+                    <h2>This link is in the <span class="dark">dark archive</span>.</h2>
+                {% elif linky.dark_archived_robots_txt_blocked %}
+                    <h2>This link is in the <span class="dark">dark archive</span> because Perma.cc has <a href="{% url 'faq' %}#robots-text">respected the content creator's request to not share this archive publicly</a>.</h2>
+                {% endif %}
+                <p>You can see the contents only because you are logged into a vesting account.</p>
+            </div>
+            </div><div class="row"> {# go to next row #}
+        {% endif %}
+
+        {# link contents #}
+        <div class="linky-view center col-sm-12">
+            <div class="watermark center">
+
+                {% if not linky.vested and serve_type != 'live' %}
+                    {% if not linky|is_darchive or request.user|has_group:'registry_user,registrar_user,vesting_user' %}
+                        <div class="watermark-container">
+                            <div class="row">
+                                <div class="col-sm-4 col-sm-offset-1 col-xs-12">
+                                    <img src="{{ STATIC_URL }}img/stopwatch.png" class="img-responsive">
+                                </div>
+                                <div class="col-sm-6 col-xs-12">
+                                    <h2>Temporary Archive</h2>
+                                    <p>This archive is temporary and will expire on <span class="highlight">{{ linky.get_expiration_date|local_datetime:"M. j, Y" }}</span> unless <a href="{% url 'docs_perma_link_vesting' %}" target="_blank">vested</a>.</p>
+                                </div>
+                            </div>
+
+                        </div>
+                    {% endif %}
+    			{% endif %}
+        
+                {% if serve_type == 'live' %}
+                    {% if display_iframe %}
+                        <iframe src="{{linky.submitted_url}}"{% if not asset.pdf_capture %} sandbox="allow-forms allow-scripts" {% endif %}>
+                            <p>You can access the archives using the tabs above or you open <a href="{{linky.submitted_url}}" target="_blank">{{linky.submitted_url}}</a> in a new browser window.</p>
+                        </iframe>
+                    {% else %}
+                        <div class="translucent-background no-live-preview"><h2>Live site view unavailable. Sorry.</h2>
+                            <p>You can access the archives by using the tabs above or open <a href="{{linky.submitted_url}}" target="_blank">{{linky.submitted_url}}</a> in a new browser window.</p>
+                        </div>
+                    {% endif %}
+
+                {% elif linky|is_darchive and not request.user|has_group:'registry_user,registrar_user,vesting_user' %}
+                    <img class="dark-bulb center" src="{{ STATIC_URL }}img/dark-bulb.png">
+                    <h1 class="cyan">Apologies.</h1>
+                    <h2>
+                        This link is not available in our public archive.<br/>
+                        Contact a participating librarian to get a copy.
+                    </h2>
+                    {% comment %}
+                        <br/>
+                        {% if linky.dark_archived %}
+                            <p>This link is in the <span class="dark">dark archive</span> because Perma.cc has complied with a takedown notice.</p>
+                        {% elif linky.dark_archived_robots_txt_blocked %}
+                            <p>This link is in the <span class="dark">dark archive</span> because Perma.cc has <a href="{% url 'faq' %}#robots-text">respected the content creator's request to not share this archive publicly</a>.</p>
+                        {% endif %}
+                    {% endcomment %}
+
+                {% elif serve_type == 'image' %}
+                    <img class="image-view" src="{{ MEDIA_URL }}{{ asset.image_url }}"/>
+
+                {% elif serve_type == 'pdf' %}
+                    <iframe src="{{ MEDIA_URL }}{{ asset.pdf_url }}">
+                        <p>Unable to create a live view of <a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a></p>
                     </iframe>
-				{% else %}
-                    <div class="translucent-background no-live-preview"><h2>Live site view unavailable. Sorry.</h2>
-                        <p>You can access the archives by using the tabs above or open <a href="{{linky.submitted_url}}" target="_blank">{{linky.submitted_url}}</a> in a new browser window.</p>
-                    </div>
-				{% endif %}
 
-			{% elif serve_type == 'image' %}
-			    <img class="image-view" src="{{ MEDIA_URL }}{{ asset.image_url }}"/>
+                {% elif serve_type == 'source' %}
+                    <iframe src="{{ warc_url }}" sandbox="allow-forms allow-scripts allow-top-navigation">
+                        <p>Unable to create a live view of <a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a></p>
+                    </iframe>
 
-			{% elif serve_type == 'pdf' %}
-                <iframe src="{{ MEDIA_URL }}{{ asset.pdf_url }}">
-                    <p>Unable to create a live view of <a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a></p>
-                </iframe>
+                {% endif %}
+            </div><!--end watermark-->
+        </div><!--end linky-view-->
 
-			{% elif serve_type == 'source' %}
-                <iframe src="{{ warc_url }}" sandbox="allow-forms allow-scripts allow-top-navigation">
-                    <p>Unable to create a live view of <a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a></p>
-                </iframe>
-			{% endif %}
-		</div><!--end watermark-->
-   	</div><!--end linky-view-->
-   	
-   	{% elif linky|is_darchive %}
-   		<div class="container">
-			<div class="row">
-				<div class="col-sm-12 yahowza">
-					<img class="dark-bulb center" src="{{ STATIC_URL }}img/dark-bulb.png">
-					 <h1 class="cyan">Apologies.</h1><h2>This link has been <span class="dark">dark archived</span>.<br/>Contact a librarian to get a copy.</h2>
-					<br/>
-					{% if linky.dark_archived %}
-						<p>This link is in the <span class="dark">dark archive</span> because Perma.cc has complied with a takedown notice.</p>
-					{% elif linky.dark_archived_robots_txt_blocked %}
-						<p>This link is in the <span class="dark">dark archive</span> because Perma.cc has <a href="{% url 'faq' %}#robots-text">respected the content creator's request to not share this archive publicly</a>.</p>
-					{% endif %}
-				</div>
-			</div>
-   	    </div>
-   	 {% else %}
-   	    <div class="container">
-			<div class="row">
-				<div class="col-sm-12 yahowza">
-					 <h1 class="cyan">Apologies.</h1><h2>This unvested link was deleted by the user who created it.</h2>
-				</div>
-			</div>
-   	    </div>
    	{% endif %}
-   	{% endif %}
-</div><!--row-->
-<script>
-	var status_url = "{% main_url 'service_link_status' linky.guid %}";
-</script>
+    <script>
+        var status_url = "{% main_url 'service_link_status' linky.guid %}";
+    </script>
 {% endblock %}
 
 {% block scripts %}

--- a/perma_web/perma/templatetags/has_group.py
+++ b/perma_web/perma/templatetags/has_group.py
@@ -5,6 +5,8 @@ register = template.Library()
 @register.filter()
 def has_group(user, group_name):
     """Usage: {% if user|has_group:"group_name,another_group_name" %}"""
+    if not hasattr(user, 'has_group'):
+        return False  # AnonymousUser
     if "," in group_name:
         group_name = [n.strip() for n in group_name.split(',')]
     return user.has_group(group_name)
@@ -12,5 +14,5 @@ def has_group(user, group_name):
 
 @register.filter()
 def has_group_by_id(user, group_id):
-    """Usage: {% if user|has_group:1 %}"""
+    """Usage: {% if user|has_group_by_id:1 %}"""
     return user.groups.filter(pk=int(group_id)).exists()

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -55,6 +55,10 @@ body {
 
 .container-fluid {
     padding: 0;
+
+    .row > div{
+        padding:0;
+    }
 }
 
 .modal {


### PR DESCRIPTION
- If an archive is deleted, you see one message if you deleted it and another message if someone else did.
- If an archive is in the darchive:
  - All users see the same thing for live view.
  - For archive view, vesting+ users see a message along with the archive, and non-vesting users see a "contact a participating librarian" message. 
  - I commented out the "in the dark archive because ..." message, because it's not accurate yet -- it reports a takedown request no matter why we darchive something.

HTML cleanup: remove some redundant <div class="row"> tags, and the layout-archive-responsive template that was confusing things.
