### PR TITLE
We were erroring out when checking if if non-auth users could delete.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -604,6 +604,9 @@ class Link(models.Model):
         """ An archive can be deleted if it is less than 24 hours old-style
             and it was created by a user or someone in the org """
 
+        if not user.is_authenticated():
+            return False
+
         user_has_delete_privs = False
 
         if user.is_staff or self.created_by == user or self.organization in user.get_orgs():


### PR DESCRIPTION
bug fixed.

This caused the record view screen to bomb. But, our tests didn't catch the issue. Yeowza!