### PR TITLE
Upgrade to Django 1.7.10.

### DIFF
--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -1,6 +1,6 @@
 # Package:                      # Used for:
 
-Django==1.7.6
+Django==1.7.10
 MySQL-python==1.2.5
 lxml==3.2.1
 PyPDF2==1.20                    # check integrity of uploaded PDFs


### PR DESCRIPTION
Upgrade from 1.7.6 to 1.7.10 — no code changes required.

There have been a couple of Django security updates since our last upgrade. Doesn’t look like anything important to us, but may as well grab the latest.