### PR TITLE
Cross-domain single-link page fixes.

### DIFF
--- a/perma_web/fabfile.py
+++ b/perma_web/fabfile.py
@@ -65,7 +65,12 @@ def run_ssl(port="0.0.0.0:8000"):
         Run django test server with SSL.
     """
     local("python manage.py runsslserver %s" % port)
-    return
+
+def runmirror():
+    """
+        Run parallel django main and mirror servers.
+    """
+    local("python manage.py runmirror")
 
 def test(apps="perma mirroring api"):
     """

--- a/perma_web/perma/templates/js_config.html
+++ b/perma_web/perma/templates/js_config.html
@@ -4,7 +4,7 @@
         STATIC_URL: "{{ STATIC_URL }}",
         MEDIA_URL: "{{ MEDIA_URL }}"
     },
-    api_path = "/api/v" + settings.API_VERSION,
+    api_path = "//{{request.main_server_host}}/api/v" + settings.API_VERSION,
     main_server_host = "http://{{request.main_server_host}}",
     mirror_server_host = "http://{{request.mirror_server_host}}",
     feedback_url = "{% url 'service_receive_feedback' %}";

--- a/perma_web/perma/templates/single-link.html
+++ b/perma_web/perma/templates/single-link.html
@@ -77,8 +77,10 @@
                                     {% if asset.image_capture and asset.image_capture != 'failed' and not asset.pdf_capture%}
                                         <li>
                                             {% if asset.image_capture == 'pending' %}
-                                                <span id="image_cap_container_loading" class="tab-styling">Screen capture</span>
-                                                <a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image" style="display:none;">Screen capture</a>
+                                                {% if request.user.is_authenticated %}
+                                                    <span id="image_cap_container_loading" class="tab-styling">Screen capture</span>
+                                                    <a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image" style="display:none;">Screen capture</a>
+                                                {% endif %}
                                             {% else %}
                                                 <span id="image_cap_container_loading" class="tab-styling" style="display:none;">Screen capture</span>
                                                 <a id="image_cap_container_complete" class="tab-styling{% if serve_type == 'image' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=image">Screen capture</a>
@@ -89,8 +91,10 @@
                                     {% if asset.warc_capture and asset.warc_capture != 'failed' %}
                                         <li>
                                             {% if asset.warc_capture == 'pending' %}
-                                                <span id="warc_cap_container_loading" class="tab-styling">Archiving page</span>
-                                                <a id="warc_cap_container_complete" class="tab-styling{% if serve_type == 'source' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=source" style="display:none;">Archived page</a>
+                                                {% if request.user.is_authenticated %}
+                                                    <span id="warc_cap_container_loading" class="tab-styling">Archiving page</span>
+                                                    <a id="warc_cap_container_complete" class="tab-styling{% if serve_type == 'source' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=source" style="display:none;">Archived page</a>
+                                                {% endif %}
                                             {% else %}
                                                 <span id="warc_cap_container_loading" class="tab-styling" style="display:none;">Archiving page</span>
                                                 <!--<img src="{{ STATIC_URL }}img/dots.gif" alt="Archiving...">-->
@@ -102,8 +106,10 @@
                                     {% if asset.pdf_capture and asset.pdf_capture != 'failed' %}
                                         <li>
                                             {% if asset.pdf_capture == 'pending' %}
-                                                <span id="pdf_cap_container_loading" class="tab-styling">Archiving PDF</span>
-                                                <a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf" style="display:none;">PDF</a>
+                                                {% if request.user.is_authenticated %}
+                                                    <span id="pdf_cap_container_loading" class="tab-styling">Archiving PDF</span>
+                                                    <a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %}active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf" style="display:none;">PDF</a>
+                                                {% endif %}
                                             {% else %}
                                                 <span id="pdf_cap_container_loading" class="tab-styling" style="display:none;">Archiving PDF</span>
                                                 <a id="pdf_cap_container_complete" class="tab-styling{% if serve_type == 'pdf' %} active-view{% endif %}" href="{% url 'single_linky' linky.guid %}?type=pdf">PDF</a>

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -129,7 +129,7 @@ def single_linky(request, guid, send_downstream=False):
         link = None
 
     # if we can't find the Link locally, and we're a mirror server, fetch from upstream -- otherwise 404
-    if settings.MIRROR_SERVER and (request.user.groups.all() or not link):
+    if settings.MIRROR_SERVER and (request.user.is_authenticated() or not link):
         try:
             json_response = post_message_upstream(reverse('mirroring:single_link_json')+"?type="+serve_type,
                                                   json_data={'guid':guid})

--- a/perma_web/static/js/single-link.js
+++ b/perma_web/static/js/single-link.js
@@ -388,10 +388,12 @@ var spinner = new Spinner(opts).spin(target);
 
 	var check_status = function() {
 		
-	// Check our status service to see if we have archiving jobs pending
+	    // Check our status service to see if we have archiving jobs pending
 		apiRequest("GET", "/archives/" + archive.guid + "/", null, {
-            error: null,
-			dataType: "jsonp"
+            error: null, // cancel out the default error handling provided by apiRequest,
+            xhrFields: {
+                withCredentials: true
+            }
 
 		}).done(function(data) {
             var asset = data.assets[0];

--- a/perma_web/static/js/single-link.js
+++ b/perma_web/static/js/single-link.js
@@ -392,9 +392,8 @@ var spinner = new Spinner(opts).spin(target);
 		apiRequest("GET", "/archives/" + archive.guid + "/", null, {
             error: null,
 			dataType: "jsonp"
-		});
 
-		request.done(function(data) {
+		}).done(function(data) {
             var asset = data.assets[0];
 
 			if ($('#image_cap_container_loading').is(":visible") && asset.image_capture != 'pending') {


### PR DESCRIPTION
- Allow authenticated API requests cross-domain from perma.cc to dashboard.perma.cc for the /archives/<id>/ get_detail endpoint. Fixes #785.

- Only show in-progress spinners for logged-in users (who should be the only ones who see single link pages immediately after creation anyway).

- Enable jsonp mode for /public/archives/ , per http://django-tastypie.readthedocs.org/en/latest/serialization.html . This still didn't work for me after a quick test, so there may be other changes necessary to allow cross-domain requests to that endpoint.