### PR TITLE
Thumbnail fix

### DIFF
--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -1,6 +1,6 @@
 # handy packages to have in a dev environment
 ipdb
-django-debug-toolbar==1.2.1     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
+django-debug-toolbar==1.3.2     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
 django-extensions==1.4.4        # if installed, `fab run` will use `python manage.py runserver_plus`
 django-nose==1.3.0              # an alternative test runner; enable in settings_testing.py
 pysqlite==2.6.3                 # for use with in memory testing set in settings_testing.py

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -46,7 +46,7 @@ INSTALLED_APPS += ("sslserver",)
 try:
     import debug_toolbar
     INSTALLED_APPS += (
-        'debug_toolbar.apps.DebugToolbarConfig',
+        'debug_toolbar',
     )
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': 'perma.utils.show_debug_toolbar'  # we have to override this check because the default depends on IP address, which doesn't work inside Vagrant

--- a/perma_web/static/js/create.js
+++ b/perma_web/static/js/create.js
@@ -198,8 +198,10 @@ function check_status() {
         var capturesPending = false,
             capturesSucceeded = false;
         $.each(data.captures, function(i, capture){
-            if(capture.status == 'pending') capturesPending = true;
-            if(capture.status == 'success') capturesSucceeded = true;
+            if(capture.role != 'favicon') {
+                if (capture.status == 'pending') capturesPending = true;
+                if (capture.status == 'success') capturesSucceeded = true;
+            }
         });
 
         // We're done checking status when nothing is pending.


### PR DESCRIPTION
Thumbnails weren’t working for pages with favicons — we would try to generate the thumbnail when the only available capture was the favicon. D’oh.

Fixes #985.