### PR TITLE
Fix upstream archive playback.

### DIFF
--- a/perma_web/mirroring/middleware.py
+++ b/perma_web/mirroring/middleware.py
@@ -5,8 +5,7 @@ from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
 from django.utils.functional import SimpleLazyObject
 
-from .models import FakeLinkUser
-from .utils import read_signed_message
+from .utils import read_signed_message, deserialize_user
 
 ### helpers ###
 
@@ -59,7 +58,7 @@ def get_user(request):
                     # own public key if we have no upstream server configured.
                     upstream_key = settings.UPSTREAM_SERVER['public_key'] if settings.UPSTREAM_SERVER else settings.GPG_PUBLIC_KEY
                     user_info, fingerprint = read_signed_message(user_info, upstream_key, max_age=request.session.get_expiry_age())
-                    user = FakeLinkUser.init_from_serialized_user(user_info)
+                    user = deserialize_user(user_info)
                 except Exception, e:
                     print "Error loading mirror user:", e
 

--- a/perma_web/mirroring/models.py
+++ b/perma_web/mirroring/models.py
@@ -17,11 +17,6 @@ class FakeLinkUser(LinkUser):
         It will be created from a serialized user object put in a cookie by the upstream server.
     """
 
-    @classmethod
-    def init_from_serialized_user(cls, serialized_user):
-        serialized_user = serialized_user.replace('perma.linkuser', 'mirroring.fakelinkuser')
-        return serializers.deserialize("json", serialized_user).next().object
-
     class Meta:
         proxy = True
 

--- a/perma_web/mirroring/urls.py
+++ b/perma_web/mirroring/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 from perma.urls import guid_pattern
 
 urlpatterns = patterns('mirroring.views',
-    url(r'^render/%s/?$' % guid_pattern, 'single_link_json', name='single_link_json'),
+    url(r'^render_link/?$', 'single_link_json', name='single_link_json'),
     url(r'^export/updates/?$', 'export_updates', name='export_updates'),
     url(r'^export/full/?$', 'export_database', name='export_database'),
     url(r'^import/updates/?$', 'import_updates', name='import_updates'),

--- a/perma_web/mirroring/utils.py
+++ b/perma_web/mirroring/utils.py
@@ -2,12 +2,12 @@ import datetime
 from functools import wraps
 import hashlib
 import json
-from django.http import HttpResponseBadRequest, HttpResponse, HttpResponseForbidden
-from django.views.decorators.csrf import csrf_exempt
 import gnupg
-import pytz
 import time
 
+from django.core import serializers
+from django.http import HttpResponseBadRequest, HttpResponseForbidden
+from django.views.decorators.csrf import csrf_exempt
 from django.conf import settings
 from django.utils.decorators import available_attrs
 from django.core.cache import cache as django_cache
@@ -42,6 +42,16 @@ def may_be_mirrored(view_func):
 
     wrapped_view.may_be_mirrored = True
     return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
+
+
+### user serialization ###
+
+def serialize_user(user):
+    return serializers.serialize("json", [user], fields=['groups','registrar','vesting_org','first_name','last_name','email'])
+
+def deserialize_user(serialized_user):
+    serialized_user = serialized_user.replace('perma.linkuser', 'mirroring.fakelinkuser')
+    return serializers.deserialize("json", serialized_user).next().object
 
 
 ### gpg ###

--- a/perma_web/mirroring/views.py
+++ b/perma_web/mirroring/views.py
@@ -10,13 +10,14 @@ from .tasks import get_updates, background_media_sync, save_full_database, get_f
 from .utils import may_be_mirrored, read_downstream_request, read_upstream_request
 
 
-def single_link_json(request, guid):
+@read_downstream_request
+def single_link_json(request, request_server, guid):
     """
         This is a version of the single link page that can only be called on the main server.
         It gets called as JSON (by the regular single link page on a mirror) and returns
         the data necessary for the mirror to render the page.
     """
-    return single_linky(request, guid)
+    return single_linky(request, guid, send_downstream=True)
 
 
 @may_be_mirrored

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -20,7 +20,7 @@ from django.core.context_processors import csrf
 from django.core.paginator import Paginator
 from django.contrib.auth.models import Group
 from django.contrib import messages
-from mirroring.utils import sign_message
+from mirroring.utils import sign_message, serialize_user
 from tastypie.models import ApiKey
 
 from perma.forms import (
@@ -1051,7 +1051,7 @@ def limited_login(request, template_name='registration/login.html',
                 # Set the user-info cookie for mirror servers.
                 # This will be set by the main server, e.g. //dashboard.perma.cc,
                 # but will be readable by any mirror serving //perma.cc.
-                user_info = serializers.serialize("json", [request.user], fields=['groups','registrar','vesting_org','first_name','last_name','email'])
+                user_info = serialize_user(request.user)
 
                 # The cookie should last as long as the login cookie, so cookie logic is copied from SessionMiddleware.
                 if request.session.get_expire_at_browser_close():


### PR DESCRIPTION
This isn't the javascript-based approach we discussed earlier, just patching up the existing technique for mirrors to pull up-to-date data from upstream during archive playback.

- Apply the same GPG auth we use for other inter-mirror communication.
- Fix the logic for forwarding to non-SSL version.