### PR TITLE
Use GET to check availability instead of HEAD.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -457,11 +457,12 @@ class Link(models.Model):
     @cached_property
     def headers(self):
         try:
-            return requests.head(
+            return requests.get(
                 self.submitted_url,
                 verify=False,  # don't check SSL cert?
                 headers={'User-Agent': USER_AGENT, 'Accept-Encoding': '*'},
-                timeout=HEADER_CHECK_TIMEOUT
+                timeout=HEADER_CHECK_TIMEOUT,
+                stream=True  # we're only looking at the headers
             ).headers
         except (requests.ConnectionError, requests.Timeout):
             return False


### PR DESCRIPTION
Fixes #628
(again).

nydailynews doesn't seem to respond reliably to HEAD requests -- sometimes it returns immediately, sometimes there's a long delay and we time out and refuse to archive.

Trying a GET request and dropping the connection when we get the headers should be more robust.