### PR TITLE
Mirroring fixes v.2

### DIFF
--- a/perma_web/fabfile.py
+++ b/perma_web/fabfile.py
@@ -225,6 +225,23 @@ def sync_mirror():
     from mirroring.tasks import sync_mirror
     sync_mirror()
 
+def generate_keys():
+    """
+        Generate a keypair suitable for settings.py on the main server.
+    """
+    if '/vagrant/' in __file__:
+        print "WARNING: This command does not run well under Vagrant, as it requires random entropy."
+    import gnupg
+    gpg = gnupg.GPG(gnupghome=settings.GPG_DIRECTORY)
+    gpg_input = gpg.gen_key_input()  # use sensible defaults
+    print "Generating keypair with this input: %s" % gpg_input
+    key = gpg.gen_key(gpg_input)
+    print "Copy these keys into settings.py on the main server, and into UPSTREAM_SERVER['public_key'] on the mirror servers:"
+    print "\nGPG_PUBLIC_KEY = %s\nGPG_PRIVATE_KEY = %s" % (
+        repr(gpg.export_keys(key.fingerprint)),  # public key
+        repr(gpg.export_keys(key.fingerprint, True))  # private key
+    )
+
 
 ### HEROKU ###
 

--- a/perma_web/mirroring/management/commands/runmirror.py
+++ b/perma_web/mirroring/management/commands/runmirror.py
@@ -126,6 +126,7 @@ class Command(BaseCommand):
                 DJANGO__DATABASES__default__NAME=mirror_database,
                 DJANGO__MIRROR_SERVER='True',
                 DJANGO__UPSTREAM_SERVER__address='http://%s:%s' % (main_server_address, main_server_port),
+                DJANGO__UPSTREAM_SERVER__public_key=settings.GPG_PUBLIC_KEY,
                 #DJANGO__RUN_TASKS_ASYNC='False',
                 DJANGO__MEDIA_ROOT=temp_dir.name,
                 DJANGO__WARC_HOST='%s:%s' % (mirror_server_media, router_port),

--- a/perma_web/mirroring/models.py
+++ b/perma_web/mirroring/models.py
@@ -1,0 +1,26 @@
+from django.core import serializers
+from perma.models import LinkUser
+
+
+class FakeLinkUser(LinkUser):
+    """
+        This is a fake user for use on mirror servers.
+        It will be created from a serialized user object put in a cookie by the upstream server.
+    """
+
+    @classmethod
+    def init_from_serialized_user(cls, serialized_user):
+        serialized_user = serialized_user.replace('perma.linkuser', 'mirroring.fakelinkuser')
+        return serializers.deserialize("json", serialized_user).next().object
+
+    class Meta:
+        proxy = True
+
+    def is_authenticated(self):
+        return True
+
+    def save(self, *args, **kwargs):
+        raise NotImplementedError("FakeLinkUser should never be saved.")
+
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError("FakeLinkUser should never be deleted.")

--- a/perma_web/mirroring/utils.py
+++ b/perma_web/mirroring/utils.py
@@ -1,8 +1,13 @@
 import datetime
 from functools import wraps
+import hashlib
+import gnupg
 import pytz
+import re
 
+from django.conf import settings
 from django.utils.decorators import available_attrs
+from django.core.cache import cache as django_cache
 
 
 ### must_be_mirrored decorator ###
@@ -45,3 +50,43 @@ def serialize_datetime(dt):
 def unserialize_datetime(dt_string):
     return pytz.UTC.localize(datetime.datetime.strptime(dt_string, "%Y-%m-%d %H:%M:%S"))
 
+
+### gpg ###
+
+gpg = gnupg.GPG(gnupghome=settings.GPG_DIRECTORY)
+_fingerprint_cache = {}
+
+def get_fingerprint(key):
+    """
+        Because gnupg calls out to a command-line tool, we don't pass keys directly. Instead we have to install the
+        key in gpg's keychain and then refer to it by fingerprint. This function installs the key (if we haven't done
+        that yet this run) then returns the fingerprint.
+    """
+    if key not in _fingerprint_cache:
+        _fingerprint_cache[key] = gpg.import_keys(key).fingerprints[0]
+    return _fingerprint_cache[key]
+
+def sign_message(message, key=settings.GPG_PRIVATE_KEY):
+    if not key:
+        return message
+    fingerprint = get_fingerprint(key)
+    return gpg.sign(message, keyid=fingerprint)
+
+def read_signed_message(message, key=settings.UPSTREAM_SERVER.get('public_key') if settings.MIRROR_SERVER else settings.GPG_PUBLIC_KEY):
+    if not key:
+        return message
+
+    # We cache decoded cookies because this will have to be done on each request.
+    cache_key = 'gpg-' + hashlib.sha256(message).hexdigest()
+    verified_message = django_cache.get(cache_key)
+
+    if not verified_message:
+        # Not in cache, run decode.
+        fingerprint = get_fingerprint(key)
+        verified_message = gpg.decrypt(message)  # decrypt instead of verify, even if message isn't encrypted, so we get the message content in verified_message.data
+        if verified_message.fingerprint != fingerprint:
+            raise Exception("Signature verification failed: fingerprint does not match %s for message %s." % (fingerprint, message))
+        verified_message = verified_message.data[:-1]  # strip extra \n that gpg adds
+        django_cache.set(cache_key, verified_message)
+
+    return verified_message

--- a/perma_web/mirroring/views.py
+++ b/perma_web/mirroring/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 
 from perma.models import Asset, Link
 from perma.utils import run_task
-from perma.views.common import single_link_header, single_linky
+from perma.views.common import single_linky
 
 from .tasks import update_perma, compress_link_assets
 from .utils import must_be_mirrored, may_be_mirrored
@@ -53,6 +53,7 @@ def single_link_json(request, guid):
         the data necessary for the mirror to render the page.
     """
     return single_linky(request, guid)
+
 
 @may_be_mirrored
 def manifest(request):

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -159,7 +159,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'mirroring.middleware.MirrorCsrfViewMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'mirroring.middleware.MirrorAuthenticationMiddleware',
     'mirroring.middleware.MirrorForwardingMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
@@ -344,17 +344,26 @@ MIRROR_USERS_SUBDOMAIN = 'dashboard'
 DIRECT_MEDIA_URL = MEDIA_URL        # URL to load media from this server in particular -- primarily useful for main server
 
 # Where to fetch new archives from, if we are a mirror.
-UPSTREAM_SERVER = {
-    'address':'http://perma.cc',
-    'headers':{
-        #'Host':'perma.cc',  # example -- handy if fetching updates over a VPN, where 'address' might be a local IP address instead of domain name
-    },
-}
+UPSTREAM_SERVER = {}
+## Example:
+# UPSTREAM_SERVER = {
+#     'address':'http://perma.cc',
+#     'headers':{
+#         #'Host':'perma.cc',  # example -- handy if fetching updates over a VPN, where 'address' might be a local IP address instead of domain name
+#     },
+#     'public_key':None,
+# }
 
 # Where to push updates to.
 # Each entry in this list is a dict in the same format as UPSTREAM_SERVER, above.
 # Note that we can have both an upstream and downstream servers if this and UPSTREAM_SERVER are set.
 DOWNSTREAM_SERVERS = []
+
+# signing/encryption
+GPG_DIRECTORY = None  # use default
+GPG_PUBLIC_KEY = None
+GPG_PRIVATE_KEY = None
+
 
 # where we will store zip archives created for transferring to mirrors
 # this is relative to MEDIA_ROOT
@@ -386,4 +395,8 @@ DIRECT_WARC_HOST = None     # host to load warc from this server in particular -
 # the prod and dev configs are considerably different. See those configs for
 # details
 THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.pil_engine.Engine' # Change this to Wand when sorl 12.x is released (since we use Wand for PDF thumbnail creation)
-THUMBNAIL_FORMAT = 'PNG' # 
+THUMBNAIL_FORMAT = 'PNG' #
+
+
+# feature flags
+SINGLE_LINK_HEADER_TEST = False

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -31,6 +31,8 @@ CELERYBEAT_SCHEDULE = {
 # If a task is running longer than five minutes, kill it
 CELERYD_TASK_TIME_LIMIT = 300
 
+# logging
+LOGGING['handlers']['default']['filename'] = '/var/log/perma/perma.log'
 PHANTOMJS_LOG = '/var/log/perma/phantom.log'
 
 # default vesting org for links vested by registry users

--- a/perma_web/perma/templates/includes/folder_select.html
+++ b/perma_web/perma/templates/includes/folder_select.html
@@ -1,16 +1,15 @@
 {% load mptt_tags repeat %}
-
 <select name="folder">
     {% if all_folder_trees %}
         {% for tree in all_folder_trees %}
             {% recursetree tree %}
-                <option value="{{ node.pk }}">{{ "&nbsp;&nbsp;"|repeat:node.display_level|safe }}- {{ node.name }}</option>
+                <option value="{{ node.pk }}" {% if selected_folder.pk == node.pk %}selected{% endif %}>{{ "&nbsp;&nbsp;"|repeat:node.display_level|safe }}- {{ node.name }}</option>
                 {% if not node.is_leaf_node %}{{ children }}{% endif %}
             {% endrecursetree %}
         {% endfor %}
     {% elif folder_tree %}
         {% recursetree folder_tree %}
-            <option value="{{ node.pk }}">{{ "&nbsp;&nbsp;"|repeat:node.display_level|safe }}- {{ node.name }}</option>
+            <option value="{{ node.pk }}" {% if selected_folder.pk == node.pk %}selected{% endif %}>{{ "&nbsp;&nbsp;"|repeat:node.display_level|safe }}- {{ node.name }}</option>
             {% if not node.is_leaf_node %}{{ children }}{% endif %}
         {% endrecursetree %}
     {% endif %}

--- a/perma_web/perma/templates/link-vest-confirm.html
+++ b/perma_web/perma/templates/link-vest-confirm.html
@@ -24,7 +24,7 @@
             </p>
         {% endif %}
         <div class="centered-box">
-            <a href="/{{ link.guid }}" class="cancel-button">Cancel</a> <button type="submit" class="btn btn-success">Vest</button>
+            <a href="/{{ link.guid }}" class="cancel-button">Cancel</a> <button type="submit" class="btn btn-success" name="vest" value="1">Vest</button>
         </div>
     </form>
 {% endblock %}

--- a/perma_web/perma/templates/single-link-header.html
+++ b/perma_web/perma/templates/single-link-header.html
@@ -37,7 +37,7 @@
                                 <a href="{{archive.submitted_url}}" target="_blank">{{ archive.submitted_url|truncatechars:130 }}</a>
                             </p>
                             <p class="creation-details">
-                                created {{ archive.creation_timestamp|local_datetime }} <span class="spacer">·</span>  <a href="{% url 'docs_perma_link_vesting'%}#vesting" target="_blank">not vested</a> <span class="spacer">·</span> viewed {{ archive.view_count }} time{% if archive.view_count > 1 %}s{% endif %} <span class="spacer">·</span> <a href="{% url 'contact' %}?message=Please have a look at perma.cc{% url 'single_link_header' archive.guid %} " target="_blank">report abuse</a>
+                                created {{ archive.creation_timestamp|local_datetime }} <span class="spacer">·</span>  <a href="{% url 'docs_perma_link_vesting'%}#vesting" target="_blank">not vested</a> <span class="spacer">·</span> viewed {{ archive.view_count }} time{% if archive.view_count > 1 %}s{% endif %} <span class="spacer">·</span> <a href="{% url 'contact' %}?message=Please have a look at perma.cc{% url 'single_linky' archive.guid %} " target="_blank">report abuse</a>
                             </p>
                         </div><!--end 9 -->
                         <div class="col-xs-12 col-sm-3">
@@ -76,7 +76,7 @@
 
                     {% if asset.image_capture and asset.image_capture != 'failed' %}
                     <div class="col-sm-6 image-container">
-                        {% if serve_type != 'image' %}<a href="{% url 'single_link_header' archive.guid %}">{% endif %}
+                        {% if serve_type != 'image' %}<a href="{% url 'single_linky' archive.guid %}">{% endif %}
                         <div class="{% if serve_type == 'image' %}selected-archive-container{% endif %} archive-container" style="overflow: hidden; ">
                             <div style="float: left; min-width: 55px;">
                                 <img src="{{ STATIC_URL }}img/static_capture_icon.png" class="" style="margin-top: 2px;" height=76px width=53px>
@@ -97,7 +97,7 @@
 
                     {% if asset.warc_capture and asset.warc_capture != 'failed' %}
                     <div class="col-sm-6 source-container">
-                        {% if serve_type != 'source' %}<a href="{% url 'single_link_header' archive.guid %}?type=source">{% endif %}
+                        {% if serve_type != 'source' %}<a href="{% url 'single_linky' archive.guid %}?type=source">{% endif %}
                             <div class="{% if serve_type == 'source' %}selected-archive-container{% endif %} archive-container" style="overflow: hidden; ">
                                 <div style="float: left; min-width: 55px;">
                                         <img src="{{ STATIC_URL }}img/lsource_capture_icon.png" style="margin-top: 2px;" height=76px width=53px>
@@ -118,7 +118,7 @@
 
                     {% if asset.pdf_capture and asset.pdf_capture != 'failed' %}
                     <div class="col-sm-6 pdf-container">
-                        {% if serve_type != 'pdf' %}<a href="{% url 'single_link_header' archive.guid %}?type=pdf_capture">{% endif %}
+                        {% if serve_type != 'pdf' %}<a href="{% url 'single_linky' archive.guid %}?type=pdf_capture">{% endif %}
                             <div class="{% if serve_type == 'pdf' %}selected-archive-container{% endif %} archive-container" style="overflow: hidden; ">
                                 <div style="float: left; min-width: 55px;">
                                         <img src="{{ STATIC_URL }}img/pdf_capture_icon.png" style="margin-top: 2px;" height=76px width=53px>

--- a/perma_web/perma/templates/single-link.html
+++ b/perma_web/perma/templates/single-link.html
@@ -35,23 +35,21 @@
                             {% if request.user.is_authenticated %}
                                 {% if not linky.user_deleted %}
                                     {% if request.user|has_group:'registry_user,registrar_user,vesting_user' and not linky.vested %}
-                                        <li><form action="{% main_url 'vest_link' linky.guid %}" method="post">
-                                            {% csrf_token %}
-                                                <input type="submit" value="Vest site" name="vest" class="btn vest">
-                                            </form>
-                                        </li>
+                                        <a class="btn vest" href="{% main_url 'vest_link' linky.guid %}">Vest site</a>
                                     {% endif %}
+
                                     {% if request.user|has_group:'registry_user' and not linky|is_darchive %}
-                                        <a class="btn vest" href="{% url 'dark_archive_link' linky.guid %}">Dark archive</a>
+                                        <a class="btn vest" href="{% main_url 'dark_archive_link' linky.guid %}">Dark archive</a>
                                     {% elif request.user|has_group:'registrar_user' and not linky|is_darchive and linky.vesting_org.registrar == request.user.registrar %}
-                                        <a class="btn vest" href="{% url 'dark_archive_link' linky.guid %}">Dark archive</a>
+                                        <a class="btn vest" href="{% main_url 'dark_archive_link' linky.guid %}">Dark archive</a>
                                     {% elif request.user|has_group:'vesting_user' and request.user.vesting_org == linky.vesting_org %}
-                                        <a class="btn vest" href="{% url 'dark_archive_link' linky.guid %}">Dark archive</a>
+                                        <a class="btn vest" href="{% main_url 'dark_archive_link' linky.guid %}">Dark archive</a>
                                     {% elif request.user == linky.created_by and not linky|is_darchive %}
-                                        <a class="btn vest" href="{% url 'dark_archive_link' linky.guid %}">Dark archive</a>
+                                        <a class="btn vest" href="{% main_url 'dark_archive_link' linky.guid %}">Dark archive</a>
                                     {% endif %}
+
                                     {% if request.user == linky.created_by and not linky.vested %}
-                                        <a class="btn user-delete" href="{% url 'user_delete_link' linky.guid %}"><i class="icon-trash"></i> Delete</a>
+                                        <a class="btn user-delete" href="{% main_url 'user_delete_link' linky.guid %}"><i class="icon-trash"></i> Delete</a>
                                     {% endif %}
                                 {% endif %}
 

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -116,7 +116,6 @@ urlpatterns = patterns('perma.views',
 #    url(r'^manage/activity/?$', 'manage.activity', name='manage_activity'),
 
     # Our Perma ID catchall
-    # url(r'^%s/?$' % r'(?P<guid>[^\./]+)', 'common.single_link_header', name='single_link_header'), # our pending, new, single link view
     url(r'^%s/?$' % r'(?P<guid>[^\./]+)', 'common.single_linky', name='single_linky'),
 
 )

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -90,9 +90,9 @@ def single_linky(request, guid):
     context = None
 
     # User requested archive type
-    serve_type = request.GET.get('type','live')
+    serve_type = request.GET.get('type','image' if settings.SINGLE_LINK_HEADER_TEST else 'live')
     if not serve_type in valid_serve_types:
-        serve_type = 'live'
+        serve_type = 'image' if settings.SINGLE_LINK_HEADER_TEST else 'live'
 
     # fetch link from DB -- unless we're logged in on a mirror server,
     # in which case always fetch status from upstream so we show the right edit buttons
@@ -137,144 +137,60 @@ def single_linky(request, guid):
 
         asset = Asset.objects.get(link=link)
 
-        text_capture = None
-        if serve_type == 'text':
-            if asset.text_capture and asset.text_capture != 'pending':
-                with default_storage.open(os.path.join(asset.base_storage_path, asset.text_capture), 'r') as f:
-                    text_capture = f.read()
-            
-        # If we are going to serve up the live version of the site, let's make sure it's iframe-able
-        display_iframe = False
-        if serve_type == 'live':
-            try:
-                response = requests.head(link.submitted_url,
-                                         headers={'User-Agent': request.META['HTTP_USER_AGENT'], 'Accept-Encoding': '*'},
-                                         timeout=5)
-                display_iframe = 'X-Frame-Options' not in response.headers
-                # TODO actually check if X-Frame-Options specifically allows requests from us
-            except:
-                # Something is broken with the site, so we might as well display it in an iFrame so the user knows
-                display_iframe = True
+        if settings.SINGLE_LINK_HEADER_TEST:
+            # If we have a PDF, we want to serve it up by default instead of an image
+            if asset.pdf_capture and asset.pdf_capture != 'failed':
+                serve_type = 'pdf'
 
-        asset = Asset.objects.get(link__guid=link.guid)
+            created_datestamp = link.creation_timestamp
+            pretty_date = created_datestamp.strftime("%B %d, %Y %I:%M GMT")
+            context = {'archive': link, 'asset': asset, 'pretty_date': pretty_date, 'next': request.get_full_path(),
+                       'serve_type': serve_type,
+                       'warc_url': asset.warc_url()}
 
-        context = {
-            'linky': link,
-            'asset': asset,
-            'next': request.get_full_path(),
-            'display_iframe': display_iframe,
-            'serve_type': serve_type,
-            'text_capture': text_capture,
-            'warc_url': asset.warc_url()
-        }
+        else:
+            text_capture = None
+            if serve_type == 'text':
+                if asset.text_capture and asset.text_capture != 'pending':
+                    with default_storage.open(os.path.join(asset.base_storage_path, asset.text_capture), 'r') as f:
+                        text_capture = f.read()
+
+            # If we are going to serve up the live version of the site, let's make sure it's iframe-able
+            display_iframe = False
+            if serve_type == 'live':
+                try:
+                    response = requests.head(link.submitted_url,
+                                             headers={'User-Agent': request.META['HTTP_USER_AGENT'], 'Accept-Encoding': '*'},
+                                             timeout=5)
+                    display_iframe = 'X-Frame-Options' not in response.headers
+                    # TODO actually check if X-Frame-Options specifically allows requests from us
+                except:
+                    # Something is broken with the site, so we might as well display it in an iFrame so the user knows
+                    display_iframe = True
+
+            context = {
+                'linky': link,
+                'asset': asset,
+                'next': request.get_full_path(),
+                'display_iframe': display_iframe,
+                'serve_type': serve_type,
+                'text_capture': text_capture,
+                'warc_url': asset.warc_url()
+            }
 
     if request.META.get('CONTENT_TYPE') == 'application/json':
         # if we were called as JSON (by a mirror), serialize and send back as JSON
         context['warc_url'] = absolute_url(request, context['asset'].warc_url(settings.DIRECT_WARC_HOST))
         context['MEDIA_URL'] = absolute_url(request, settings.DIRECT_MEDIA_URL)
         context['asset'] = serializers.serialize("json", [context['asset']], fields=['text_capture','image_capture','pdf_capture','warc_capture','base_storage_path'])
-        context['linky'] = serializers.serialize("json", [context['linky']], fields=['dark_archived','guid','vested','view_count','creation_timestamp','submitted_url','submitted_title'])
+        context['linky'] = serializers.serialize("json", [context['linky']], fields=['dark_archived','guid','vested','vesting_org','view_count','creation_timestamp','submitted_url','submitted_title'])
         return HttpResponse(json.dumps(context), content_type="application/json")
 
     elif serve_type == 'warc_download':
         if context['asset'].warc_download_url():
             return HttpResponseRedirect(context.get('MEDIA_URL', settings.MEDIA_URL)+context['asset'].warc_download_url())
 
-    return render(request, 'single-link.html', context)
-
-
-@must_be_mirrored
-@ratelimit(method='GET', rate=settings.MINUTE_LIMIT, block=True, ip=False,
-           keys=lambda req: req.META.get('HTTP_X_FORWARDED_FOR', req.META['REMOTE_ADDR']))
-@ratelimit(method='GET', rate=settings.HOUR_LIMIT, block=True, ip=False,
-           keys=lambda req: req.META.get('HTTP_X_FORWARDED_FOR', req.META['REMOTE_ADDR']))
-@ratelimit(method='GET', rate=settings.DAY_LIMIT, block=True, ip=False,
-           keys=lambda req: req.META.get('HTTP_X_FORWARDED_FOR', req.META['REMOTE_ADDR']))
-def single_link_header(request, guid):
-    """
-    Given a Perma ID, serve it up. Vesting also takes place here.
-    
-    This function is temporary and should be removed or merged with 
-    single_linky (above) once we nail down the UX for the single archive page
-    """
-
-    # Create a canonical version of guid (non-alphanumerics removed, hyphens every 4 characters, uppercase),
-    # and forward to that if it's different from current guid.
-    canonical_guid = Link.get_canonical_guid(guid)
-    if canonical_guid != guid:
-        return HttpResponsePermanentRedirect(reverse('single_link_header', args=[canonical_guid]))
-
-    context = None
-
-    # User requested archive type
-    serve_type = request.GET.get('type','image')
-    if not serve_type in valid_serve_types:
-        serve_type = 'image'
-
-    try:
-        link = Link.objects.get(guid=guid)
-    except Link.DoesNotExist:
-        if settings.MIRROR_SERVER:
-            # if we can't find the Link, and we're a mirror server, try fetching it from main server
-            try:
-                json_url = get_url_for_host(request,
-                                            request.main_server_host,
-                                            reverse('mirroring:single_link_json', args=[guid])+"?type="+serve_type)
-                json_response = requests.get(json_url, headers={'Content-Type': 'application/json'})
-            except requests.ConnectionError:
-                raise Http404
-
-            # check response
-            if not json_response.ok:
-                raise Http404
-
-            # load context from JSON
-            context = json.loads(json_response.content)
-            context['linky'] = serializers.deserialize("json", context['linky']).next().object
-            context['asset'] = serializers.deserialize("json", context['asset']).next().object
-            context['asset'].link = context['linky']
-        else:
-            raise Http404
-
-    if not context:
-        # Increment the view count if we're not the referrer
-        parsed_url = urlparse(request.META.get('HTTP_REFERER', ''))
-        current_site = Site.objects.get_current()
-
-        if not current_site.domain in parsed_url.netloc:
-            link.view_count += 1
-            link.save()
-
-        asset = Asset.objects.get(link=link)
-
-
-        # If we have a PDF, we want to serve it up by default instead
-        # of an image
-        if asset.pdf_capture and asset.pdf_capture != 'failed':
-            serve_type = 'pdf'
-
-        created_datestamp = link.creation_timestamp
-        pretty_date = created_datestamp.strftime("%B %d, %Y %I:%M GMT")
-
-        context = {'archive': link, 'asset': asset, 'pretty_date': pretty_date, 'next': request.get_full_path(),
-                    'serve_type': serve_type,
-                    'warc_url':asset.warc_url()}
-
-    if request.META.get('CONTENT_TYPE') == 'application/json':
-        # if we were called as JSON (by a mirror), serialize and send back as JSON
-        context['MEDIA_URL'] = request.build_absolute_uri(settings.MEDIA_URL)
-        context['warc_url'] = request.build_absolute_uri(context['warc_url'])
-        context['asset'] = serializers.serialize("json", [context['asset']], fields=['text_capture','image_capture','pdf_capture','warc_capture','base_storage_path'])
-        context['linky'] = serializers.serialize("json", [context['linky']], fields=['dark_archived','guid','vested','view_count','creation_timestamp','submitted_url','submitted_title'])
-        return HttpResponse(json.dumps(context), content_type="application/json")
-
-    if serve_type == 'warc_download':
-        if context['asset'].warc_download_url():
-            return HttpResponseRedirect(context.get('MEDIA_URL', settings.MEDIA_URL)+context['asset'].warc_download_url())
-
-    return render_to_response('single-link-header.html', context, RequestContext(request))
-
-
+    return render(request, 'single-link-header.html' if settings.SINGLE_LINK_HEADER_TEST else 'single-link.html', context)
 
 
 def rate_limit(request, exception):

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -31,6 +31,7 @@ sorl-thumbnail==11.12			# Used to create our thumbnails
 Pillow==2.6.1					# Used to generate thumbnails with sorl. We can likely remove this dependency when Sorl 12.x is released (and we use Wand as our sorl engine)
 redis==2.10.1					# Needed to bind with Redis. Supports our sorl thumbnails in production
 django-redis==3.7.2             # use redis as django's cache backend
+python-gnupg==0.3.6             # Sign messages between main server and mirrors.
 
 # deployment
 gunicorn==18.0


### PR DESCRIPTION
Oops, last request left out some of the single_link_header logic. Here's a fixed version.

The idea here isn't to remove the single_link_header stuff, but to merge it back into single_link. With SINGLE_LINK_HEADER_TEST = False you get the live site behavior; with SINGLE_LINK_HEADER_TEST = True you get the single_link_header behavior.

This way:

(1) We don't have a bunch of duplicated code that's confusing to people like me -- it's more self-documenting.
(2) We don't have code that's diverging -- the single_link_header stuff is more likely to work over time because it inherits bug fixes from single_link, and when we do have to merge them we can just look at the explicit differences.

---

Original pull req. message:

This includes some changes I made to get mirroring running on perma-test. Biggest changes are that messages from the upstream server can now be signed with a public key, and post requests can't cross subdomains -- which means the confirmation screen for vesting always has to show, to get you on the right subdomain.
