### PR TITLE
PDF thumbnail cleanup.

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -422,7 +422,7 @@ Now you can start and stop RabbitMQ as a service. Something like,
 
 ## ImageMagick and Wand
 
-If you're on OS X you should might need to do adjust and [environment variable](http://docs.wand-py.org/en/0.3.8/guide/install.html#install-imagemagick-on-mac)
+If you're on OS X you might need to adjust an [environment variable](http://docs.wand-py.org/en/0.3.8/guide/install.html#install-imagemagick-on-mac)
 
 	export MAGICK_HOME=/opt/local
 

--- a/install.md
+++ b/install.md
@@ -173,7 +173,7 @@ We use ImageMagick (through [Wand](http://docs.wand-py.org/)) to create thumbnai
 
     yum install ImageMagick-devel
 
-If you're on OS X you should might need to do adjust and [environment variable](http://docs.wand-py.org/en/0.3.8/guide/install.html#install-imagemagick-on-mac)
+If you're on OS X you might need to adjust an [environment variable](http://docs.wand-py.org/en/0.3.8/guide/install.html#install-imagemagick-on-mac)
 
 	export MAGICK_HOME=/opt/local
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -477,11 +477,10 @@ LINK_EXPIRATION_TIME = relativedelta(years=2)
 WARC_HOST = None
 DIRECT_WARC_HOST = None     # host to load warc from this server in particular -- primarily useful for main server
 
-# Sorl settings. This releates to our thumbnail creation
-# the prod and dev configs are considerably different. See those configs for
-# details
-THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.pil_engine.Engine'  # Change this to Wand when sorl 12.x is released (since we use Wand for PDF thumbnail creation)
-THUMBNAIL_FORMAT = 'PNG'  #
+# Sorl settings. This relates to our thumbnail creation.
+# The prod and dev configs are considerably different. See those configs for details.
+THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.wand_engine.Engine'
+THUMBNAIL_FORMAT = 'PNG'
 
 # feature flags
 SINGLE_LINK_HEADER_TEST = False

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -1,9 +1,13 @@
+from contextlib import contextmanager
 import operator
+import os
 
 from django.db.models import Q
 from django.conf import settings
+import struct
+import tempdir
 
-        
+
 class favicon:
     
     def get_favicon(target_url, parsed_html, link_guid, disk_path, url_details):
@@ -130,3 +134,31 @@ def show_debug_toolbar(request):
 
 class ReadOnlyException(Exception):
     pass
+
+### image manipulation ###
+
+@contextmanager
+def imagemagick_temp_dir():
+    """
+        Inside this context manager, the environment variable MAGICK_TEMPORARY_PATH will be set to a
+        temp path that gets deleted when the context closes. This stops Wand's calls to ImageMagick
+        leaving temp files around.
+    """
+    temp_dir = tempdir.TempDir()
+    old_environ = dict(os.environ)
+    os.environ['MAGICK_TEMPORARY_PATH'] = temp_dir.name
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)
+        temp_dir.dissolve()
+
+def get_png_size(fh):
+    data = fh.read(24)
+    if len(data) < 24:
+        raise IOError
+    if data[:8] != '\211PNG\r\n\032\n' or data[12:16] != 'IHDR':
+        raise ValueError("File is not a png.")
+    w, h = struct.unpack('>LL', data[16:24])
+    return int(w), int(h)

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -1,6 +1,8 @@
-from PIL import Image
+import json, os, logging, csv, hashlib
+from sorl.thumbnail import get_thumbnail as sorl_get_thumbnail
 
 from django.conf import settings
+from django.core.files.storage import default_storage
 from django.core.mail import send_mail
 from django.shortcuts import get_object_or_404
 from django.http import Http404
@@ -11,10 +13,11 @@ from django.template import RequestContext
 from django.core.cache import cache as django_cache
 from django.contrib.auth.decorators import login_required
 
-import json, os, logging, csv, hashlib
-from perma.models import Link, Asset, Stat
-from sorl.thumbnail import get_thumbnail as sorl_get_thumbnail
 from mirroring.utils import may_be_mirrored, must_be_mirrored
+
+from perma.models import Link, Asset, Stat
+from perma.utils import get_png_size
+
 
 
 logger = logging.getLogger(__name__)
@@ -348,33 +351,22 @@ def get_thumbnail(request, guid=None):
         # tasks aren't still going though. So, don't thumbnail if we see
         # 'pending' statuses.
         thumbnail_url = ''
-        if target_asset.image_capture != 'pending' and target_asset.pdf_capture != 'pending':
-            capture_name = None
-            if target_asset.image_capture and target_asset.image_capture != 'failed':
-                capture_name = target_asset.image_capture
-            elif target_asset.pdf_capture != 'failed':
-                capture_name = target_asset.pdf_capture
+        if target_asset.image_capture and target_asset.image_capture != 'pending' and target_asset.image_capture != 'failed':
+            image_path = os.path.join(target_asset.base_storage_path, target_asset.image_capture)
 
-            if capture_name is not None:
+            try:
+                # enforce max image size limit
+                image_size = get_png_size(default_storage.open(image_path))
+                print "Image size: ", image_size
+                if image_size[0]*image_size[1] > settings.MAX_IMAGE_SIZE:
+                    logger.info("Can't generate thumbnail -- image is too large.")
 
-                image_path = os.path.join(settings.MEDIA_ROOT, target_asset.base_storage_path, capture_name)
+                else:
+                    thumbnail = sorl_get_thumbnail(image_path, size)
+                    thumbnail_url = thumbnail.url.replace(settings.MEDIA_URL, '', 1)
 
-                try:
-                    # enforce max image size limit
-                    pixel_count = 0
-                    if image_path.endswith('.png'):
-                        image_size = Image.open(image_path).size
-                        pixel_count = image_size[0]*image_size[1]
-
-                    if pixel_count > settings.MAX_IMAGE_SIZE:
-                        logger.info("Can't generate thumbnail -- image is too large.")
-
-                    else:
-                        thumbnail = sorl_get_thumbnail(image_path, size)
-                        thumbnail_url = thumbnail.url.replace(settings.MEDIA_URL, '', 1)
-
-                except IOError:
-                    logger.info("Thumbnail creation failed. Unable to find capture image")
+            except (IOError, ValueError):
+                logger.info("Thumbnail creation failed.")
 
         data = json.dumps({"thumbnail": thumbnail_url,})
         return HttpResponse(data, content_type="application/json")

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -25,12 +25,11 @@ tempdir==0.6                    # create temp dirs to be deleted at end of funct
 netaddr==0.7.12                 # to check archive IPs against banned ranges
 internetarchive==0.7.0          # upload warcs to internet archive
 python-dateutil==2.2            # calculate link expiration date
-Wand==0.3.8					            # ImageMagick bindings to help with thumbnail creation and PDF -> PNG conversions
+Wand==0.3.8					    # ImageMagick bindings to help with thumbnail creation and PDF -> PNG conversions
 django-tastypie==0.12.1         # API framework
 -e git://github.com/leppert/django-tastypie-extendedmodelresource.git@caf08005699d8e5616f93726bd8c1c5a51f74b07#egg=django-tastypie-extendedmodelresource
-sorl-thumbnail==12.2			      # Used to create our thumbnails
-Pillow==2.6.1					          # Used to generate thumbnails with sorl. We can likely remove this dependency when Sorl 12.x is released (and we use Wand as our sorl engine)
-redis==2.10.1					          # Needed to bind with Redis. Supports our sorl thumbnails in production
+sorl-thumbnail==12.2			# Used to create our thumbnails
+redis==2.10.1					# Needed to bind with Redis. Supports our sorl thumbnails in production
 django-redis==3.7.2             # use redis as django's cache backend
 python-gnupg==0.3.6             # Sign messages between main server and mirrors.
 django-forms-bootstrap==3.0.1   # produce Bootstrap compatable forms


### PR DESCRIPTION
- Use Wand for thumbnail creation. Check PNG size manually. Remove PIL dependency.
- Don't try to create PDF thumbnails in the thumbnail service -- it's messy to get right, and not scaleable. Just do it once in get_pdf.
- Temp files created by Wand will be deleted at the end of the get_pdf task.
- Only look at the first page of the PDF -- don't have Wand load up all the pages.