### PR TITLE
Include user email and user agent in footer of all contact emails.

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -145,11 +145,24 @@ def copy_file_data(from_file_handle, to_file_handle, chunk_size=1024*100):
 
 ### email ###
 
-def send_contact_email(title, content, from_address):
+def send_contact_email(title, content, from_address, request):
     """
         Send a message on behalf of a user to the admins.
         Use reply-to for the user address so we can use email services that require authenticated from addresses.
     """
+
+    # append user agent and from email
+    user_agent = ''
+    if request:
+        user_agent = request.META.get('HTTP_USER_AGENT', '')
+    content += """
+
+----
+User email: %s
+User agent: %s
+""" % (from_address, user_agent)
+
+    # send message
     EmailMessage(
         title,
         content,

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -199,31 +199,23 @@ def contact(request):
         if form.is_valid():
             # If our form is valid, let's generate and email to our contact folks
 
-            user_agent = 'Unknown'
-            if 'HTTP_USER_AGENT' in request.META:
-                user_agent = request.META.get('HTTP_USER_AGENT')
-
             from_address = form.cleaned_data['email']
 
             content = '''
-            This is a message from the Perma.cc contact form, http://perma.cc/contact
+This is a message from the Perma.cc contact form, http://perma.cc/contact
 
 
 
-            Message from user
-            --------
-            %s
-
-
-            User email: %s
-            User agent: %s
-
-            ''' % (form.cleaned_data['message'], from_address, user_agent)
+Message from user
+--------
+%s
+''' % (form.cleaned_data['message'])
 
             send_contact_email(
                 "New message from Perma contact form",
                 content,
-                from_address
+                from_address,
+                request
             )
 
             # redirect to a new URL:

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -44,10 +44,6 @@ def receive_feedback(request):
     """
     Take feedback data and send it off in an email
     """
-    
-    user_agent = ''
-    if 'HTTP_USER_AGENT' in request.META:
-        user_agent = request.META.get('HTTP_USER_AGENT')
 
     visited_page = request.POST.get('visited_page')
     feedback_text = request.POST.get('feedback_text')
@@ -61,26 +57,22 @@ def receive_feedback(request):
     
     from_address = request.POST.get('user_email')
     content = '''
-    Visited page: %s
-    
-    COMMENTS
-    --------
-    %s
-    
-    
-    %s
-    
-    USER INFO
-    ---------
-    %s
+Visited page: %s
 
-''' % (visited_page, feedback_text, broken_text, user_agent)
+COMMENTS
+--------
+%s
+
+
+%s
+''' % (visited_page, feedback_text, broken_text)
     logger.debug(content)
     
     send_contact_email(
         "New Perma feedback",
         content,
-        from_address
+        from_address,
+        request
     )
         
     response_object = {'submitted': 'true', 'content': content}

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1617,7 +1617,8 @@ http://%s%s
     send_contact_email(
         "Perma.cc new library registrar account request",
         content,
-        pending_registrar.email
+        pending_registrar.email,
+        request
     )
     
 


### PR DESCRIPTION
This makes sure we don’t lose track of the user email now that it’s moved to Reply-To header instead of From.