### PR TITLE
API subdomain redirection.

### DIFF
--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.utils.cache import patch_vary_headers
+
+from mirroring.middleware import get_subdomain
+
+
+class APISubdomainMiddleware(object):
+    def process_request(self, request):
+        if get_subdomain(request) == settings.API_SUBDOMAIN:
+            request.urlconf = 'api.urls'
+            request.no_mirror_forwarding = True
+
+    def process_response(self, request, response):
+        """
+        Forces the HTTP ``Vary`` header onto requests to avoid having responses
+        cached across subdomains.
+
+        Copied from django-subdomains package.
+        """
+        if getattr(settings, 'FORCE_VARY_ON_HOST', True):
+            patch_vary_headers(response, ('Host',))
+
+        return response

--- a/perma_web/mirroring/management/commands/runmirror.py
+++ b/perma_web/mirroring/management/commands/runmirror.py
@@ -72,13 +72,15 @@ class Command(BaseCommand):
         router_port = 8000
         running_processes = []
 
-        main_server_port = 8001
-        main_server_address = '%s.perma.dev' % settings.MIRROR_USERS_SUBDOMAIN
-        main_server_media = 'user-content.'+main_server_address
-
         mirror_server_port = 8002
         mirror_server_address = 'perma.dev'
         mirror_server_media = 'user-content.'+mirror_server_address
+
+        main_server_port = 8001
+        main_server_address = '%s.%s' % (settings.DASHBOARD_SUBDOMAIN, mirror_server_address)
+        api_server_address = 'api.%s' % mirror_server_address
+        main_server_media = 'user-content.'+main_server_address
+
 
         temp_dir = tempdir.TempDir()
 
@@ -146,6 +148,7 @@ class Command(BaseCommand):
 
             main_host = ForwardedReverseProxyResource('127.0.0.1', main_server_port, '')
             root.addHost(main_server_address, main_host)
+            root.addHost(api_server_address, main_host)
             root.addHost(main_server_media, main_host)
 
             mirror_host = ForwardedReverseProxyResource('127.0.0.1', mirror_server_port, '')

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -231,20 +231,22 @@ TEMPLATE_LOADERS = (
 
 MIDDLEWARE_CLASSES = (
     'perma.middleware.SecurityMiddleware',
-    'subdomains.middleware.SubdomainURLRoutingMiddleware',
+    'api.middleware.APISubdomainMiddleware',  # this should come before MirrorForwardingMiddleware
+    'mirroring.middleware.MirrorForwardingMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'mirroring.middleware.MirrorAuthenticationMiddleware',
     'perma.middleware.AdminAuthMiddleware',
-    'mirroring.middleware.MirrorForwardingMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
 RATELIMIT_VIEW = 'perma.views.common.rate_limit'
+
+ROOT_URLCONF = 'urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'perma.wsgi.application'
@@ -420,13 +422,14 @@ CELERY_SEND_TASK_ERROR_EMAILS = True
 # if you're running a mirror on Heroku or something like that.
 RUN_TASKS_ASYNC = True
 
+API_SUBDOMAIN = 'api'
 
 ### mirror stuff
 
 MIRRORING_ENABLED = False           # whether to use mirroring features
 MIRROR_SERVER = False               # whether we are a mirror
 MIRROR_COOKIE_NAME = 'user_info'
-MIRROR_USERS_SUBDOMAIN = 'dashboard'
+DASHBOARD_SUBDOMAIN = 'dashboard'
 DIRECT_MEDIA_URL = MEDIA_URL        # URL to load media from this server in particular -- primarily useful for main server
 
 # Where to fetch new archives from, if we are a mirror.
@@ -475,22 +478,6 @@ DIRECT_WARC_HOST = None     # host to load warc from this server in particular -
 # details
 THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.pil_engine.Engine'  # Change this to Wand when sorl 12.x is released (since we use Wand for PDF thumbnail creation)
 THUMBNAIL_FORMAT = 'PNG'  #
-
-# for django-subdomains
-# This is the urlconf that will be used for any subdomain that is not
-# listed in ``SUBDOMAIN_URLCONFS``, or if the HTTP ``Host`` header does not
-# contain the correct domain.
-# If you're planning on using wildcard subdomains, this should correspond
-# to the urlconf that will be used for the wildcard subdomain. For example,
-# 'accountname.mysite.com' will load the ROOT_URLCONF, since it is not
-# defined in ``SUBDOMAIN_URLCONFS``.
-ROOT_URLCONF = 'urls'
-
-# A dictionary of urlconf module paths, keyed by their subdomain.
-SUBDOMAIN_URLCONFS = {
-    None: 'urls',  # no subdomain, e.g. ``example.com``
-    'api': 'api.urls',
-}
 
 # feature flags
 SINGLE_LINK_HEADER_TEST = False

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -990,10 +990,7 @@ def account_is_deactivated(request):
 
 
 def get_mirror_cookie_domain(request):
-    host = request.get_host().split(':')[0] # remove port
-    if host.startswith(settings.MIRROR_USERS_SUBDOMAIN+'.'):
-        host = host[len(settings.MIRROR_USERS_SUBDOMAIN+'.'):]
-    return '.'+host
+    return '.' + request.mirror_server_host.split(':')[0]  # remove port
 
 
 def logout(request):

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -37,7 +37,6 @@ python-gnupg==0.3.6             # Sign messages between main server and mirrors.
 django-forms-bootstrap==3.0.1   # produce Bootstrap compatable forms
 django-secure==1.0.1            # Force SSL -- this can be removed in Django 1.8
 django-sslserver==0.14          # For testing SSL locally.
-django-subdomains==2.0.4        # enables subdomain based url routing
 django-model-utils==2.2         # for tracking dirty models
 django-settings-context-processor==0.2 # make settings available in templates
 

--- a/services/ansible/templates/django_settings.py.j2
+++ b/services/ansible/templates/django_settings.py.j2
@@ -36,7 +36,7 @@ CELERYBEAT_SCHEDULE = {
 # mirroring
 MIRRORING_ENABLED = True
 MIRROR_SERVER = True
-MIRROR_USERS_SUBDOMAIN = 'dashboard'
+DASHBOARD_SUBDOMAIN = 'dashboard'
 
 # mirror v1 stuff
 UPSTREAM_SERVER = {


### PR DESCRIPTION
- Stop api.perma.cc redirecting to dashboard.api.perma.cc.
- Rename confusing "MIRROR_USERS_SUBDOMAIN" to "DASHBOARD_SUBDOMAIN"