### PR TITLE
Capture and playback fixes.

### DIFF
--- a/perma_web/perma/templates/archive/iframe.html
+++ b/perma_web/perma/templates/archive/iframe.html
@@ -4,7 +4,7 @@
         <div><a href="{{ capture.playback_url }}" class="btn btn-primary">View/Download File</a></div>
     </div>
 {% else %}
-    <iframe src="{{ capture.playback_url }}" {% if capture.use_sandbox %}sandbox="allow-forms allow-scripts allow-top-navigation"{% endif %}>
+    <iframe src="{{ capture.playback_url }}" {% if capture.use_sandbox %}sandbox="allow-forms allow-scripts allow-top-navigation allow-same-origin"{% endif %}>
         <p>Unable to create a live view of <a class="submitted_url" href="{{link.submitted_url}}">{{link.submitted_url}}</a></p>
     </iframe>
 {% endif %}

--- a/perma_web/perma/tests/assets/target_capture_files/test.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>Test title.</title>
-        <link href="/favicon_meta.ico" rel="shortcut icon" type="image/x-icon">
+        <link Href="/favicon_meta.ico" rel="shortcuT icoN" type="image/x-icon">
     </head>
     <body>
         Test body.

--- a/perma_web/static/js/create.js
+++ b/perma_web/static/js/create.js
@@ -268,7 +268,7 @@ function check_status() {
         });
 
         // We're done checking status when nothing is pending.
-        if(capturesSucceeded || !capturesPending){
+        if(!capturesPending){
 
             // Clear out our pending jobs
             $.each(refreshIntervalIds, function(ndx, id) {


### PR DESCRIPTION
- Wait to forward user to success page until all captures have finished. Closes #1157
- Check for favicon tags is now case-insensitive (and our test now uses mixed case to make sure).
- Add "allow-same-origin" to sandbox. Drastically improves playbacks that depend on lots of JS includes.
- Speed up captures by about five seconds, by waiting only 1.5 seconds instead of 5 seconds for delayed post-load requests to start, and fetching favicons in a background thread.