### PR TITLE
Fetch and display favicons for HTML captures.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -593,7 +593,7 @@ class Asset(models.Model):
     integrity_check_succeeded = models.NullBooleanField(blank=True, null=True)      # whether the last integrity check succeeded
 
     # what info to send downstream
-    mirror_fields = ('link', 'base_storage_path', 'image_capture', 'warc_capture', 'pdf_capture', 'text_capture')
+    mirror_fields = ('link', 'base_storage_path', 'image_capture', 'warc_capture', 'pdf_capture', 'text_capture', 'favicon')
 
     tracker = FieldTracker()
 
@@ -604,6 +604,9 @@ class Asset(models.Model):
 
     def base_url(self, extra=u""):
         return "%s/%s" % (self.base_storage_path, extra)
+
+    def favicon_url(self):
+        return self.base_url(self.favicon)
 
     def image_url(self):
         return self.base_url(self.image_capture)

--- a/perma_web/perma/templates/single-link.html
+++ b/perma_web/perma/templates/single-link.html
@@ -34,6 +34,9 @@
                     </div><!--end span 3 -->
                     <div class="col-sm-6 meta-data">
                         {% if not linky.user_deleted or request.user.is_authenticated and request.user.pk == linky.created_by_id %}
+                            {% if asset.favicon %}
+                                <img src="{{ MEDIA_URL }}{{ asset.favicon_url }}" width="16" height="16">
+                            {% endif %}
                             <a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_title}}</a><br/>
 
                             <!--<a class="submitted_url" href="{{linky.submitted_url}}">{{linky.submitted_url}}</a>-->

--- a/perma_web/perma/templates/user_management/created-links.html
+++ b/perma_web/perma/templates/user_management/created-links.html
@@ -122,6 +122,9 @@
 
         <div class="row link-row" link_id="{{guid}}">
             <div class="col-sm-6">
+                {{#if favicon_url}}
+                    <img src="{{ favicon_url }}" width="16" height="16">
+                {{/if}}
                 <a href="{{local_url}}" target="_blank">{{local_url}}</a><br/>
                 <a href="{{url}}" target="_blank" class="original-link">
                     {{truncatechars url 200}}

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -8,66 +8,6 @@ import struct
 import tempdir
 
 
-class favicon:
-    
-    def get_favicon(target_url, parsed_html, link_guid, disk_path, url_details):
-        """ Given a URL and the markup, see if we can find a favicon.
-            TODO: this is a rough draft. cleanup and move to an appropriate place. """
-
-        # We already have the parsed HTML, let's see if there is a favicon in the META elements
-        favicons = parsed_html.xpath('//link[@rel="icon"]/@href')
-
-        favicon = False
-
-        if len(favicons) > 0:
-            favicon = favicons[0]
-
-        if not favicon:
-            favicons = parsed_html.xpath('//link[@rel="shortcut"]/@href')
-            if len(favicons) > 0:
-                favicon = favicons[0]
-
-        if not favicon:
-            favicons = parsed_html.xpath('//link[@rel="shortcut icon"]/@href')
-            if len(favicons) > 0:
-                favicon = favicons[0]
-
-        if favicon:
-
-            if re.match(r'^//', favicon):
-                favicon = url_details.scheme + ':' + favicon
-            elif not re.match(r'^http', favicon):
-                favicon = url_details.scheme + '://' + url_details.netloc + '/' + favicon
-
-            try:
-              f = urllib2.urlopen(favicon)
-              data = f.read()
-
-              with open(disk_path + 'fav.png', "wb") as asset:
-                asset.write(data)
-
-              return 'fav.png'
-            except urllib2.HTTPError:
-              pass
-
-        # If we haven't returned True above, we didn't find a favicon in the markup.
-        # let's try the favicon convention: http://example.com/favicon.ico
-        target_favicon_url = url_details.scheme + '://' + url_details.netloc + '/favicon.ico'
-
-        try:
-            f = urllib2.urlopen(target_favicon_url)
-            data = f.read()
-            with open(disk_path + 'fav.ico' , "wb") as asset:
-                asset.write(data)
-
-            return 'fav' + '.ico'
-        except urllib2.HTTPError:
-            pass
-
-
-        return False
-
-
 ### celery helpers ###
 
 def run_task(task, *args, **kwargs):

--- a/perma_web/static/js/links-list.js
+++ b/perma_web/static/js/links-list.js
@@ -209,6 +209,9 @@ $(function() {
                 // same thing runs on success or error, since we get back success or error-displaying HTML
                 showLoadingMessage = false;
                 data.objects.map(function(obj){
+                    if(obj.assets && obj.assets.length){
+                        if(obj.assets[0].favicon) obj.favicon_url = settings.DIRECT_MEDIA_URL + obj.assets[0].base_storage_path + '/' + obj.assets[0].favicon;
+                    }
                     obj.local_url = mirror_server_host + '/' + obj.guid;
                     obj.can_vest = can_vest;
                     obj.search_query_in_notes = (query && obj.notes.indexOf(query) > -1);


### PR DESCRIPTION
This shows the favicon (for HTML captures only) in the folder view and on the single link page.

Not sure if we actually want to show it in those places, but it's fun to play with, and we can at least get it capturing so we can use it elsewhere later.