### PR TITLE
Use whitenoise to deliver static assets

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -56,9 +56,9 @@ MONITOR_ROOT = '/tmp/perma/monitor'
 MONITOR_URL = '/monitor/media/'
 
 # static files
-STATIC_ROOT = ''                # where to store collected static files
+STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static-collected')                # where to store collected static files
 STATIC_URL = '/static/'         # URL to serve static files
-STATICFILES_DIRS = ('static',)  # where to look for static files (in addition to app/static/)
+STATICFILES_DIRS = (os.path.join(PROJECT_ROOT, 'static'),)  # where to look for static files (in addition to app/static/)
 STATICFILES_FINDERS = (         # how to look for static files
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -67,10 +67,10 @@ STATICFILES_FINDERS = (         # how to look for static files
 )
 
 # Django Pipeline config
-STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+STATICFILES_STORAGE = 'perma.storage_backends.StaticStorage'
 
 # media storage -- default_storage config
-DEFAULT_FILE_STORAGE = 'perma.storage_backends.FileSystemStorage'
+DEFAULT_FILE_STORAGE = 'perma.storage_backends.FileSystemMediaStorage'
 
 # We likely want to do something like this:
 # PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.jsmin.JSMinCompressor'

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -145,11 +145,5 @@ urlpatterns = patterns('perma.views',
 
 )
 
-# debug-only serving of static and media assets
-if settings.DEBUG:
-    from django.contrib.staticfiles.views import serve as static_view
-    urlpatterns += static(settings.STATIC_URL, static_view) + \
-                   static(getattr(settings, 'DEBUG_MEDIA_URL', settings.MEDIA_URL), debug_media_view, document_root=settings.MEDIA_ROOT)
-
 handler404 = 'perma.views.common.server_error_404'
 handler500 = 'perma.views.common.server_error_500'

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -1,10 +1,8 @@
-from django.conf import settings
-from django.conf.urls.static import static
 from django.conf.urls import patterns, url
 from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
 
-from .views.common import DirectTemplateView, debug_media_view
+from .views.common import DirectTemplateView
 
 
 guid_pattern = r'(?P<guid>[a-zA-Z0-9\-]+)'

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -223,15 +223,3 @@ Message from user
 
         context = RequestContext(request, {'form': form})
         return render_to_response('contact.html', context)
-
-
-def debug_media_view(request, *args, **kwargs):
-    """
-        Override Django's built-in dev-server view for serving media files,
-        in order to NOT set content-encoding for gzip files.
-        This stops the dev server from messing up delivery of archive.warc.gz files.
-    """
-    response = media_view(request, *args, **kwargs)
-    if response.get("Content-Encoding") == "gzip":
-        del response["Content-Encoding"]
-    return response

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -21,12 +21,13 @@ os.environ.setdefault("CELERY_LOADER", "django")
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
-
 from warc_server.app import application as warc_application
+from whitenoise.django import DjangoWhiteNoise
+
 
 application = DispatcherMiddleware(
-    get_wsgi_application(), # Django
+    DjangoWhiteNoise(get_wsgi_application()),  # Django app wrapped with whitenoise to serve static assets
     {
-        '/warc': warc_application,
+        '/warc': warc_application,  # pywb for record playback
     }
 )

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -25,8 +25,15 @@ from warc_server.app import application as warc_application
 from whitenoise.django import DjangoWhiteNoise
 
 
+# subclass WhiteNoise to add missing mime types
+class PermaWhiteNoise(DjangoWhiteNoise):
+    def __init__(self, *args, **kwargs):
+        self.EXTRA_MIMETYPES += (('image/svg+xml', '.svg'))
+        super(PermaWhiteNoise, self).__init__(*args, **kwargs)
+
+
 application = DispatcherMiddleware(
-    DjangoWhiteNoise(get_wsgi_application()),  # Django app wrapped with whitenoise to serve static assets
+    PermaWhiteNoise(get_wsgi_application()),  # Django app wrapped with whitenoise to serve static assets
     {
         '/warc': warc_application,  # pywb for record playback
     }

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -28,7 +28,7 @@ from whitenoise.django import DjangoWhiteNoise
 # subclass WhiteNoise to add missing mime types
 class PermaWhiteNoise(DjangoWhiteNoise):
     def __init__(self, *args, **kwargs):
-        self.EXTRA_MIMETYPES += (('image/svg+xml', '.svg'))
+        self.EXTRA_MIMETYPES += (('image/svg+xml', '.svg'),)
         super(PermaWhiteNoise, self).__init__(*args, **kwargs)
 
 

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -39,6 +39,7 @@ django-model-utils==2.2         # for tracking dirty models
 django-settings-context-processor==0.2 # make settings available in templates
 django-admin-smoke-tests==0.1.11    # basic tests for the Django admin
 Pillow==2.9.0                   # Used by the Django admin for ImageField display
+whitenoise==2.0.4               # serve static assets
 
 # deployment
 gunicorn==19.3.0

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -19,7 +19,7 @@ pexpect==3.1
 coverage==3.7.1
 selenium==2.47.3
 jsmin==2.0.9
-django-pipeline==1.5.3          # manages our css and js assets
+django-pipeline==1.5.4          # manages our css and js assets
 django-pipeline-compass==0.1.5  # lets us compile .scss to .css
 pyScss==1.3.4  					# dependency of d-p-compass. included here to avoid wonkiness found in older versions
 tempdir==0.6                    # create temp dirs to be deleted at end of function -- handy for archive creation

--- a/services/heroku/extra_requirements.txt
+++ b/services/heroku/extra_requirements.txt
@@ -7,5 +7,3 @@ newrelic==2.54.0.41
 rollbar==0.9.14
 cffi                        # This is a dependency of some of our packages. Heroku will detect it and install a previously-compiled version.
 
-# Overrides django-pipeline with a branch that fixes https://github.com/cyberdelia/django-pipeline/issues/473
--e git://github.com/skirsdeda/django-pipeline.git@fix473#egg=django-pipeline-heroku-fix

--- a/services/heroku/heroku_settings.py
+++ b/services/heroku/heroku_settings.py
@@ -43,10 +43,6 @@ else:
 # TODO: this is from Heroku's getting started with Django page -- is there a safer way?
 ALLOWED_HOSTS = ['*']
 
-STATICFILES_DIRS = (
-    os.path.join(PROJECT_ROOT, 'static'),
-)
-
 DEFAULT_FILE_STORAGE = 'perma.storage_backends.S3MediaStorage'
 
 # message passing
@@ -71,7 +67,6 @@ ADMINS = (
 
 # these are relative to the S3 bucket
 MEDIA_ROOT = '/generated/'
-STATIC_ROOT = '/static/'
 
 # AWS storage settings
 AWS_QUERYSTRING_AUTH = False
@@ -105,7 +100,6 @@ AWS_ACCESS_KEY_ID = ''
 AWS_SECRET_ACCESS_KEY = ''
 AWS_STORAGE_BUCKET_NAME = ''
 MEDIA_URL = 'http://BUCKET_NAME.s3.amazonaws.com/media/'
-STATIC_URL = 'http://BUCKET_NAME.s3.amazonaws.com/static/'
 
 
 ########## EMAIL CONFIGURATION

--- a/services/heroku/heroku_settings.py
+++ b/services/heroku/heroku_settings.py
@@ -47,8 +47,7 @@ STATICFILES_DIRS = (
     os.path.join(PROJECT_ROOT, 'static'),
 )
 
-DEFAULT_FILE_STORAGE = 'perma.storage_backends.MediaRootS3BotoStorage'
-STATICFILES_STORAGE = 'perma.storage_backends.StaticRootS3BotoStorage'
+DEFAULT_FILE_STORAGE = 'perma.storage_backends.S3MediaStorage'
 
 # message passing
 # settings via https://www.cloudamqp.com/docs/celery.html


### PR DESCRIPTION
This uses the WhiteNoise project for serving static assets, [which is recommended as a best practice by Heroku](https://devcenter.heroku.com/articles/django-assets). Static assets are now served by the same WSGI process that serves our Django app with no special handling needed, instead of a separate `/static` route in nginx or an S3 domain.

(We do still need to run collectstatic if DEBUG is off, as usual.)

On Heroku in particular, this is a win because the static assets end up bundled into the app slug. This way we don't have to re-run collectstatic when promoting a slug from perma-staging to prod.