### PR TITLE
Allow for deletion based on time window

### DIFF
--- a/perma_web/api/authorizations.py
+++ b/perma_web/api/authorizations.py
@@ -1,8 +1,6 @@
 from perma.models import Link
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.exceptions import Unauthorized, BadRequest
-from django.utils import timezone
-from datetime import timedelta
 
 class FolderAuthorization(ReadOnlyAuthorization):
 

--- a/perma_web/api/authorizations.py
+++ b/perma_web/api/authorizations.py
@@ -1,7 +1,8 @@
 from perma.models import Link
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.exceptions import Unauthorized, BadRequest
-
+from django.utils import timezone
+from datetime import timedelta
 
 class FolderAuthorization(ReadOnlyAuthorization):
 
@@ -181,7 +182,8 @@ class LinkAuthorization(AuthenticatedLinkAuthorization):
         return True
 
     def delete_detail(self, object_list, bundle):
-        if bundle.obj.vested or not self.can_access(bundle.request.user, bundle.obj):
+
+        if not bundle.obj.can_delete(bundle.request.user):
             raise Unauthorized()
 
         return True

--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -231,12 +231,16 @@ class LinkAuthorizationTestCase(ApiResourceTestCase):
     ############
 
     def test_should_allow_owner_to_delete_link(self):
-        count = Link.objects.count()
-        self.successful_delete(self.unvested_url, user=self.vesting_member)
-        self.assertEqual(Link.objects.count(), count-1)
-        self.rejected_get(self.unvested_url, user=self.vesting_member, expected_status_code=404)
+        with self.serve_file(os.path.join(TEST_ASSETS_DIR, 'target_capture_files/test.html')):
+            successful_response = self.successful_post(self.list_url, user=self.regular_user, data=self.post_data)
+            new_link = Link.objects.get(pk=successful_response['guid'])
+            new_link_url = "{0}/{1}".format(self.list_url, new_link.pk)
+            count = Link.objects.count()
+            self.successful_delete(new_link_url, user=self.regular_user)
+            self.assertEqual(Link.objects.count(), count-1)
+            self.rejected_get(new_link_url, user=self.regular_user, expected_status_code=404)
 
-    def test_should_reject_delete_for_vested_link(self):
+    def test_should_reject_delete_for_out_of_window_link(self):        
         self.rejected_delete(self.vested_url, user=self.vesting_member)
         self.successful_get(self.vested_url, user=self.vesting_member)
 

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -253,7 +253,14 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
     ############
 
     def test_delete_detail(self):
-        self.successful_delete(self.unvested_link_detail_url, user=self.vesting_member)
+        with self.serve_file(os.path.join(TEST_ASSETS_DIR, 'target_capture_files/robots.txt')):
+            obj = self.successful_post(self.list_url,
+                                       data={'url': self.server_url + "/subdir/test.html"},
+                                       user=self.vesting_member)
+
+            new_link = Link.objects.get(guid=obj['guid'])
+            new_link_url = "{0}/{1}".format(self.list_url, new_link.pk)
+            self.successful_delete(new_link_url, user=self.vesting_member)
 
     ############
     # Ordering #

--- a/perma_web/fixtures/archive.json
+++ b/perma_web/fixtures/archive.json
@@ -17,6 +17,7 @@
             "submitted_url": "http://arxiv.org/pdf/1406.3611.pdf",
             "vested_by_editor": null,
             "creation_timestamp": "2014-06-16T19:23:24Z",
+            "archive_timestamp": "2014-06-17T19:23:24Z",
             "organization": null
         }
     },
@@ -38,6 +39,7 @@
             "submitted_url": "http://dolekemp96.org",
             "vested_by_editor": null,
             "creation_timestamp": "2014-06-16T19:22:51Z",
+            "archive_timestamp": "2014-06-17T19:22:51Z",
             "organization": null
         }
     },
@@ -62,6 +64,7 @@
             "submitted_url": "http://metafilter.com",
             "vested_by_editor": 3,
             "creation_timestamp": "2014-12-07T18:55:37Z",
+            "archive_timestamp": "2014-12-08T18:55:37Z",
             "notes": "Maybe the source of all cool things on the internet.",
             "organization": 1
         }
@@ -87,6 +90,7 @@
             "submitted_url": "http://google.com",
             "vested_by_editor": 3,
             "creation_timestamp": "2014-12-08T18:55:37Z",
+            "archive_timestamp": "2014-12-09T18:55:37Z",
             "notes": "In an org subfolder, vested.",
             "organization": 1
         }
@@ -112,6 +116,7 @@
             "submitted_url": "http://google.com",
             "vested_by_editor": null,
             "creation_timestamp": "2014-12-09T18:55:37Z",
+            "archive_timestamp": "2014-12-10T18:55:37Z",
             "notes": "In an org subfolder, unvested.",
             "organization": null
         }
@@ -134,6 +139,7 @@
             "submitted_url": "https://www.wikipedia.org/",
             "vested_by_editor": null,
             "creation_timestamp": "2014-07-19T20:21:31Z",
+            "archive_timestamp": "2014-07-20T20:21:31Z",
             "organization": null
         }
     },

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -600,6 +600,17 @@ class Link(models.Model):
         """ Return date when this link will theoretically be deleted. """
         return self.creation_timestamp + settings.LINK_EXPIRATION_TIME
 
+    def can_delete(self, user):
+        """ An archive can be deleted if it is less than 24 hours old-style
+            and it was created by a user or someone in the org """
+
+        user_has_delete_privs = False
+
+        if user.is_staff or self.created_by == user or self.organization in user.get_orgs:
+            user_has_delete_privs = True
+
+        return timezone.now() < self.archive_timestamp and user_has_delete_privs
+
     def can_upload_to_internet_archive(self):
         """ Return True if this link is appropriate for upload to IA. """
         return self.vested \

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -606,7 +606,7 @@ class Link(models.Model):
 
         user_has_delete_privs = False
 
-        if user.is_staff or self.created_by == user or self.organization in user.get_orgs:
+        if user.is_staff or self.created_by == user or self.organization in user.get_orgs():
             user_has_delete_privs = True
 
         return timezone.now() < self.archive_timestamp and user_has_delete_privs

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -183,7 +183,7 @@
                         {% endif %}
                     {% endif %}
 
-                    {% if request.user.is_authenticated and request.user.pk == link.created_by_id and not link.vested %}
+                    {% if can_delete %}
                         <a class="btn btn-ui-small btn-dashboard user-delete" href="{% url 'user_delete_link' link.guid %}">Delete<span class="label-verbose"> record</span></a>
                     {% endif %}
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -137,6 +137,7 @@ def single_linky(request, guid):
     context = {
         'link': link,
         'can_view': link.can_view(request.user),
+        'can_delete': link.can_delete(request.user),
         'capture': capture,
         'next': request.get_full_path(),
         'serve_type': serve_type,


### PR DESCRIPTION
Users can delete a link if it hasn't been sent to the archive network. We're no longer filtering on the vesting flag for deletes.

fixes #1059