### PR TITLE
Read-only mode for deployment.

### DIFF
--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -118,6 +118,13 @@ class DefaultResource(ExtendedModelResource):
     def raise_error_response(self, bundle, errors):
         raise ImmediateHttpResponse(response=self.error_response(bundle.request, errors))
 
+    def _handle_500(self, request, exception):
+        if settings.READ_ONLY_MODE:
+            return self.error_response(request, {
+                'error_message':"Perma is in read only mode for scheduled maintenance. Please try again shortly."
+            })
+        super(DefaultResource, self)._handle_500(request, exception)
+
 
 # via: http://stackoverflow.com/a/14134853/313561
 # also: https://github.com/toastdriven/django-tastypie/issues/42#issuecomment-5485666
@@ -398,6 +405,12 @@ class LinkResource(AuthenticatedLinkResource):
         # We create a new entry in our datastore and pass the work off to our indexing
         # workers. They do their thing, updating the model as they go. When we get some minimum
         # set of results we can present the user (a guid for the link), we respond back.
+
+        if settings.READ_ONLY_MODE:
+            raise ImmediateHttpResponse(response=self.error_response(bundle.request, {
+                'archives': {'__all__': "Perma has paused archive creation for scheduled maintenance. Please try again shortly."},
+                'reason': "Perma has paused archive creation for scheduled maintenance. Please try again shortly.",
+            }))
 
         # Runs validation (exception thrown if invalid), sets properties and saves the object
         bundle = super(LinkResource, self).obj_create(bundle, created_by=bundle.request.user)

--- a/perma_web/perma/middleware.py
+++ b/perma_web/perma/middleware.py
@@ -1,6 +1,8 @@
 from functools import wraps
 
+from django.conf import settings
 from django.http import Http404
+from django.shortcuts import render
 from django.utils.decorators import available_attrs
 import djangosecure.middleware
 
@@ -40,3 +42,11 @@ class SecurityMiddleware(djangosecure.middleware.SecurityMiddleware):
         if getattr(view_func, 'ssl_optional', False):
             return
         return super(SecurityMiddleware, self).process_request(request)
+
+
+### read only mode ###
+
+class ReadOnlyMiddleware(object):
+    def process_exception(self, request, exception):
+        if settings.READ_ONLY_MODE:
+            return render(request, 'read_only_mode.html')

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1,6 +1,9 @@
 import logging
 import random
 import re
+import socket
+from urlparse import urlparse
+import requests
 
 from django.contrib.auth.models import BaseUserManager, AbstractBaseUser
 from django.conf import settings
@@ -13,10 +16,6 @@ from django.utils.functional import cached_property
 from mptt.models import MPTTModel, TreeForeignKey
 from model_utils import FieldTracker
 
-# For Link
-import socket
-from urlparse import urlparse
-import requests
 
 logger = logging.getLogger(__name__)
 
@@ -699,3 +698,32 @@ class Stat(models.Model):
 
     # TODO, we also display the top 10 perma links in the stats view
     # we should probably generate these here or put them in memcache or something
+
+
+### read only mode ###
+
+# install signals to prevent database writes if settings.READ_ONLY_MODE is set
+
+### this is in models for now because it's annoying to put it in signals.py and resolve circular imports with models.py
+### in Django 1.8 we can avoid that issue by putting this in signals.py and importing it from ready()
+### https://docs.djangoproject.com/en/dev/topics/signals/
+
+from django.contrib.sessions.models import Session
+from django.db.models.signals import pre_save
+
+from .utils import ReadOnlyException
+
+write_whitelist = (
+    (Session, None),
+    (LinkUser, {'password'}),
+    (LinkUser, {'last_login'}),
+)
+
+def read_only_mode(sender, instance, **kwargs):
+    for whitelist_sender, whitelist_fields in write_whitelist:
+        if whitelist_sender==sender and (whitelist_fields is None or whitelist_fields==kwargs['update_fields']):
+            return
+    raise ReadOnlyException("Read only mode enabled.")
+
+if settings.READ_ONLY_MODE:
+    pre_save.connect(read_only_mode)

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -240,6 +240,7 @@ MIDDLEWARE_CLASSES = (
     'mirroring.middleware.MirrorAuthenticationMiddleware',
     'perma.middleware.AdminAuthMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
+    'perma.middleware.ReadOnlyMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
@@ -503,3 +504,6 @@ TASTYPIE_DEFAULT_FORMATS = ['json']
 # These will be added to CELERYBEAT_SCHEDULE in settings.utils.post_processing
 CELERYBEAT_JOB_NAMES = []
 
+
+# Set to true to disable database/file writes for maintenance.
+READ_ONLY_MODE = False

--- a/perma_web/perma/storage_backends.py
+++ b/perma_web/perma/storage_backends.py
@@ -11,6 +11,8 @@ import django.dispatch
 from pipeline.storage import PipelineMixin
 from storages.backends.s3boto import S3BotoStorage
 
+from perma.utils import ReadOnlyException
+
 file_saved = django.dispatch.Signal(providing_args=["instance", "path", "overwrite"])
 
 class StorageHelpersMixin(object):
@@ -27,6 +29,9 @@ class StorageHelpersMixin(object):
             File name will only change if file_path conflicts with an existing file.
             If overwrite=True, existing file will instead be deleted and overwritten.
         """
+        if settings.READ_ONLY_MODE:
+            raise ReadOnlyException("Read only mode enabled.")
+
         if overwrite:
             if self.exists(file_path):
                 self.delete(file_path)

--- a/perma_web/perma/templates/404.html
+++ b/perma_web/perma/templates/404.html
@@ -1,15 +1,11 @@
 {% extends "layout-responsive.html" %}
-{% load file_exists %}
 {% block title %} | 404{% endblock %}
 
 {% block content %}
-<div class="container">
-<div class="row">
 	<div class="col-sm-12 column">
 		<div class="center-block">
 			<h2>Page not found. HTTP 404. Sorry.</h2>
 			<p>The thing you're looking for doesn't exist at this address. If that seems wrong to you, <a href="{% url 'contact' %}" >please drop us a note</a>.</p>
 		</div>
 	</div>
-</div>	
 {% endblock %}

--- a/perma_web/perma/templates/500.html
+++ b/perma_web/perma/templates/500.html
@@ -1,15 +1,11 @@
 {% extends "layout-responsive.html" %}
-{% load file_exists %}
 {% block title %} | 500{% endblock %}
 
 {% block content %}
-<div class="container">
-<div class="row">
 	<div class="col-sm-12 column">
 		<div class="center-block">
 			<h2>Error. HTTP 500. Sorry.</h2>
 			<p>Please <a href="{% url 'contact' %}" >drop us a note</a> and let us know how you found this error.</p>
 		</div>
 	</div>
-</div>	
 {% endblock %}

--- a/perma_web/perma/templates/read_only_mode.html
+++ b/perma_web/perma/templates/read_only_mode.html
@@ -1,0 +1,11 @@
+{% extends "layout-responsive.html" %}
+{% block title %} | Read-only mode{% endblock %}
+
+{% block content %}
+	<div class="col-sm-12 column">
+		<div class="center-block">
+			<h2>Read-only mode.</h2>
+			<p>Perma is in read-only mode for scheduled maintenance. Please check back shortly.</p>
+		</div>
+	</div>
+{% endblock %}

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -125,3 +125,8 @@ def direct_media_url(url):
 def show_debug_toolbar(request):
     """ Used by django-debug-toolbar in settings_dev.py to decide whether to show debug toolbar. """
     return settings.DEBUG
+
+### read only mode ###
+
+class ReadOnlyException(Exception):
+    pass

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -161,7 +161,7 @@ def single_linky(request, guid, send_downstream=False):
         # Increment the view count if we're not the referrer
         parsed_url = urlparse(request.META.get('HTTP_REFERER', ''))
         
-        if not settings.MIRROR_SERVER and not request.get_host() in parsed_url.netloc:
+        if not settings.MIRROR_SERVER and not request.get_host() in parsed_url.netloc and not settings.READ_ONLY_MODE:
             link.view_count += 1
             link._no_downstream_update = True  # no need to pass this change to mirror servers
             link.save()

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -1270,7 +1270,6 @@ ul {
 
 #upload-error {
   margin-top:10px;
-  height:15px;
   font-size:14px;
 }
 

--- a/perma_web/static/maintenance/maintenance.html
+++ b/perma_web/static/maintenance/maintenance.html
@@ -7,7 +7,7 @@
  
 <body id="index" class="home">
 <h1>
-    Perma.cc is undergoing maintenance now. Sorry.
+    Perma.cc is undergoing scheduled maintenance.
 </h1>
 <h2>
     Check back in a few. If you're seeing this for more than a few minutes, email info@perma.cc


### PR DESCRIPTION
This is an experimental read-only mode for deployments. The idea is that you can disable file and database writes by setting `READ_ONLY_MODE=True` during a deploy. People can still log in, view archives, etc., but get a pretty error message if trying to save anything.