### PR TITLE
Handle phantomjs capture errors.

### DIFF
--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -145,9 +145,9 @@
 <script id="success-steps-template" type="text/x-handlebars-template">
     <p class="message-large">Success!</p>
     {{#if vesting_privs }}
-            <p>You're half way there. To make this archive permanent, review and vest it.</p>
+            <p>You're halfway there. To make this archive permanent, review and vest it.</p>
     {{ else }}
-            <p>You're half way there. To make this archive permanent, it needs to be vested by a partner organization. <a href="{{userguide_url}}">Learn more about vesting.</a></p>
+            <p>You're halfway there. To make this archive permanent, it needs to be vested by a partner organization. <a href="{{userguide_url}}">Learn more about vesting.</a></p>
     {{/if}}
 
     <p class="message-url"> <a href="{{url}}" target="_blank" class="perma-url">{{url}}</a></p>


### PR DESCRIPTION
- When an error occurs during PhantomJS capture, close out all open resources in a finally block. This should fix the lingering PhantomJS processes we've had.
- Handle a couple of specific cases that were interfering with captures (framesets, javascript that broke scrolling operations).
- Show an error message when capture fails (we were testing for image_capture!=='pending', but not image_capture=='failed').

Fixes #854.