### PR TITLE
Improve playbacks.

### DIFF
--- a/perma_web/perma/templates/single-link.html
+++ b/perma_web/perma/templates/single-link.html
@@ -197,7 +197,7 @@
                                 <div><a href="{{ capture.playback_url }}" class="btn btn-primary">View/Download File</a></div>
                             </div>
                         {% else %}
-                            <iframe src="{{ capture.playback_url }}" {% if capture.use_sandbox %}sandbox="allow-forms allow-scripts allow-top-navigation"{% endif %}>
+                            <iframe src="{{ capture.playback_url }}" {% if capture.use_sandbox %}sandbox="allow-forms allow-scripts allow-top-navigation allow-same-origin"{% endif %}>
                                 <p>Unable to create a live view of <a class="submitted_url" href="{{link.submitted_url}}">{{link.submitted_url}}</a></p>
                             </iframe>
                         {% endif %}

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -46,7 +46,7 @@ gevent==1.0.2
 
 # PyWB-related stuff
 surt==0.2                       # our simple CDX server to canonicalize URL
-pywb==0.10.6
+pywb==0.10.9.1
 -e git://github.com/internetarchive/warcprox.git@67f2ceb717c158771a18e040e062f7aff20e95dd#egg=warcprox  # use 7/17/15 version of warcprox, which has SNI support not yet in warcprox==1.4
 
 # alternate storages

--- a/perma_web/static/pywb/wb.js
+++ b/perma_web/static/pywb/wb.js
@@ -136,6 +136,7 @@ this.load = function() {
 
     window._wb_js_inited = true;
 
+    // Non-Framed Replay OR top frame for framed replay!
     if (window.wbinfo && (!window.__WB_top_frame || window.__WB_top_frame == window)) {
         if (wbinfo.is_framed && wbinfo.mod != "bn_") {
             var hash = window.location.hash;
@@ -154,6 +155,7 @@ this.load = function() {
         // Init Banner (no frame or top frame)
         add_event("readystatechange", init_banner, document);
 
+    // Framed Replay
     } else if (window.__WB_top_frame && window != window.__WB_top_frame && window.__WB_top_frame.update_wb_url) {
         add_event("readystatechange", notify_top, document);
     }

--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -247,13 +247,13 @@ class PermaCDXSource(CDXSource):
         # When a GUID is in the url, we'll have already queried for the lines
         # in order to grab the timestamp for Memento-Datetime header
         if query.params.get('lines'):
-            return query.params.get('lines').values_list('raw', flat=True)
+            return [str(i) for i in query.params.get('lines').values_list('raw', flat=True)]
 
         filters = {'urlkey': query.key}
         if query.params.get('guid'):
             filters['link_id'] = query.params.get('guid')
 
-        return CDXLine.objects.filter(**filters).values_list('raw', flat=True)
+        return [str(i) for i in CDXLine.objects.filter(**filters).values_list('raw', flat=True)]
 
 
 class CachedLoader(BlockLoader):


### PR DESCRIPTION
Fixes a few issues with playbacks:

- allow-same-origin allows many page resources to load.
- return strings instead of unicode() from our CDX server so pywb doesn't choke on unicode urls.
- upgrade to latest pywb JS includes for better document.write support.
- patch pywb JS include to work with iframe and outside frame on different domains.