### PR TITLE
Disable celery features to avoid excessive msgs

### DIFF
--- a/services/heroku/Procfile
+++ b/services/heroku/Procfile
@@ -1,2 +1,2 @@
 web: newrelic-admin run-program gunicorn --log-level debug --access-logfile - -w 1 -b 0.0.0.0:$PORT -k gevent --forwarded-allow-ips '*' perma.wsgi
-worker: newrelic-admin run-program celery -A perma worker --loglevel=info --concurrency=1
+worker: newrelic-admin run-program celery -A perma worker --loglevel=info --concurrency=1 --without-gossip --without-mingle --without-heartbeat


### PR DESCRIPTION
These flags were recommended in a CloudAMQP email warning us that we were about to exceed our monthly allotment.