### PR TITLE
Don't require email in API queries.

### DIFF
--- a/perma_web/api/authentication.py
+++ b/perma_web/api/authentication.py
@@ -1,12 +1,36 @@
 from tastypie.authentication import (MultiAuthentication,
                                      ApiKeyAuthentication,
                                      SessionAuthentication)
+from perma.models import LinkUser
+
+
+class KeyOnlyAuthentication(ApiKeyAuthentication):
+    """ Subclass of Tastypie's ApiKeyAuthentication that doesn't require username. """
+
+    def is_authenticated(self, request, **kwargs):
+        if request.META.get('HTTP_AUTHORIZATION') and request.META['HTTP_AUTHORIZATION'].lower().startswith('apikey '):
+            (auth_type, api_key) = request.META['HTTP_AUTHORIZATION'].split()
+        else:
+            api_key = request.GET.get('api_key') or request.POST.get('api_key')
+
+        if not api_key:
+            return self._unauthorized()
+
+        try:
+            request.user = LinkUser.objects.get(is_active=True, api_key__key=api_key)
+        except LinkUser.DoesNotExist:
+            return self._unauthorized()
+
+        return True
+
+    def get_identifier(self, request):
+        return unicode(request.user)
 
 
 # Order here matters. If ApiKeyAuthentication comes first,
 # you'll get "You cannot access body after reading from request's data stream"
 # errors when POSTing multipart forms using SessionAuthentication
-backends = (SessionAuthentication(), ApiKeyAuthentication())
+backends = (SessionAuthentication(), KeyOnlyAuthentication())
 
 
 class DefaultAuthentication(MultiAuthentication):

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -89,7 +89,7 @@ class ApiResourceTestCase(ResourceTestCase):
 
     def get_credentials(self, user=None):
         user = user or self.user
-        return self.create_apikey(username=user.email, api_key=user.api_key.key)
+        return "ApiKey %s" % user.api_key.key
 
     @classmethod
     def start_server(cls):


### PR DESCRIPTION
Tweak so you only need to pass in `api_key=<key>` for authentication, and don't also have to provide `username=<email>`.