### PR TITLE
Fix user name/vest button in header for mirroring+SSL.

### DIFF
--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -1,4 +1,4 @@
-{% load compressed truncatesmart has_group %}<!DOCTYPE html>
+{% load compressed has_group %}<!DOCTYPE html>
 <html lang="en-us">
     <head>
         <title>perma.cc{% block title %}{% endblock %}</title>
@@ -52,7 +52,7 @@
 					  	{% if request.user.is_authenticated %}
                             {% comment %}<li><a href="{% url 'logout' %}" style="color: #aaa;">Log out</a></li>{% endcomment %}
                             <li class="dropdown">
-                              <a href="#" class="dropdown-toggle navbar-link" data-toggle="dropdown" role="button" aria-expanded="false">{% if request.user.first_name %}{{ request.user.first_name }}{% else %}{{ request.user.email|truncateatsymbol }}{% endif %} <span class="caret"></span></a>
+                              <a href="#" class="dropdown-toggle navbar-link" data-toggle="dropdown" role="button" aria-expanded="false">{{ request.user.get_short_name }} <span class="caret"></span></a>
                               <ul class="dropdown-menu" role="menu">
                                 <li><a href="{% url 'link_browser' %}">My links</a></li>
                                 

--- a/perma_web/perma/templatetags/truncatesmart.py
+++ b/perma_web/perma/templatetags/truncatesmart.py
@@ -39,30 +39,3 @@ def truncatesmart(value, limit=80):
 
     # Join the words and return
     return ' '.join(words) + '...'
-    
-
-@register.filter
-def truncateatsymbol(value):
-    """
-    Truncates a string after a given number of chars keeping whole words.
-
-    Usage:
-        {{ string|truncateatsymbol }}
-        {{ string|truncatesmart:50 }}
-    """
-    try:
-        has_at = value.index('@')
-    # not an email
-    except ValueError:
-        # Fail silently.
-        return value
-
-    # Make sure it's unicode
-    value = unicode(value)
-
-    # Break into words and remove the last
-    words = value.split('@')[:-1]
-
-    # Join the words and return
-    #return ' '.join(words) + '...'
-    return ' '.join(words)

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1036,7 +1036,7 @@ def limited_login(request, template_name='registration/login.html',
                 # Set the user-info cookie for mirror servers.
                 # This will be set by the main server, e.g. //dashboard.perma.cc,
                 # but will be readable by any mirror serving //perma.cc.
-                user_info = serializers.serialize("json", [request.user], fields=['groups','registrar','vesting_org'])
+                user_info = serializers.serialize("json", [request.user], fields=['groups','registrar','vesting_org','first_name','last_name','email'])
 
                 # The cookie should last as long as the login cookie, so cookie logic is copied from SessionMiddleware.
                 if request.session.get_expire_at_browser_close():
@@ -1053,7 +1053,7 @@ def limited_login(request, template_name='registration/login.html',
                                     expires=expires,
                                     domain=get_mirror_cookie_domain(request),
                                     path=settings.SESSION_COOKIE_PATH,
-                                    secure=settings.SESSION_COOKIE_SECURE or None,
+                                    secure=False,  # so we can read the cookie on http link playbacks -- this can be changed if we no longer rely on http: links
                                     httponly=settings.SESSION_COOKIE_HTTPONLY or None)
 
             return response


### PR DESCRIPTION
Fixes 3 and 4 from Claire's testing. Vest button should appear on archive pages, and user's name should appear in the header for regular pages (e.g. FAQ) when logged in.
