### PR TITLE
Allow spaces in submitted URLs.

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -78,7 +78,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
         self.assertEqual(capture.status, 'success')
         headers, data = capture.link.replay_url(capture.url)
         self.assertTrue(capture.content_type, "Capture is missing a content type.")
-        self.assertEqual(capture.content_type, capture.read_content_type())
+        self.assertEqual(capture.content_type.split(';',1)[0], capture.read_content_type().split(';',1)[0])
         data = "".join(data)
         self.assertTrue(data, "Capture data is missing.")
 

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -17,6 +17,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
                 'fixtures/api_keys.json']
 
     serve_files = [os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.html'),
+                   [os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.html'), 'test page.html'],
                    os.path.join(TEST_ASSETS_DIR, 'target_capture_files/noarchive.html'),
                    os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.pdf'),
                    os.path.join(TEST_ASSETS_DIR, 'target_capture_files/favicon.ico'),
@@ -149,6 +150,14 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
 
         link = Link.objects.get(guid=obj['guid'])
         self.assertTrue(link.dark_archived_robots_txt_blocked)
+
+    def test_should_accept_spaces_in_url(self):
+        obj = self.successful_post(self.list_url,
+                                   data={'url': self.server_url + "/test page.html?a b=c d#e f"},
+                                   user=self.vesting_member)
+
+        link = Link.objects.get(guid=obj['guid'])
+        self.assertValidCapture(link.primary_capture)
 
     #########################
     # File Archive Creation #

--- a/perma_web/api/validations.py
+++ b/perma_web/api/validations.py
@@ -1,3 +1,4 @@
+import urllib
 from tastypie.validation import Validation
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
@@ -78,7 +79,7 @@ class LinkValidation(Validation):
         elif bundle.obj.tracker.has_changed('submitted_url'):  # url is aliased to submitted_url in the API
             try:
                 validate = URLValidator()
-                validate(bundle.data.get('url'))
+                validate(bundle.data.get('url').replace(' ', '%20'))
 
                 # Don't force URL resolution validation if a file is provided
                 if not bundle.data.get('file', None):


### PR DESCRIPTION
Turns out spaces and fragments in URLs both work great (since `requests`, `phantomJS`, `pywb` etc already know how to handle them), except that our URL validator doesn’t like unencoded spaces. So this just encodes spaces for the validator and lets them proceed as usual.

Fixes #1003.