### PR TITLE
More efficient playbacks.

### DIFF
--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -40,6 +40,7 @@ django-settings-context-processor==0.2 # make settings available in templates
 django-admin-smoke-tests==0.1.11    # basic tests for the Django admin
 Pillow==2.9.0                   # Used by the Django admin for ImageField display
 whitenoise==2.0.4               # serve static assets
+-e git://github.com/smartfile/django-mysqlpool.git@2b5709116e03bd9331ee304350141f210cd285de#egg=django-mysqlpool
 
 # deployment
 gunicorn==19.3.0

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -40,7 +40,6 @@ django-settings-context-processor==0.2 # make settings available in templates
 django-admin-smoke-tests==0.1.11    # basic tests for the Django admin
 Pillow==2.9.0                   # Used by the Django admin for ImageField display
 whitenoise==2.0.4               # serve static assets
--e git://github.com/smartfile/django-mysqlpool.git@2b5709116e03bd9331ee304350141f210cd285de#egg=django-mysqlpool
 
 # deployment
 gunicorn==19.3.0


### PR DESCRIPTION
- Cache CDX lookups so we don't have to hit the database for each sub-resource when playing back a page.
- Close Django database connections in pywb playbacks (since they're outside a request and don't close manually).

This should fix instability we've been having on stage caused by exceeding max_user_connections.