### PR TITLE
User management cleanup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ install:
   - pip install coveralls
 before_script:
   - mysql -e 'create database perma;'
+
+  # try to avoid mysql has gone away errors
+  # via https://github.com/travis-ci/travis-ci/issues/2250
+  - echo -e "[server]\nmax_allowed_packet=64M" | sudo tee -a /etc/mysql/conf.d/perma.cnf
+  - sudo service mysql restart
+
   - python manage.py collectstatic --noinput
 script:
   fab test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,14 @@ before_script:
 
   # try to avoid mysql has gone away errors
   # via https://github.com/travis-ci/travis-ci/issues/2250
-  - echo -e "[server]\nmax_allowed_packet=64M" | sudo tee -a /etc/mysql/conf.d/perma.cnf
+  - echo -e "[server]\nmax_allowed_packet=64M\nwait_timeout=36000" | sudo tee -a /etc/mysql/conf.d/perma.cnf
   - sudo service mysql restart
+  - mysql -e "SHOW VARIABLES LIKE 'max_allowed_packet';"
+  - mysql -e "SHOW VARIABLES LIKE 'wait_timeout';"
+  - mysql -e "SET GLOBAL wait_timeout = 36000;"
+  - mysql -e "SET GLOBAL max_allowed_packet = 67108864;"
+  - mysql -e "SHOW VARIABLES LIKE 'max_allowed_packet';"
+  - mysql -e "SHOW VARIABLES LIKE 'wait_timeout';"
 
   - python manage.py collectstatic --noinput
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ before_script:
   # via https://github.com/travis-ci/travis-ci/issues/2250
   - echo -e "[server]\nmax_allowed_packet=64M\nwait_timeout=36000" | sudo tee -a /etc/mysql/conf.d/perma.cnf
   - sudo service mysql restart
-  - mysql -e "SHOW VARIABLES LIKE 'max_allowed_packet';"
-  - mysql -e "SHOW VARIABLES LIKE 'wait_timeout';"
-  - mysql -e "SET GLOBAL wait_timeout = 36000;"
-  - mysql -e "SET GLOBAL max_allowed_packet = 67108864;"
-  - mysql -e "SHOW VARIABLES LIKE 'max_allowed_packet';"
-  - mysql -e "SHOW VARIABLES LIKE 'wait_timeout';"
 
   - python manage.py collectstatic --noinput
 script:

--- a/developer.md
+++ b/developer.md
@@ -40,7 +40,7 @@ If you are using Vagrant, all of your logs will end up in /vagrant/services/logs
 We have several types of users:
 
 * Logged in users are identified the standard Django way: `user.is_authenticated`
-* Users may belong to a vesting org (`user.vesting_org is not None`). You should test this with `user.is_vesting_org_member()`, which avoids an extra database call and can be easily updated in case the underlying data model changes.
+* Users may belong to a vesting org. You should test this with `user.is_vesting_org_member`.
 * Users may belong to a registrar (`user.registrar is not None`). You should test this with `user.is_registrar_member()`. 
 * Admin users are identified the standard Django way: `user.is_staff`
 

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -79,7 +79,7 @@ class VestingOrgManager(models.Manager):
         return VestingOrgQuerySet(self.model, using=self._db)
 
     def user_access_filter(self, user):
-        if user.is_vesting_org_member():
+        if user.is_vesting_org_member:
             return Q(id__in=user.vesting_org.all())
         elif user.is_registrar_member():
             return Q(registrar_id=user.registrar_id)
@@ -228,7 +228,7 @@ class LinkUser(AbstractBaseUser):
             ([vesting_org.shared_folder.get_descendants(include_self=True) for vesting_org in vesting_orgs if vesting_org])
 
     def get_default_vesting_org(self):
-        if self.is_vesting_org_member():
+        if self.is_vesting_org_member:
             return self.vesting_org.all()
         if self.is_registrar_member():
             return self.registrar.default_vesting_org
@@ -274,12 +274,13 @@ class LinkUser(AbstractBaseUser):
 
     def can_vest(self):
         """ Can the user vest links? """
-        return bool(self.is_staff or self.is_registrar_member() or self.is_vesting_org_member())
+        return bool(self.is_staff or self.is_registrar_member() or self.is_vesting_org_member)
 
     def is_registrar_member(self):
         """ Is the user a member of a registrar? """
         return bool(self.registrar_id)
 
+    @cached_property
     def is_vesting_org_member(self):
         """ Is the user a member of a vesting org? """
         return self.vesting_org.exists()

--- a/perma_web/perma/templates/user_management/includes/paginator.html
+++ b/perma_web/perma/templates/user_management/includes/paginator.html
@@ -1,18 +1,19 @@
+{% load current_query_string %}
 {% if page.paginator.num_pages > 1 %}
     <div class="pagination">
         <ul class="pagination">
             {% if page.has_previous %}
-                <li><a href="?page={{ page.previous_page_number }}&sort={{ sort }}{% if search_query %}&q={{ search_query }}{% endif %}">&lt;</a></li>
+                <li><a href="?{% current_query_string page=page.previous_page_number %}">&lt;</a></li>
             {% endif %}
             {% for i in page.paginator.page_range %}
                 {% ifequal i page.number %}
                     <li class="active"><a href="">{{ i }}</a></li>
                 {% else %}
-                    <li><a href="?page={{ i }}&sort={{ sort }}{% if search_query %}&q={{ search_query }}{% endif %}">{{ i }}</a></li>
+                    <li><a href="?{% current_query_string page=i %}">{{ i }}</a></li>
                 {% endifequal %}
             {% endfor %}
             {% if page.has_next  %}
-                <li><a href="?page={{ page.next_page_number }}&sort={{ sort }}{% if search_query %}&q={{ search_query }}{% endif %}">&gt;</a></li>
+                <li><a href="?{% current_query_string page=page.next_page_number %}">&gt;</a></li>
             {% endif %}
         </ul>
     </div>

--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -1,5 +1,5 @@
 {% extends "manage-layout.html" %}
-{% load local_datetime humanize %}
+{% load local_datetime humanize current_query_string %}
 {% block title %} | Registrars{% endblock %}
 
 {% block manage-nav-registrar %}<li class="active"><a href="{% url 'user_management_manage_registrar' %}">Registrars</a></li>{% endblock %}
@@ -34,7 +34,7 @@
         </div>
         <div class="col-sm-3">
             <p class="count-label">Registrars</p>
-            <p class="count-number">{{ registrar_count }}</p>
+            <p class="count-number">{{ registrars.paginator.count }}</p>
         </div>
     </div>
 
@@ -47,7 +47,7 @@
         {% endif %}
         <div class="row">
             <div class="col-sm-12">
-                <p class="sort-filter-count">{{registrar_results}} registrar{% if not registrar_results == 1 %}s{% endif %}</p>
+                <p class="sort-filter-count">{{ registrars.paginator.count }} registrar{{ registrars.paginator.count|pluralize }}</p>
                 <div class="sort-filter-bar">
                 {% include "user_management/includes/search_form_simple.html" %}
                 <div class="dropdown">
@@ -57,14 +57,14 @@
                 
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                     <li>
-                        <a {% if sort == 'name' %}class="selected" {% endif %}href="?sort=name&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Name A - Z</a>
-                        <a {% if sort == '-name' %}class="selected" {% endif %} href="?sort=-name&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Name Z - A</a>
-                        <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?sort=-date_created&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Newest</a>
-                        <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?sort=date_created&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Oldest</a>
-                        <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?sort=-last_active&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Recently active</a>
-                        <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?sort=last_active&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Least recently active</a>
-                        <a {% if sort == '-vested_links' %}class="selected" {% endif %} href="?sort=-vested_links&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Most vested links</a>
-                        <a {% if sort == 'vested_links' %}class="selected" {% endif %} href="?sort=vested_links&page={{ registrars.number }}{% if search_query %}&q={{ search_query }}{% endif %}"><i class="icon-ok"></i> Least vested links</a>
+                        <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
+                        <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
+                        <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
+                        <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
+                        <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
+                        <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="last_active" %}"><i class="icon-ok"></i> Least recently active</a>
+                        <a {% if sort == '-vested_links' %}class="selected" {% endif %} href="?{% current_query_string sort="-vested_links" %}"><i class="icon-ok"></i> Most vested links</a>
+                        <a {% if sort == 'vested_links' %}class="selected" {% endif %} href="?{% current_query_string sort="vested_links" %}"><i class="icon-ok"></i> Least vested links</a>
                     </li>
                   </ul>
                 </div>

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -1,5 +1,5 @@
 {% extends "manage-layout.html" %}
-{% load local_datetime humanize %}
+{% load local_datetime humanize current_query_string %}
 {% block title %} | {{ pretty_group_name_plural }}{% endblock %}
 
 {% block content %}
@@ -44,15 +44,16 @@
         <div class="row">
             <div class="col-sm-3">
                 <p class="count-label">Users</p>
-                <p class="count-number">{{ users_count|intcomma }}</p>
+                <p class="count-number">{{ users.paginator.count|intcomma }}</p>
             </div>
 
             {% if request.user.is_staff and group_name == 'user' %}
-            <div class="col-sm-3">
-                <p class="count-label">Deactivated Users</p>
-                <p class="count-number">{{ deactivated_users }}</p>
-            </div>
+                <div class="col-sm-3">
+                    <p class="count-label">Deactivated Users</p>
+                    <p class="count-number">{{ deactivated_users }}</p>
+                </div>
             {% endif %}
+
             <div class="col-sm-3">
                 <p class="count-label">Unactivated Users</p>
                 <p class="count-number">{{ unactivated_users }}</p>
@@ -60,7 +61,7 @@
 
             <div class="col-sm-3">
                 <p class="count-label">Vested Links</p>
-                <p class="count-number">{{ total_vested_links_count.count|intcomma }}</p>
+                <p class="count-number">{{ total_vested_links_count.count|default:0|intcomma }}</p>
             </div>
         </div>
         {% if registrar_filter.name or vesting_org_filter.name or status or search_query %}
@@ -72,7 +73,7 @@
         {% endif %}
         <div class="row">
             <div class="col-sm-12">
-                <p class="sort-filter-count">{{users_count}} user{% if not users_count == 1 %}s{% endif %}</p>
+                <p class="sort-filter-count">{{ users.paginator.count }} user{{ users.paginator.count|pluralize }}</p>
                 <div class="sort-filter-bar">
                 {% include "user_management/includes/search_form_simple.html" %}
                 <div class="dropdown">
@@ -82,15 +83,15 @@
                 
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                     <li>
-                        <a {% if sort == 'last_name' %}class="selected" {% endif %}href="?sort=last_name&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Last name A - Z</a>
-                        <a {% if sort == '-last_name' %}class="selected" {% endif %} href="?sort=-last_name&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Last name Z - A</a>
-                        <a {% if sort == '-date_joined' %}class="selected" {% endif %} href="?sort=-date_joined&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Newest</a>
-                        <a {% if sort == 'date_joined' %}class="selected" {% endif %} href="?sort=date_joined&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Oldest</a>
-                        <a {% if sort == '-last_login' %}class="selected" {% endif %} href="?sort=-last_login&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Recently active</a>
-                        <a {% if sort == 'last_login' %}class="selected" {% endif %} href="?sort=last_login&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Least recently active</a>
+                        <a {% if sort == 'last_name' %}class="selected" {% endif %}href="?{% current_query_string sort="last_name" %}"><i class="icon-ok"></i> Last name A - Z</a>
+                        <a {% if sort == '-last_name' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_name" %}"><i class="icon-ok"></i> Last name Z - A</a>
+                        <a {% if sort == '-date_joined' %}class="selected" {% endif %} href="?{% current_query_string sort="-date_joined" %}"><i class="icon-ok"></i> Newest</a>
+                        <a {% if sort == 'date_joined' %}class="selected" {% endif %} href="?{% current_query_string sort="date_joined" %}"><i class="icon-ok"></i> Oldest</a>
+                        <a {% if sort == '-last_login' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_login" %}"><i class="icon-ok"></i> Recently active</a>
+                        <a {% if sort == 'last_login' %}class="selected" {% endif %} href="?{% current_query_string sort="last_login" %}"><i class="icon-ok"></i> Least recently active</a>
                         {% if group_name == 'vesting_user' %}
-                        <a {% if sort == '-vested_links_count' %}class="selected" {% endif %} href="?sort=-vested_links_count&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Most vested links</a>
-                        <a {% if sort == 'vested_links_count' %}class="selected" {% endif %} href="?sort=vested_links_count&page={{ users.number }}{% if sort_url %}{{ sort_url }}{% endif %}"><i class="icon-ok"></i> Least vested links</a>
+                            <a {% if sort == '-vested_links_count' %}class="selected" {% endif %} href="?{% current_query_string sort="-vested_links_count" %}"><i class="icon-ok"></i> Most vested links</a>
+                            <a {% if sort == 'vested_links_count' %}class="selected" {% endif %} href="?{% current_query_string sort="vested_links_count" %}"><i class="icon-ok"></i> Least vested links</a>
                         {% endif %}
                     </li>
                   </ul>
@@ -99,15 +100,13 @@
                   <a role="button" data-toggle="dropdown" data-target="#" href="/page.html">
                     Status <span class="caret"></span>
                   </a>
-                
-                
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                     <li>
-                        <a {% if status == 'active' %}class="selected" {% endif %}href="?status=active&page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if vesting_org_filter %}&vesting_org={{ vesting_org_filter.id }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Active</a>
+                        <a {% if status == 'active' %}class="selected" {% endif %}href="?{% current_query_string status="active" %}"><i class="icon-ok"></i> Active</a>
                         {% if request.user.is_staff and group_name == 'user' %}
-                        <a {% if status == 'deactivated' %}class="selected" {% endif %}href="?status=deactivated&page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if vesting_org_filter %}&vesting_org={{ vesting_org_filter.id }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Deactivated</a>
+                            <a {% if status == 'deactivated' %}class="selected" {% endif %}href="?{% current_query_string status="deactivated" %}"><i class="icon-ok"></i> Deactivated</a>
                         {% endif %}
-                        <a {% if status == 'unactivated' %}class="selected" {% endif %}href="?status=unactivated&page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if vesting_org_filter %}&vesting_org={{ vesting_org_filter.id }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Unactivated</a>
+                        <a {% if status == 'unactivated' %}class="selected" {% endif %}href="?{% current_query_string status="unactivated" %}"><i class="icon-ok"></i> Unactivated</a>
                     </li>
                   </ul>
                 </div>
@@ -123,11 +122,11 @@
                     <li>
                         {% if vesting_orgs %}
                             {% for vesting_org in vesting_orgs %}
-                            {% if vesting_org_filter == vesting_org %}
-                                <a class="selected" href="?page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}{% if status %}&status={{ status }}{% endif %}"><i class="icon-ok"></i> {{vesting_org.name}}</a>
-                            {% else %}
-                                <a href="?vesting_org={{vesting_org.id}}&page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}{% if status %}&status={{ status }}{% endif %}"><i class="icon-ok"></i> {{vesting_org.name}}</a>
-                            {% endif %}
+                                {% if vesting_org_filter == vesting_org %}
+                                    <a class="selected" href="?{% current_query_string vesting_org='' %}"><i class="icon-ok"></i> {{vesting_org.name}}</a>
+                                {% else %}
+                                    <a href="?{% current_query_string vesting_org=vesting_org.id %}"><i class="icon-ok"></i> {{vesting_org.name}}</a>
+                                {% endif %}
                             {% endfor %}
                         {% else %}
                             <a href="">None</a>
@@ -149,11 +148,11 @@
                     <li>
                         {% if registrars %}
                             {% for registrar in registrars %}
-                            {% if registrar_filter == registrar %}
-                                <a class="selected" href="?page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if vesting_org_filter %}&vesting_org={{ vesting_org_filter.id }}{% endif %}"><i class="icon-ok"></i> {{registrar.name}}</a>
-                            {% else %}
-                                <a href="?registrar={{registrar.id}}&page={{ users.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}{% if vesting_org_filter %}&vesting_org={{ vesting_org_filter.id }}{% endif %}"><i class="icon-ok"></i> {{registrar.name}}</a>
-                            {% endif %}
+                                {% if registrar_filter == registrar %}
+                                    <a class="selected" href="?{% current_query_string registrar='' vesting_org='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+                                {% else %}
+                                    <a href="?{% current_query_string registrar=registrar.id vesting_org='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+                                {% endif %}
                             {% endfor %}
                         {% else %}
                             <a href="">None</a>
@@ -185,12 +184,14 @@
               <p class="list-vesting-org">
                 {% if request.user.is_staff or request.user.is_registrar_member %}
                     {% for vesting_org in listed_user.vesting_org.all %}
-                            <a href="{% url 'user_management_manage_vesting_org' %}?q={{vesting_org.name.split|join:'+'|lower}}">{{vesting_org.name.strip}}</a>
-                            {% include "user_management/includes/comma.html" %}
+                        <a href="{% url 'user_management_manage_vesting_org' %}?q={{vesting_org.name.split|join:'+'|lower}}">{{vesting_org.name.strip}}</a>
+                        {% include "user_management/includes/comma.html" %}
                     {% endfor %}
                 {% endif %}
               </p>
-            {% if group_name == 'registrar_user' and request.user.is_staff %}<p class="list-registrar"><a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}">{{ listed_user.registrar.name }}</a></p>{% endif %}
+              {% if group_name == 'registrar_user' and request.user.is_staff %}
+                  <p class="list-registrar"><a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}">{{ listed_user.registrar.name }}</a></p>
+              {% endif %}
               </div>
               <div class="col-sm-3">
                 {% if group_name == 'vesting_user' %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -179,6 +179,7 @@
                 {% else %}
                     {{ listed_user.first_name }} {{ listed_user.last_name }}
                 {% endif %}
+                {% if listed_user == request.user %}(you){% endif %}
                 </p>
               <p class="list-email">{{ listed_user.email }}</p>
               <p class="list-vesting-org">

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -1,5 +1,5 @@
 {% extends "manage-layout.html" %}
-{% load local_datetime humanize current_query_string %}
+{% load local_datetime humanize current_query_string visible_vesting_orgs %}
 {% block title %} | {{ pretty_group_name_plural }}{% endblock %}
 
 {% block content %}
@@ -183,12 +183,10 @@
                 </p>
               <p class="list-email">{{ listed_user.email }}</p>
               <p class="list-vesting-org">
-                {% if request.user.is_staff or request.user.is_registrar_member %}
-                    {% for vesting_org in listed_user.vesting_org.all %}
-                        <a href="{% url 'user_management_manage_vesting_org' %}?q={{vesting_org.name.split|join:'+'|lower}}">{{vesting_org.name.strip}}</a>
-                        {% include "user_management/includes/comma.html" %}
-                    {% endfor %}
-                {% endif %}
+                {% for vesting_org in listed_user|visible_vesting_orgs:request.user %}
+                    <a href="{% url 'user_management_manage_vesting_org' %}?q={{vesting_org.name.split|join:'+'|lower}}">{{vesting_org.name.strip}}</a>
+                    {% include "user_management/includes/comma.html" %}
+                {% endfor %}
               </p>
               {% if group_name == 'registrar_user' and request.user.is_staff %}
                   <p class="list-registrar"><a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}">{{ listed_user.registrar.name }}</a></p>

--- a/perma_web/perma/templates/user_management/manage_vesting_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_vesting_orgs.html
@@ -1,5 +1,5 @@
 {% extends "manage-layout.html" %}
-{% load local_datetime humanize %}
+{% load local_datetime humanize current_query_string %}
 {% block title %} | Vesting organizations{% endblock %}
 
 {% block content %}
@@ -43,7 +43,7 @@
             {% endcomment %}
         <div class="col-sm-3">
             <p class="count-label">Vesting Organizations</p>
-            <p class="count-number">{{ vesting_orgs|length }}</p>
+            <p class="count-number">{{ vesting_orgs.paginator.count }}</p>
         </div>
     </div>
 
@@ -56,7 +56,7 @@
         {% endif %}
         <div class="row">
             <div class="col-sm-12">
-                <p class="sort-filter-count">{{ vesting_orgs|length }} vesting organization{% if not vesting_orgs_count == 1 %}s{% endif %}</p>
+                <p class="sort-filter-count">{{ vesting_orgs.paginator.count }} vesting organization{{ vesting_orgs.paginator.count|pluralize }}</p>
                 <div class="sort-filter-bar">
                 {% include "user_management/includes/search_form_simple.html" %}
                 <div class="dropdown">
@@ -66,14 +66,15 @@
                 
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                     <li>
-                        <a {% if sort == 'name' %}class="selected" {% endif %}href="?sort=name&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Name A - Z</a>
-                        <a {% if sort == '-name' %}class="selected" {% endif %} href="?sort=-name&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Name Z - A</a>
-                        <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?sort=-date_created&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Newest</a>
-                        <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?sort=date_created&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Oldest</a>
-                        <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?sort=-last_active&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Recently active</a>
-                        <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?sort=last_active&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Least recently active</a>
-                        <a {% if sort == '-vested_links' %}class="selected" {% endif %} href="?sort=-vested_links&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Most vested links</a>
-                        <a {% if sort == 'vested_links' %}class="selected" {% endif %} href="?sort=vested_links&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Least vested links</a>
+                        <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
+                        <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
+                        <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
+                        <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
+                        <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
+                        <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="=last_active" %}"><i class="icon-ok"></i> Least recently active</a>
+                        <a {% if sort == '-vested_links' %}class="selected" {% endif %} href="?{% current_query_string sort="-vested_links" %}"><i class="icon-ok"></i> Most vested links</a>
+                        <a {% if sort == 'vested_links' %}class="selected" {% endif %} href="?{% current_query_string sort="vested_links" %}"><i class="icon-ok"></i> Least vested links</a><a {% if sort == '-vesting_users' %}class="selected" {% endif %} href="?sort=-vesting_users{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Most users</a>
+                        <a {% if sort == 'vesting_users' %}class="selected" {% endif %} href="?{% current_query_string sort="vesting_users" %}"><i class="icon-ok"></i> Least users</a>
                     </li>
                   </ul>
                 </div>
@@ -88,11 +89,11 @@
                     <li>
                         {% if registrars %}
                             {% for registrar in registrars %}
-                            {% if registrar_filter == registrar %}
-                                <a class="selected" href="?page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}"><i class="icon-ok"></i> {{registrar.name}}</a>
-                            {% else %}
-                                <a href="?registrar={{registrar.id}}&page={{ vesting_orgs.number }}{% if search_query %}&q={{ search_query }}{% endif %}{% if sort %}&sort={{ sort }}{% endif %}"><i class="icon-ok"></i> {{registrar.name}}</a>
-                            {% endif %}
+                                {% if registrar_filter == registrar %}
+                                    <a class="selected" href="?{% current_query_string registrar='' page='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+                                {% else %}
+                                    <a href="?{% current_query_string registrar=registrar.id page='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+                                {% endif %}
                             {% endfor %}
                         {% else %}
                             <a href="">None</a>

--- a/perma_web/perma/templatetags/current_query_string.py
+++ b/perma_web/perma/templatetags/current_query_string.py
@@ -1,0 +1,13 @@
+import urllib
+from django import template
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def current_query_string(context, **kwargs):
+    """
+        Given {% current_query_string page=1 q='' %}, return the current query string but with page and q values changed.
+    """
+    query_params = dict(context['request'].GET, **kwargs)
+    query_params = dict((k,v) for k, v in query_params.items() if v is not None and v != '')
+    return urllib.urlencode(query_params, doseq=True)

--- a/perma_web/perma/templatetags/visible_vesting_orgs.py
+++ b/perma_web/perma/templatetags/visible_vesting_orgs.py
@@ -1,0 +1,16 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def visible_vesting_orgs(vesting_user, viewing_user):
+    """
+        Return just the vesting orgs that viewing_user is allowed to know about.
+    """
+    if viewing_user.is_staff:
+        return vesting_user.vesting_org.all()
+    elif viewing_user.is_registrar_member():
+        return vesting_user.vesting_org.filter(registrar_id=viewing_user.registrar_id)
+    elif viewing_user.is_vesting_org_member:
+        return vesting_user.vesting_org.filter(id__in=[v.pk for v in viewing_user.vesting_org.all()])
+    return []

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -1,10 +1,13 @@
 from contextlib import contextmanager
 import operator
 import os
+from django.core.paginator import Paginator
 
 from django.db.models import Q
 from django.conf import settings
 import struct
+from django.utils.http import urlquote
+from django.utils.safestring import mark_safe
 import tempdir
 
 
@@ -20,31 +23,55 @@ def run_task(task, *args, **kwargs):
     else:
         return task.apply(args, kwargs, **options)
 
-### simple search ###
+### list view helpers ###
 
-def get_search_query(target, search_string, fields):
+def apply_search_query(request, queryset, fields):
     """
-        For the given `target` (either a Model or QuerySet),
+        For the given `queryset`,
         apply consecutive .filter()s such that each word
-        in `search_string` appears in one of the `fields`.
+        in request.GET['q'] appears in one of the `fields`.
     """
+    search_string = request.GET.get('q', '')
+    if not search_string:
+        return queryset, ''
+
     # get words in search_string
     required_words = search_string.strip().split()
     if not required_words:
-        return target
-
-    # if we got a Model, turn into a QuerySet
-    if hasattr(target, 'objects'):
-        target = target.objects
+        return queryset
 
     for required_word in required_words:
-        # apply the equivalent of target = target.filter(Q(field1__icontains=required_word) | Q(field2__icontains=required_word) | ...)
+        # apply the equivalent of queryset = queryset.filter(Q(field1__icontains=required_word) | Q(field2__icontains=required_word) | ...)
         query_parts = [Q(**{field+"__icontains":required_word}) for field in fields]
         query_parts_joined = reduce(operator.or_, query_parts, Q())
-        target = target.filter(query_parts_joined)
+        queryset = queryset.filter(query_parts_joined)
 
-    return target
-    
+    return queryset, search_string
+
+def apply_sort_order(request, queryset, valid_sorts, default_sort=None):
+    """
+        For the given `queryset`,
+        apply sort order based on request.GET['sort'].
+    """
+    if not default_sort:
+        default_sort = valid_sorts[0]
+    sort = request.GET.get('sort', default_sort)
+    if sort not in valid_sorts:
+      sort = default_sort
+    return queryset.order_by(sort), sort
+
+def apply_pagination(request, queryset):
+    """
+        For the given `queryset`,
+        apply pagination based on request.GET['page'].
+    """
+    try:
+        page = max(int(request.GET.get('page', 1)), 1)
+    except ValueError:
+        page = 1
+    paginator = Paginator(queryset, settings.MAX_USER_LIST_SIZE)
+    return paginator.page(page)
+
 ### url manipulation ###
 
 def absolute_url(request, url):

--- a/perma_web/perma/views/link_management.py
+++ b/perma_web/perma/views/link_management.py
@@ -66,7 +66,7 @@ def folder_contents(request, folder_id):
 
 ###### link editing ######
 @login_required
-@user_passes_test(lambda user: user.is_staff or user.is_registrar_member() or user.is_vesting_org_member())
+@user_passes_test(lambda user: user.is_staff or user.is_registrar_member() or user.is_vesting_org_member)
 def vest_link(request, guid):
     link = get_object_or_404(Link, guid=guid)
     folder = None

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -374,7 +374,7 @@ def list_users_in_group(request, group_name):
             users = users.filter(registrar=request.user.registrar)
         is_registrar = True
     elif request.user.is_vesting_org_member:
-        users = users.filter(vesting_org=request.user.vesting_org)
+        users = users.filter(vesting_org__in=request.user.vesting_org.all())
     else:
         raise Http404  # this shouldn't happen
 


### PR DESCRIPTION
- Move vesting org list back to sql-based annotations, so sorting and pagination work again. Fixes #897.
- Refactor user_management so sorting, searching and pagination are handled by the same helpers functions for vesting orgs, registrars and users.
- Reduce number of sql queries required for lists.
- Add the "current_query_string" tag to simplify search/sort/filter/paginate interactions.

- In vesting user list, only show vesting org membership to registrars for vesting orgs belonging to that registrar. Fixes #889.
- As a bonus, vesting users viewing that list now see a list of orgs they have in common. Fixes #888.

- Users now see themselves in user list, with "(you)" next to their name.

- Fix "mysql has gone away" error we were getting at the end of Travis builds.