### PR TITLE
Add "v1a" API endpoint for alpha testing.

### DIFF
--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -1,19 +1,15 @@
-from django.conf import settings
-from tastypie.api import Api
-from api.resources import (VestingOrgResource,
-                           LinkResource,
+from django.conf.urls import patterns, include
+from tastypie.api import Api, NamespacedApi
+from api.resources import (LinkResource,
                            FolderResource,
-                           AssetResource,
-                           RegistrarResource,
                            CurrentUserResource,
                            CurrentUserLinkResource,
                            CurrentUserFolderResource,
                            CurrentUserVestingOrgResource, PublicLinkResource)
 
+### v1 ###
+
 v1_api = Api(api_name='v1')
-# v1_api.register(VestingOrgResource())
-# v1_api.register(AssetResource())
-# v1_api.register(RegistrarResource())
 
 # /public/archives
 v1_api.register(PublicLinkResource())
@@ -35,4 +31,13 @@ v1_api.register(CurrentUserLinkResource())
 v1_api.register(CurrentUserFolderResource())
 v1_api.register(CurrentUserVestingOrgResource())
 
-urlpatterns = v1_api.urls
+### v1a ###
+
+v1a_api = NamespacedApi(api_name='v1a', urlconf_namespace='v1a')
+v1a_api._registry = v1_api._registry.copy()
+v1a_api._canonicals = v1_api._canonicals.copy()
+
+### add API versions to urlpatters ###
+
+urlpatterns = v1_api.urls + v1a_api.urls
+


### PR DESCRIPTION
This creates an identical version of the API at /v1a/ (for alpha). This way we can point the Word plugin at that while we're still thinking of making breaking changes, and if we do make breaking changes we can just switch that off and the plugin will display a pretty error message about needing to upgrade.