### PR TITLE
Surfaced is_private attribute in API

### DIFF
--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -343,6 +343,7 @@ class AuthenticatedLinkResource(BaseLinkResource):
                                          readonly=True)
     # folders = fields.ToManyField(FolderResource, 'folders', readonly=True, null=True)
     archive_timestamp = fields.DateTimeField(attribute='archive_timestamp', readonly=True)
+    is_private = fields.BooleanField(attribute='is_private')
 
     class Meta(BaseLinkResource.Meta):
         authorization = AuthenticatedLinkAuthorization()

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -65,6 +65,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
             'created_by',
             'dark_archived_by',
             'archive_timestamp',
+            'is_private',
             'vested_by_editor',
         ]
 

--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -232,6 +232,9 @@
             <div class="row">
 	            <div class="col col-sm-8">
 	            	<div class="link-title-display">
+	            	{{#if is_private }}
+                            [private]
+                        {{/if}}
 		            	<span class="z-top">{{ title }}</span>
 	            	</div>
 	                <div class="record-url">

--- a/perma_web/static/js/create.js
+++ b/perma_web/static/js/create.js
@@ -113,7 +113,6 @@ $(function() {
                 });
                 obj.local_url = 'http://' + settings.HOST + '/' + obj.guid;
                 obj.creation_timestamp_formatted = new Date(obj.creation_timestamp).format("F j, Y");
-
                 if (Date.now() < Date.parse(obj.archive_timestamp)) {
                     obj.delete_available = true;
                 }


### PR DESCRIPTION
We needed the is_private value in the api response (we want to include an icon in the created links list to indicate to the user when a link is private)

fixes #1114