### PR TITLE
Capture fixes.

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -18,6 +18,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
 
     serve_files = [os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.html'),
                    [os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.html'), 'test page.html'],
+                   [os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.html'), 'subdir/test.html'],
                    os.path.join(TEST_ASSETS_DIR, 'target_capture_files/noarchive.html'),
                    os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.pdf'),
                    os.path.join(TEST_ASSETS_DIR, 'target_capture_files/favicon.ico'),
@@ -145,7 +146,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
     def test_should_dark_archive_when_disallowed_in_robots_txt(self):
         with self.serve_file(os.path.join(TEST_ASSETS_DIR, 'target_capture_files/robots.txt')):
             obj = self.successful_post(self.list_url,
-                                       data={'url': self.server_url + "/test.html"},
+                                       data={'url': self.server_url + "/subdir/test.html"},
                                        user=self.vesting_member)
 
         link = Link.objects.get(guid=obj['guid'])

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -25,6 +25,9 @@ TEST_ASSETS_DIR = os.path.join(settings.PROJECT_ROOT, "perma/tests/assets")
 
 
 def copy_file_or_dir(src, dst):
+    dst_dir = os.path.abspath(os.path.dirname(dst))
+    if not os.path.isdir(dst_dir):
+        os.makedirs(dst_dir)
     try:
         shutil.copytree(src, dst)
     except OSError as e:

--- a/perma_web/api/validations.py
+++ b/perma_web/api/validations.py
@@ -1,4 +1,4 @@
-import urllib
+from requests import TooManyRedirects
 from tastypie.validation import Validation
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
@@ -93,6 +93,8 @@ class LinkValidation(Validation):
                         errors['url'] = "Target page is too large (max size 1MB)."
             except ValidationError:
                 errors['url'] = "Not a valid URL."
+            except TooManyRedirects:
+                errors['url'] = "URL caused a redirect loop."
 
         uploaded_file = bundle.data.get('file')
         if uploaded_file:

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -177,7 +177,7 @@ def proxy_capture(self, link_guid, user_agent=''):
             return requests.get(url,
                                 headers={'User-Agent': user_agent},
                                 proxies={'http': 'http://' + proxy_address, 'https': 'http://' + proxy_address},
-                                cert=proxy.ca.ca_file)
+                                verify=False)
 
         # start warcprox in the background
         warc_writer = WarcWriter(gzip=True, port=warcprox_port)
@@ -212,6 +212,7 @@ def proxy_capture(self, link_guid, user_agent=''):
         for header in har_log_entries[0]['response']['headers']:
             if header['name'].lower() == 'content-type':
                 content_type = header['value'].lower()
+                break
         content_url = har_log_entries[0]['request']['url']
         have_html = content_type and content_type.startswith('text/html')
         print "Finished fetching url."
@@ -251,7 +252,7 @@ def proxy_capture(self, link_guid, user_agent=''):
         # fetch robots.txt in the background
         def robots_txt_thread():
             print "Fetching robots.txt ..."
-            robots_txt_location = urlparse.urljoin(content_url, 'robots.txt')
+            robots_txt_location = urlparse.urljoin(content_url, '/robots.txt')
             try:
                 robots_txt_response = proxied_get_request(robots_txt_location)
                 assert robots_txt_response.ok


### PR DESCRIPTION
Fix some edge cases during capture:

- Favicons and robots.txt load properly over SSL.

- Check for absolute `/robots.txt` instead of relative `robots.txt`. Update tests to make sure that robots.txt is found for URLs with sub-directories in the path.

- Display custom error message for URLs that cause redirect loops during capture, instead of 500 error.