### PR TITLE
Ignore content-length when we see a PDF.

### DIFF
--- a/perma_web/api/validations.py
+++ b/perma_web/api/validations.py
@@ -19,7 +19,13 @@ class LinkValidation(Validation):
         return True
 
     def is_valid_size(self, headers):
+        # If we get a PDF, check its file size as we download it
+        # and don't worry about what the header tells us about size
+        if headers.get('content-type', None) == 'application/pdf':
+            return True
+
         try:
+            # If it's not a PDF trust the value in the header
             if int(headers.get('content-length', 0)) > settings.MAX_HTTP_FETCH_SIZE:
                 return False
         except ValueError:


### PR DESCRIPTION
Our content-length limit was blocking PDFs over 1MB. We want to
check for PDF size as we stream. Removed the content-length
validation for PDFs.

There might be a better way, more unified way to look at archives
as we download? It feels like content-length is unreliable (the
host can set that value to anything they like in the header), and
if we check for mime-type, we're playing whack-a-mole (like I did
in this patch) and again, we're relying on the host to set the
proper value for content-type.

fixes #830