### PR TITLE
Record page permissions and tests.

### DIFF
--- a/perma_web/api/tests/test_current_user_resource.py
+++ b/perma_web/api/tests/test_current_user_resource.py
@@ -30,8 +30,8 @@ class CurrentUserResourceTestCase(ApiResourceTestCase):
         self.successful_get(self.detail_url, user=self.vesting_member, fields=self.fields)
 
     def test_get_archives_json(self):
-        self.successful_get(self.detail_url + 'archives/', user=self.vesting_member, count=4)
-        self.successful_get(self.detail_url + 'archives/', user=self.regular_user, count=5)
+        self.successful_get(self.detail_url + 'archives/', user=self.vesting_member, count=6)
+        self.successful_get(self.detail_url + 'archives/', user=self.regular_user, count=7)
 
     def test_get_folders_json(self):
         self.successful_get(self.detail_url + 'folders/', user=self.vesting_member, count=1)

--- a/perma_web/fixtures/archive.json
+++ b/perma_web/fixtures/archive.json
@@ -107,10 +107,10 @@
             "vested": false,
             "vested_timestamp": null,
             "user_deleted": false,
+            "user_deleted_timestamp": null,
             "dark_archived_robots_txt_blocked": false,
             "created_by": 4,
             "dark_archived_by": null,
-            "user_deleted_timestamp": null,
             "dark_archived": false,
             "submitted_title": "Google",
             "submitted_url": "http://google.com",
@@ -141,6 +141,80 @@
             "creation_timestamp": "2014-07-19T20:21:31Z",
             "archive_timestamp": "2014-07-20T20:21:31Z",
             "organization": null
+        }
+    },
+    {
+        "pk": "ABCD-0001",
+        "model": "perma.link",
+        "fields": {
+            "folders": [
+                30,
+                34
+            ],
+            "view_count": 1,
+            "vested": false,
+            "vested_timestamp": null,
+            "notes": "Dark archived.",
+            "dark_archived_robots_txt_blocked": false,
+            "created_by": 4,
+            "dark_archived": true,
+            "dark_archived_by": 4,
+            "submitted_title": "Wikipedia",
+            "submitted_url": "https://www.wikipedia.org/",
+            "vested_by_editor": null,
+            "creation_timestamp": "2014-07-19T20:21:31Z",
+            "archive_timestamp": "2014-07-20T20:21:31Z",
+            "organization": 1
+        }
+    },
+    {
+        "pk": "ABCD-0002",
+        "model": "perma.link",
+        "fields": {
+            "folders": [
+                30,
+                34
+            ],
+            "view_count": 1,
+            "vested": false,
+            "vested_timestamp": null,
+            "notes": "Dark archived - robots.txt.",
+            "dark_archived_robots_txt_blocked": true,
+            "created_by": 4,
+            "dark_archived": false,
+            "dark_archived_by": 4,
+            "submitted_title": "Wikipedia",
+            "submitted_url": "https://www.wikipedia.org/",
+            "vested_by_editor": null,
+            "creation_timestamp": "2014-07-19T20:21:31Z",
+            "archive_timestamp": "2014-07-20T20:21:31Z",
+            "organization": 1
+        }
+    },
+    {
+        "pk": "ABCD-0003",
+        "model": "perma.link",
+        "fields": {
+            "folders": [
+                30,
+                34
+            ],
+            "view_count": 1,
+            "vested": false,
+            "vested_timestamp": null,
+            "notes": "",
+            "dark_archived_robots_txt_blocked": false,
+            "created_by": 4,
+            "dark_archived": false,
+            "dark_archived_by": null,
+            "user_deleted": true,
+            "user_deleted_timestamp": "2014-07-19T20:22:31Z",
+            "submitted_title": "Wikipedia",
+            "submitted_url": "https://www.wikipedia.org/",
+            "vested_by_editor": null,
+            "creation_timestamp": "2014-07-19T20:21:31Z",
+            "archive_timestamp": "2014-07-20T20:21:31Z",
+            "organization": 1
         }
     },
   {
@@ -233,5 +307,44 @@
     },
     "model": "perma.capture",
     "pk": 7
+  },
+  {
+    "fields": {
+      "status": "success",
+      "url": "file:///ABCD-0001/cap.png",
+      "user_upload": false,
+      "record_type": "resource",
+      "role": "screenshot",
+      "content_type": "image/png",
+      "link": "ABCD-0001"
+    },
+    "model": "perma.capture",
+    "pk": 8
+  },
+  {
+    "fields": {
+      "status": "success",
+      "url": "file:///ABCD-0002/cap.png",
+      "user_upload": false,
+      "record_type": "resource",
+      "role": "screenshot",
+      "content_type": "image/png",
+      "link": "ABCD-0002"
+    },
+    "model": "perma.capture",
+    "pk": 9
+  },
+  {
+    "fields": {
+      "status": "success",
+      "url": "file:///ABCD-0003/cap.png",
+      "user_upload": false,
+      "record_type": "resource",
+      "role": "screenshot",
+      "content_type": "image/png",
+      "link": "ABCD-0003"
+    },
+    "model": "perma.capture",
+    "pk": 10
   }
 ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -585,13 +585,16 @@ class Link(models.Model):
             a user can view their own dark archived links.
         """
 
-        if not self.dark_archived:
+        if not self.dark_archived and not self.dark_archived_robots_txt_blocked:
             return True
+
+        if user.is_anonymous():
+            return False
 
         if self.created_by == user:
             return True
 
-        if self.organization in user.get_orgs:
+        if self.organization in user.get_orgs():
             return True
 
         return False

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -204,7 +204,7 @@
             </div>
         </div>
 		
-		{% if can_view and link.dark_archived %}
+		{% if can_view and link|is_darchive %}
 	        <div class="banner banner-status row _isDarchive">
 		        <strong>This record is in the Dark Archive.</strong> It’s only visible to libraries and your Archiving Organization.
 	        </div>

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -8,11 +8,46 @@ from .utils import PermaTestCase
 
 class CommonViewsTestCase(PermaTestCase):
 
+    def setUp(self):
+        self.users = ['test_user@example.com', 'test_org_user@example.com', 'test_registrar_member@example.com', 'test_registry_member@example.com']
+
     def test_public_views(self):
         # test static template views
         for urlpattern in urlpatterns:
             if urlpattern.callback.func_name == 'DirectTemplateView':
                 resp = self.get(urlpattern.name)
+
+    # Record page
+
+    def assert_can_view_capture(self, guid):
+        response = self.get('single_linky', reverse_kwargs={'kwargs':{'guid': guid}})
+        self.assertIn("<iframe ", response.content)
+
+    def test_regular_archive(self):
+        self.assert_can_view_capture('7CF8-SS4G')
+        for user in self.users:
+            self.log_in_user(user)
+            self.assert_can_view_capture('7CF8-SS4G')
+
+    def test_dark_archive(self):
+        response = self.get('single_linky', reverse_kwargs={'kwargs':{'guid': 'ABCD-0001'}})
+        self.assertIn("Dark Archive and cannot be displayed.", response.content)
+        for user in self.users:
+            self.log_in_user(user)
+            response = self.get('single_linky', reverse_kwargs={'kwargs': {'guid': 'ABCD-0001'}})
+            self.assertIn("only visible to libraries and your Archiving Organization.", response.content)
+
+    def test_dark_archive_robots_txt_blocked(self):
+        response = self.get('single_linky', reverse_kwargs={'kwargs': {'guid': 'ABCD-0002'}})
+        self.assertIn("Dark Archive and cannot be displayed.", response.content)
+        for user in self.users:
+            self.log_in_user(user)
+            response = self.get('single_linky', reverse_kwargs={'kwargs': {'guid': 'ABCD-0002'}})
+            self.assertIn("only visible to libraries and your Archiving Organization.", response.content)
+
+    def test_deleted(self):
+        response = self.get('single_linky', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}})
+        self.assertIn("This record has been deleted.", response.content)
 
     def test_misformatted_nonexistent_links_404(self):
         response = self.client.get(reverse('single_linky', kwargs={'guid': 'JJ99--JJJJ'}))
@@ -28,6 +63,8 @@ class CommonViewsTestCase(PermaTestCase):
         # Test the original ID style. We shouldn't get a redirect.
         response = self.client.get(reverse('single_linky', kwargs={'guid': '0J6pkzDeQwT'}))
         self.assertEqual(response.status_code, 404)
+
+    # Misc
 
     def test_contact(self):
         # Does our contact form behave reasonably?

--- a/perma_web/perma/tests/utils.py
+++ b/perma_web/perma/tests/utils.py
@@ -10,13 +10,6 @@ class PermaTestCase(TransactionTestCase):
                 'fixtures/folders.json',
                 'fixtures/archive.json']
 
-    def setUp(self):
-        # create test registrar and an org
-        # TODO: move these to fixtures
-        registrar = Registrar(name='Test Registrar', email='registrar@test.com', website='http://testregistrar.com')
-        registrar.save()
-        Organization(name='Test Org', registrar=registrar).save()
-
     def log_in_user(self, username, password='pass'):
         # TODO: check resp to see if login actually worked
         self.client.logout()


### PR DESCRIPTION
- Add unit tests for the record page -- logged out and logged in, normal, dark archived, deleted.
- Fix 500 error for dark archived pages.
- Fix permissions checks to include dark_archived_robots_txt_blocked (although really we want to change to a `visible` flag and maybe a `visibility_reason` choicefield, right?)