### PR TITLE
Simplify group updates.

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -460,9 +460,7 @@ def list_users_in_group(request, group_name):
                     new_user.vesting_org = request.user.vesting_org
 
             new_user.save()
-
-            group = Group.objects.get(name=group_name)
-            new_user.groups.add(group)
+            new_user.groups = [Group.objects.get(name=group_name)]
 
             email_new_user(request, new_user)
 
@@ -488,7 +486,7 @@ def edit_user_in_group(request, user_id, group_name):
 
     # Registrar members can only edit their own vesting members
     if not is_registry:
-    	if group_name == 'vesting_user' and request.user.registrar != target_user.vesting_org.registrar:
+        if group_name == 'vesting_user' and request.user.registrar != target_user.vesting_org.registrar:
             raise Http404
         if group_name == 'registrar_user' or group_name == 'user' or group_name == 'registry_user':
             raise Http404
@@ -586,12 +584,8 @@ def vesting_user_add_user(request):
                 target_user.vesting_org = vesting_org
             else:
                 target_user.vesting_org = request.user.vesting_org
-    
-            group = Group.objects.get(name='vesting_user')
-            all_groups = Group.objects.all()
-            for ag in all_groups:
-              target_user.groups.remove(ag)
-            target_user.groups.add(group)
+
+            target_user.groups = [Group.objects.get(name='vesting_user')]
     
             if is_new_user:
                 target_user.is_active = False
@@ -644,12 +638,7 @@ def registrar_user_add_user(request):
                 is_new_user = True
     
             target_user.registrar = request.user.registrar
-    
-            group = Group.objects.get(name='registrar_user')
-            all_groups = Group.objects.all()
-            for ag in all_groups:
-              target_user.groups.remove(ag)
-            target_user.groups.add(group)
+            target_user.groups = [Group.objects.get(name='registrar_user')]
     
             if is_new_user:
                 target_user.is_active = False
@@ -676,12 +665,7 @@ def vesting_user_leave_vesting_org(request):
     if request.method == 'POST':
         request.user.vesting_org = None
         request.user.save()
-        
-        group = Group.objects.get(name='user')
-        all_groups = Group.objects.all()
-        for ag in all_groups:
-            request.user.groups.remove(ag)
-        request.user.groups.add(group)
+        request.user.groups = [Group.objects.get(name='user')]
 
         return HttpResponseRedirect(reverse('user_management_manage_account'))
 
@@ -1061,8 +1045,7 @@ def register(request):
             new_user.is_active = False
             new_user.save()
 
-            group = Group.objects.get(name='user')
-            new_user.groups.add(group)
+            new_user.groups = [Group.objects.get(name='user')]
             
             email_new_user(request, new_user)
 


### PR DESCRIPTION
This just simplifies user group updates using Django's m2m array assignment syntax.

(I made these changes while messing around with mirroring propagation. Don't think they actually made propagation more efficient the way I hoped, but they're nicer to read anyway so what the heck.)
