### PR TITLE
Archive tweaks.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -277,6 +277,10 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
     save_screenshot(browser, image_path)
     save_fields(asset, image_capture=image_name)
 
+    # scroll to bottom of page and back up, in case that prompts anything else to load
+    browser.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+    browser.execute_script("window.scrollTo(0, 0);")
+
     # make sure all requests are finished
     print "Waiting for post-load requests."
     start_time = time.time()

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -47,7 +47,7 @@ gevent==1.0.1
 
 # PyWB-related stuff
 surt==0.2                       # our simple CDX server to canonicalize URL
-pywb==0.6.3
+pywb==0.7.5
 warcprox==1.2
 
 # alternate storages


### PR DESCRIPTION
- Upgrade to latest pywb. Closes #770.
- Scroll up and down during capture to trigger any late-loaded page resources. This helps us on the acid test. Didn't see other low-hanging fruit; may as well call that good for now. Closes #771.