### PR TITLE
Thumbnailing logic refactor

### DIFF
--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -1,5 +1,5 @@
 {% extends "admin-layout.html" %}
-{% load truncatesmart compressed %}
+{% load compressed %}
 {% block title %} | Create a Perma link{% endblock %}
 
 {% block content %}
@@ -71,7 +71,8 @@
     <script>
         var userguide_url = "{% url 'docs_perma_link_vesting' %}",
             vest_link_url = "{% url 'vest_link' 'GUID' %}",
-            vesting_privs = {% if request.user.can_vest %}true{% else %}false{% endif %};
+            vesting_privs = {% if request.user.can_vest %}true{% else %}false{% endif %},
+            thumbnail_service_url = "{% url 'service_get_thumbnail' %}";
     </script>
 
     {% compressed_js 'create' %}

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -62,6 +62,7 @@ urlpatterns = patterns('perma.views',
     url(r'^service/stats/registrar/?$', 'service.stats_registrar', name='service_stats_registrar'),
     url(r'^service/bookmarklet-create/$', 'service.bookmarklet_create', name='service.bookmarklet_create'),
     url(r'^service/image-wrapper/%s?/?$' % guid_pattern, 'service.image_wrapper', name='service_image_wrapper'),
+    url(r'^service/thumbnail/%s?/?$' % guid_pattern, 'service.get_thumbnail', name='service_get_thumbnail'),
 
     # Session/account management
     url(r'^login/?$', 'user_management.limited_login', {'template_name': 'registration/login.html'}, name='user_management_limited_login'),

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -6,10 +6,12 @@ from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect, render_to_response
 from django.template import RequestContext
+from django.core.cache import cache as django_cache
+from django.contrib.auth.decorators import login_required
 
-import json, os, logging, csv
+import json, os, logging, csv, hashlib
 from perma.models import Link, Asset, Stat
-from sorl.thumbnail import get_thumbnail
+from sorl.thumbnail import get_thumbnail as sorl_get_thumbnail
 from mirroring.utils import may_be_mirrored, must_be_mirrored
 from perma.utils import direct_media_url
 
@@ -97,31 +99,9 @@ def link_status(request, guid):
     """
     target_link = get_object_or_404(Link, guid=guid)
     target_asset = get_object_or_404(Asset, link=target_link)
-
-
-    # Create a thumbnail for new archives.
-    # this logic should be temporary. When we refactor the asset/link model
-    # relationship we should wrap this thumbnailing work into a func in utils
-    # or maybe even a standaole service
-    thumbnail_url = ''
-    if target_asset.image_capture != 'pending' and target_asset.pdf_capture != 'pending':
-        if target_asset.image_capture:
-            capture_name = target_asset.image_capture
-            thumbnail_url = direct_media_url(settings.MEDIA_URL + target_asset.image_url())
-        else:
-            capture_name = target_asset.pdf_capture
-            thumbnail_url = settings.STATIC_URL + 'pdf-preview.jpg'
-
-        # try:
-        #    #image_path = os.path.join(settings.MEDIA_ROOT, target_asset.base_storage_path, capture_name)
-        #    #thumbnail = get_thumbnail(image_path, '456')
-        #    thumbnail_url = 'not_found.gif'  # direct_media_url(thumbnail.url)
-        #except IOError:
-        #    logger.info("Thumnail creation failed. Unable to find capture image")
     
     response_object = {"path": target_asset.base_storage_path, "text_capture": target_asset.text_capture,
             "source_capture": target_asset.warc_capture, "image_capture": target_asset.image_capture,
-            "thumbnail": thumbnail_url,
             "pdf_capture": target_asset.pdf_capture,
             "vested": target_link.vested,
             "dark_archived": target_link.dark_archived,
@@ -321,7 +301,7 @@ def image_wrapper(request, guid):
     """
     When we display an image, our display logic is greatly simplified if we
     display our archived image in an iframe. That's all we do here, take
-    and archived image and wrap it in a page that we server through an iframe
+    an archived image and wrap it in a page that we server through an iframe
     """
 
     asset = Asset.objects.get(link__guid=guid)
@@ -334,3 +314,60 @@ def image_wrapper(request, guid):
         raise Http404
 
     return render_to_response('image_wrapper.html', {'asset': asset}, RequestContext(request))
+
+@login_required
+def get_thumbnail(request, guid=None):
+    """
+    This is our thumbnailing service. Pass it the guid of an archive and 
+    a size and get back a URL for the thumbnail.
+
+    This is a pretty basic, naive implemention and we may want to outsource
+    this at some point to imgix or thumbor or some other service.
+    """
+
+
+    # Is this a guid we know about?
+    target_link = get_object_or_404(Link, guid=guid)
+    target_asset = get_object_or_404(Asset, link=target_link)
+
+
+    # Have we recently received a thumbnail request for this?
+    # If so, let's assume we're still processing it
+    size = request.GET.get('size', 'medium')
+    cache_key = 'thumbnail-%s-%s' % (size, hashlib.sha256(guid).hexdigest())
+    if django_cache.get(cache_key):
+        return HttpResponse(status=202)
+
+
+    # Some common sizes we might use
+    sizes = {'small': '200', 'medium': '600'}
+
+
+    # Try to reate a thumbnail. We need to make sure that our archiving
+    # tasks aren't still going thought. So, don't thumbnail if we see
+    # 'pending' statuses
+    django_cache.set(cache_key, True)
+    thumbnail_url = ''
+
+
+    thumbnail_url = ''
+    if target_asset.image_capture != 'pending' and target_asset.pdf_capture != 'pending':
+        if target_asset.image_capture:
+            capture_name = target_asset.image_capture
+        else:
+            capture_name = target_asset.pdf_capture
+
+        try:
+            image_path = os.path.join(settings.MEDIA_ROOT, target_asset.base_storage_path, capture_name)
+            thumbnail = sorl_get_thumbnail(image_path, sizes.get(size))
+            thumbnail_url = thumbnail.url
+        except IOError:
+            logger.info("Thumnail creation failed. Unable to find capture image")
+
+
+    data = json.dumps({"thumbnail": thumbnail_url,})
+    if 'callback' in request.REQUEST:
+        # jsonp response
+        data = '%s(%s);' % (request.REQUEST['callback'], data)
+
+    return HttpResponse(data, content_type="application/json", status=200)

--- a/perma_web/static/js/create.js
+++ b/perma_web/static/js/create.js
@@ -135,6 +135,27 @@ function upload_form() {
 
 
 
+
+/* Handle the thumbnail fetching - start */
+
+function get_thumbnail() {
+    $.ajax({
+        url: main_server_host + thumbnail_service_url + new_archive.guid,
+        cache: false
+    })
+    .done(function(data) {
+        $('#preview-container').html(templates.preview_available({
+            image_url: data.thumbnail,
+            archive_url: new_archive.url
+        })).removeClass('hide').hide().slideDown();
+    });
+}
+
+/* Handle the thumbnail fetching - end */
+
+
+
+
 /* Our polling function for the thumbnail completion - start */
 
 // The plan is to set a timer to periodically check if the thumbnail
@@ -162,12 +183,7 @@ function check_status() {
 		    if (asset.image_capture !== 'pending') {
             // Replace our Archive Pending spinner and message
             // with our new thumbnail
-            var image_url = settings.DIRECT_MEDIA_URL + asset.base_storage_path + "/" + asset.image_capture;
-
-            $('#preview-container').html(templates.preview_available({
-                image_url: image_url,
-                archive_url: new_archive.url
-            })).removeClass('hide').hide().slideDown();
+            get_thumbnail();
             
             $('#steps-container').html(templates.success_steps({
                 url: new_archive.url,


### PR DESCRIPTION
Created a basic service to handle thumbnail creation.

We're using similar logic as we were before, on top of the sorl-thumbnail library, but we first check our cache to make sure we're not kicking off the same thumbnailing job more than once.