### PR TITLE
Tiny fix when checking for new record

### DIFF
--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -129,6 +129,7 @@ def single_linky(request, guid):
     else:
         capture = link.primary_capture
 
+    new_record = False
     if request.user.is_authenticated():
         # If a record is new (less than a minute old), let's assume
         # that the user just created it and we should show them a new record message


### PR DESCRIPTION
If a user wasn't authenticated and they were viewing a record, they might see an error pop up during our new record check logic.
fixed.