### PR TITLE
Avoid deprecation warning.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -414,10 +414,10 @@ class LinkManager(models.Manager):
         return LinkQuerySet(self.model, using=self._db).filter(user_deleted=False)
 
     def all_with_deleted(self):
-        return super(LinkManager, self).get_query_set()
+        return super(LinkManager, self).get_queryset()
 
     def deleted_set(self):
-        return super(LinkManager, self).get_query_set().filter(user_deleted=True)
+        return super(LinkManager, self).get_queryset().filter(user_deleted=True)
 
     def user_access_filter(self, user):
         """


### PR DESCRIPTION
Use get_queryset instead of get_query_set to avoid that “RemovedInDjango18Warning: `BaseManager.get_query_set` is deprecated, use `get_queryset` instead.” warning we’ve been getting.