### PR TITLE
Add a note when a folder is empty

### DIFF
--- a/perma_web/perma/templates/user_management/created-links.html
+++ b/perma_web/perma/templates/user_management/created-links.html
@@ -181,6 +181,16 @@
 
         <a href="#" class="link-expand z-bottom">Show Record Details</a>
     </div>
+{{else}}
+    <div class="row link-row row-no-bleed">
+        <div class="row">
+            <div class="col col-sm-8">
+                <div class="link-title-display">
+                    <p>This is an empty folder</p>
+                </div>
+            </div>
+        </div>
+    </div>
 {{/each}}
 </script>
 {% endverbatim %}


### PR DESCRIPTION
Added a friendly note when the folder is empty, "This is an empty folder"

fixes #1086