### PR TITLE
Reduce celery logging.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -159,6 +159,9 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
 
     print "%s: Fetching %s" % (link_guid, target_url)
 
+    # suppress verbose warcprox logs
+    logging.disable(logging.INFO)
+
     # Set up an exception we can trigger to halt capture and release all the resources involved.
     class HaltCaptureException(Exception):
         pass
@@ -206,11 +209,11 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
         warcprox_thread = threading.Thread(target=warcprox_controller.run_until_shutdown, name="warcprox", args=())
         warcprox_thread.start()
 
-        print "WarcProx opened."
+        # print "WarcProx opened."
 
         # fetch robots.txt in the background
         def robots_txt_thread():
-            print "Fetching robots.txt ..."
+            # print "Fetching robots.txt ..."
             parsed_url = urlparse.urlparse(target_url)
             robots_txt_location = parsed_url.scheme + '://' + parsed_url.netloc + '/robots.txt'
             try:
@@ -219,10 +222,8 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
                                                    proxies={parsed_url.scheme:'http://'+proxy_address},
                                                    cert=fake_cert_authority.ca_file)
             except (requests.ConnectionError, requests.Timeout):
-                print "Couldn't reach robots.txt"
+                # print "Couldn't reach robots.txt"
                 return
-            if not robots_txt_response.ok:
-                print "No robots.txt found"
 
             # We only want to respect robots.txt if Perma is specifically asked not to archive (we're not a crawler)
             if 'Perma' in robots_txt_response.content:
@@ -231,34 +232,34 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
                 rp.parse([line.strip() for line in robots_txt_response.content.split('\n')])
                 if not rp.can_fetch('Perma', target_url):
                     save_fields(link, dark_archived_robots_txt_blocked=True)
-            print "Robots.txt fetched."
+            # print "Robots.txt fetched."
         robots_txt_thread = threading.Thread(target=robots_txt_thread, name="robots")
         robots_txt_thread.start()
 
         # fetch page in the background
         # (we'll give
-        print "Fetching url."
+        # print "Fetching url."
         browser = get_browser(user_agent, proxy_address, fake_cert_authority.ca_file)
         browser.set_window_size(1024, 800)
         page_load_thread = threading.Thread(target=browser.get, args=(target_url,))  # returns after onload
         page_load_thread.start()
         page_load_thread.join(PAGE_LOAD_TIMEOUT)
         if page_load_thread.is_alive():
-            print "Waited 60 seconds for onLoad event -- giving up."
+            # print "Waited 60 seconds for onLoad event -- giving up."
             if not unique_responses:
                 # if nothing at all has loaded yet, give up on the capture
                 save_fields(asset, warc_capture='failed', image_capture='failed')
                 raise HaltCaptureException
-        print "Finished fetching url."
+        # print "Finished fetching url."
 
         # get page title
-        print "Getting title."
+        # print "Getting title."
         if browser.title:
             save_fields(link, submitted_title=browser.title)
 
         # check meta tags
         # (run this in a thread and give it long enough to find the tags, but then let other stuff proceed)
-        print "Checking meta tags."
+        # print "Checking meta tags."
         def meta_thread():
             # get all meta tags
             meta_tags = browser.find_elements_by_tag_name('meta')
@@ -270,9 +271,8 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
             # if we found a relevant meta tag, check for noarchive
             if meta_tag and 'noarchive' in meta_tag.get_attribute("content").lower():
                 save_fields(link, dark_archived_robots_txt_blocked=True)
-                print "Meta found, darchiving"
-            else:
-                print "Meta not found."
+                # print "Meta found, darchiving"
+
         meta_thread = threading.Thread(target=meta_thread)
         meta_thread.start()
         meta_thread.join(ELEMENT_DISCOVERY_TIMEOUT*2)
@@ -298,30 +298,30 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
             pixel_count = page_size['width']*page_size['height']
             capture_screenshot = pixel_count < settings.MAX_IMAGE_SIZE
         if not capture_screenshot:
-            print "Not saving screenshots! Page size is %s pixels." % pixel_count
+            # print "Not saving screenshots! Page size is %s pixels." % pixel_count
             save_fields(asset, image_capture='failed')
 
         # save preliminary screenshot immediately, and an updated version later
         # (we want to return results quickly, but also give javascript time to render final results)
         if capture_screenshot:
-            print "Saving first screenshot."
+            # print "Saving first screenshot."
             save_screenshot(browser, image_path)
             save_fields(asset, image_capture=image_name)
 
         # make sure all requests are finished
-        print "Waiting for post-load requests."
+        # print "Waiting for post-load requests."
         start_time = time.time()
         time.sleep(min(AFTER_LOAD_TIMEOUT, 5))
         while len(unique_responses) < len(unique_requests):
-            print "%s/%s finished" % (len(unique_responses), len(unique_requests))
+            # print "%s/%s finished" % (len(unique_responses), len(unique_requests))
             if time.time() - start_time > AFTER_LOAD_TIMEOUT:
-                print "Waited %s seconds to finish post-load requests -- giving up." % AFTER_LOAD_TIMEOUT
+                # print "Waited %s seconds to finish post-load requests -- giving up." % AFTER_LOAD_TIMEOUT
                 break
             time.sleep(.5)
 
         # take second screenshot after all requests done
         if capture_screenshot:
-            print "Taking second screenshot."
+            # print "Taking second screenshot."
             save_screenshot(browser, image_path)
 
         have_warc = True
@@ -331,7 +331,7 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
 
     finally:
         # teardown (have to do this before save to make sure WARC is done writing):
-        print "Shutting down browser and proxies."
+        # print "Shutting down browser and proxies."
 
         if browser:
             browser.quit()  # shut down phantomjs
@@ -348,9 +348,12 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
         if warcprox_thread:
             warcprox_thread.join()  # wait until warcprox thread is done writing out warc
 
+        # un-suppress logging
+        logging.disable(logging.NOTSET)
+
     # save generated warc file
     if have_warc:
-        print "Saving WARC."
+        # print "Saving WARC."
         try:
             temp_warc_path = os.path.join(warc_writer.directory, warc_writer._f_finalname)
             with open(temp_warc_path, 'rb') as warc_file:
@@ -360,7 +363,7 @@ def proxy_capture(self, link_guid, target_url, base_storage_path, user_agent='')
             logger.info("Web Archive File creation failed for %s: %s" % (target_url, e))
             save_fields(asset, warc_capture='failed')
 
-    print "%s capture done." % link_guid
+    # print "%s capture done." % link_guid
 
 class GetPDFTask(Task):
     """


### PR DESCRIPTION
The celery log was getting huge because warc captures were doing a ton of play-by-play logging, including a line for each resource in the page. This should cut those down.