### PR TITLE
Use user-supplied emails as reply-to rather than from.

### DIFF
--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -1,7 +1,10 @@
+from django.conf import settings
+from django.core import mail
+from django.core.urlresolvers import reverse
+
 from perma.urls import urlpatterns
 
 from .utils import PermaTestCase
-from django.core.urlresolvers import reverse
 
 class CommonViewsTestCase(PermaTestCase):
 
@@ -30,20 +33,30 @@ class CommonViewsTestCase(PermaTestCase):
         # Does our contact form behave reasonably?
 
         # The form should be fine will all fields
+        message_body = 'Just some message here'
+        from_email = 'example@example.com'
         self.submit_form('contact', data={
-                            'email': 'example@example.com',
-                            'message': 'Just some message here'},
+                            'email': from_email,
+                            'message': message_body},
                        success_url=reverse('contact_thanks'))
 
-        # We should fail if we don't get an email
+        # check contents of sent email
+        message = mail.outbox[0]
+        self.assertIn(message_body, message.body)
+        self.assertEqual(message.subject, 'New message from Perma contact form')
+        self.assertEqual(message.from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEqual(message.recipients(), [settings.DEFAULT_FROM_EMAIL])
+        self.assertDictEqual(message.extra_headers, {'Reply-To': from_email})
+
+        # We should fail if we don't get a from email
         response = self.client.post(reverse('contact'), data={
                             'email': '',
-                            'message': 'some message here'})
+                            'message': message_body})
         self.assertEqual(response.request['PATH_INFO'], reverse('contact'))
 
         # We need at least a message. We should get the contact page back
         # instead of the thanks page.
         response = self.client.post(reverse('contact'), data={
-                            'email': '',
+                            'email': from_email,
                             'message': ''})
         self.assertEqual(response.request['PATH_INFO'], reverse('contact'))

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -1,12 +1,13 @@
 from contextlib import contextmanager
 import operator
 import os
-from django.core.paginator import Paginator
-
-from django.db.models import Q
-from django.conf import settings
 import struct
 import tempdir
+
+from django.core.mail import EmailMessage
+from django.core.paginator import Paginator
+from django.db.models import Q
+from django.conf import settings
 
 
 ### celery helpers ###
@@ -141,3 +142,18 @@ def copy_file_data(from_file_handle, to_file_handle, chunk_size=1024*100):
         if not data:
             break
         to_file_handle.write(data)
+
+### email ###
+
+def send_contact_email(title, content, from_address):
+    """
+        Send a message on behalf of a user to the admins.
+        Use reply-to for the user address so we can use email services that require authenticated from addresses.
+    """
+    EmailMessage(
+        title,
+        content,
+        settings.DEFAULT_FROM_EMAIL,
+        [settings.DEFAULT_FROM_EMAIL],
+        headers={'Reply-To': from_address}
+    ).send(fail_silently=False)

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -17,7 +17,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.cache import cache_control
-from django.core.mail import send_mail
+from django.core.mail import EmailMessage
 from django.views.static import serve as media_view
 
 import logging
@@ -28,8 +28,7 @@ from ratelimit.decorators import ratelimit
 from ..models import Link, Asset
 from perma.forms import ContactForm
 from perma.middleware import ssl_optional
-from perma.utils import if_anonymous
-
+from perma.utils import if_anonymous, send_contact_email
 
 logger = logging.getLogger(__name__)
 valid_serve_types = ['image', 'pdf', 'source', 'warc_download']
@@ -215,11 +214,10 @@ def contact(request):
 
             ''' % (form.cleaned_data['message'], from_address, user_agent)
 
-            send_mail(
+            send_contact_email(
                 "New message from Perma contact form",
                 content,
-                from_address,
-                [settings.DEFAULT_FROM_EMAIL], fail_silently=False
+                from_address
             )
 
             # redirect to a new URL:

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -11,6 +11,7 @@ from django.template import RequestContext
 from django.contrib.auth.decorators import login_required
 
 from perma.models import Link, Stat
+from perma.utils import send_contact_email
 
 
 logger = logging.getLogger(__name__)
@@ -76,11 +77,10 @@ def receive_feedback(request):
 ''' % (visited_page, feedback_text, broken_text, user_agent)
     logger.debug(content)
     
-    send_mail(
+    send_contact_email(
         "New Perma feedback",
         content,
-        from_address,
-        [settings.DEFAULT_FROM_EMAIL], fail_silently=False
+        from_address
     )
         
     response_object = {'submitted': 'true', 'content': content}

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -33,7 +33,7 @@ from perma.forms import (
     SetPasswordForm, 
 )
 from perma.models import Registrar, LinkUser, Organization
-from perma.utils import apply_search_query, apply_pagination, apply_sort_order
+from perma.utils import apply_search_query, apply_pagination, apply_sort_order, send_contact_email
 
 logger = logging.getLogger(__name__)
 valid_member_sorts = ['last_name', '-last_name', 'date_joined', '-date_joined', 'last_login', '-last_login', 'vested_links_count', '-vested_links_count']
@@ -1450,11 +1450,10 @@ http://%s%s
 
     logger.debug(content)
 
-    send_mail(
+    send_contact_email(
         "Perma.cc new library registrar account request",
         content,
-        pending_registrar.email,
-        [settings.DEFAULT_FROM_EMAIL], fail_silently=False
+        pending_registrar.email
     )
     
 


### PR DESCRIPTION
So e.g. when a user submits something to the contact form, we get an email that's from info@perma.cc but Reply-To user-email, instead of from user-email.

This lets us use something like Amazon SES for email sending, which won't send emails from unverified addresses.