### PR TITLE
Partner display improvements.

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -25,11 +25,11 @@ class LinkInline(admin.TabularInline):
 
 class RegistrarAdmin(admin.ModelAdmin):
     search_fields = ['name', 'email', 'website']
-    list_display = ['name', 'email', 'website', 'show_partner_status', 'partner_display_name', 'logo', 'vested_links', 'registrar_users', 'last_active', 'orgs_count']
-    list_editable = ['show_partner_status', 'partner_display_name']
+    list_display = ['name', 'email', 'website', 'show_partner_status', 'partner_display_name', 'logo', 'latitude', 'longitude', 'vested_links', 'registrar_users', 'last_active', 'orgs_count']
+    list_editable = ['show_partner_status', 'partner_display_name', 'latitude', 'longitude']
     fieldsets = (
         (None, {'fields': ('name', 'email', 'website', 'default_organization', 'is_approved')}),
-        ("Partner Display", {'fields': ('show_partner_status', 'partner_display_name', 'logo')}),
+        ("Partner Display", {'fields': ('show_partner_status', 'partner_display_name', 'logo', 'latitude', 'longitude')}),
     )
     inlines = [
         new_class("OrganizationInline", InlineEditLinkMixin, admin.TabularInline, model=Organization,

--- a/perma_web/perma/migrations/0023_auto_20151021_1840.py
+++ b/perma_web/perma/migrations/0023_auto_20151021_1840.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perma', '0022_link_archive_timestamp'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='registrar',
+            name='latitude',
+            field=models.FloatField(null=True, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='registrar',
+            name='longitude',
+            field=models.FloatField(null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -47,6 +47,8 @@ class Registrar(models.Model):
     show_partner_status = models.BooleanField(default=False, help_text="Whether to show this registrar in our list of partners.")
     partner_display_name = models.CharField(max_length=400, blank=True, null=True, help_text="Optional. Use this to override 'name' for the partner list.")
     logo = models.ImageField(upload_to='registrar_logos', blank=True, null=True)
+    latitude = models.FloatField(blank=True, null=True)
+    longitude = models.FloatField(blank=True, null=True)
 
     tracker = FieldTracker()
 

--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -73,7 +73,7 @@ Perma.cc prevents link rot.
 			</div><!--col-sm-6-->
 			<div class="col-sm-6 _image">
         		<div class="content">
-					<div id="plot-map-container"></div>
+					{% include "includes/partner_map.html" %}
 					<div class="caption">
 						<p>Perma.cc is used and supported by libraries and institutions across America.</p>
 					</div>

--- a/perma_web/perma/templates/includes/participating_institutions.html
+++ b/perma_web/perma/templates/includes/participating_institutions.html
@@ -1,124 +1,28 @@
-<div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
-    <div class="carousel-inner">
-        <div class="item active">
-            <a href="http://www.wcl.american.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/AU-WCL-bw.png" alt="American University Washington University Law Library"></a>
-            <a href="http://www.bu.edu/lawlibrary/"><img src="{{ STATIC_URL }}img/participating-institutions/BU-bw.png" alt="Boston University Law School"></a>
-            <a href="https://www.law.upenn.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/Biddle-bw.png" alt="Biddle Law Library, University of Pennsylvania"></a>
-            <a href="http://www.charlestonlaw.edu/Library.aspx"><img src="{{ STATIC_URL }}img/participating-institutions/Charleston-bw.png" alt="Charleston School of Law"></a>
-            <a href="http://lawlibrary.colorado.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/Colorado-bw.png" alt="Colorado Law"></a>
-            <a href="http://web.law.columbia.edu/library"><img src="{{ STATIC_URL }}img/participating-institutions/Columbia-bw.png" alt="Columbia Law School"></a>
-            <a href="http://www.lawschool.cornell.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/Cornell-bw.png" alt="Cornell University Law School"></a>
-            <a href="http://law.duke.edu/lib/"><img src="{{ STATIC_URL }}img/participating-institutions/Duke-bw.png" alt="Duke Law School"></a>
-            <a href="http://www.law.ttu.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/tt-bw.png" alt="Texas Tech University School of Law"></a>
-        </div>
-        <div class="item">
-            <a href="http://www.bc.edu/schools/law/library.html" class="square"><img src="{{ STATIC_URL }}img/participating-institutions/BC-bw.png" alt="Law Library At Boston College"></a>
-            <a href="http://www.law.fsu.edu/library/" class="square"><img src="{{ STATIC_URL }}img/participating-institutions/FSU-bw.png" alt="Florida State Law Research Center"></a>
-            <a href="http://www.valpo.edu/law/current-students/law-library" class="square"><img src="{{ STATIC_URL }}img/participating-institutions/valparaiso-bw.png" alt="Valparaiso University School of Law Library"></a>
-            <a href="http://library.law.yale.edu/" class="square"><img src="{{ STATIC_URL }}img/participating-institutions/YLS-bw.png" alt="Yale Law Library"></a>
-            <a href="http://www.bodleian.ox.ac.uk/law" class="square"><img src="{{ STATIC_URL }}img/participating-institutions/Oxford-bw.png" alt="University of Oxford"></a>
-            <a href="http://mckinneylaw.iu.edu/library/" class="square"><img src="{{ STATIC_URL }}img/participating-institutions/Indiana-bw.png" alt="Robert H. McKinney School of Law, Indiana University"></a>
-        </div>
-        <div class="item">
-            <a href="http://www.law.ufl.edu/library"><img src="{{ STATIC_URL }}img/participating-institutions/Florida-bw.png" alt="University of Florida Levin College of Law"></a>
-            <a href="http://lawlib1.lawnet.fordham.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/Fordham-bw.png" alt="Fordham law school"></a>
-            <a href="http://www.law.georgetown.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/Georgetown-bw.png" alt="Georgetown law library"></a>
-            <a href="http://www.law.harvard.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/HLS-bw.png" alt="Harvard Law School Library"></a>
-            <a href="http://library.jmls.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/Jmls-bw.png" alt="John Marshall Law School"></a>
-            <a href="http://lawlibrary.laverne.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/LaVerne-bw.png" alt="College of Law Library, University of La Verne"></a>
-            <a href="http://lawlib.lclark.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/LC-bw.png" alt="Paul L. Boley Law Library, Lewis &amp; Clark Law School"></a>
+{% load carousel cache thumbnail %}
+{% cache 3600 carousel %}
+    {% set_carousel_partners %} {# sets carousel_logo_groups #}
+    <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
+        <div class="carousel-inner">
+            {% for logo_group in carousel_logo_groups %}
+                <div class="item{% if forloop.first %} active{% endif %}">
+                    {% for partner in logo_group %}
+                        <a href="{{ partner.website }}" class="{{ partner.logo_class }}">
+                            {% thumbnail partner.logo partner.thumbnail_geometry upscale=False quality=60 as logo %}
+                                <img src="{{ logo.url }}" alt="{{ partner.partner_display_name|default:partner.name }}">
+                            {% endthumbnail %}
+                        </a>
+                    {% endfor %}
+                </div>
+            {% endfor %}
         </div>
 
-        <div class="item">
-            <a href="http://www1.law.lsu.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/LSU-bw.png" alt="Lousiana State University Law School Library"></a>
-            <a href="http://www.luc.edu/law/library/"><img src="{{ STATIC_URL }}img/participating-institutions/Loyola-bw.png" alt="Loyola University School of Law"></a>
-            <a href="http://www.law.umaryland.edu/marshall/"><img src="{{ STATIC_URL }}img/participating-institutions/Maryland-bw.png" alt="University of Maryland Francis King Carey School of Law"></a>
-            <a href="http://www.law.unimelb.edu.au/lawlib"><img src="{{ STATIC_URL }}img/participating-institutions/Melbourne-bw.png" alt="Melbourne Law School Library, The University of Melbourne"></a>
-            <a href="http://www.law.miami.edu/library"><img src="{{ STATIC_URL }}img/participating-institutions/Miami-bw.png" alt="University of Miami School of Law"></a>
-            <a href="http://law.unl.edu/library"><img src="{{ STATIC_URL }}img/participating-institutions/Nebraska-bw.png" alt="University of Nebraska College of Law"></a>
-            <a href="http://www.law.northwestern.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/northwestern-bw.png" alt="Northwestern Law"></a>
-            <a href="http://moritzlaw.osu.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/Ohio-State-bw.png" alt="Ohio State University"></a>
-            <a href="http://law.pepperdine.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/Pepperdine-bw.png" alt="Pepperdine University Law School"></a>
-        </div>
+        <a class="left carousel-control" href="#carousel-example-generic" data-slide="prev"><span class="ui-chev-left"></span></a>
+        <a class="right carousel-control" href="#carousel-example-generic" data-slide="next"><span class="ui-chev-right"></span></a>
 
-        <div class="item">
-            <a href="http://law.richmond.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/richmond-bw.png" alt="Richmond School of Law"></a>
-            <a href="http://www.law.stanford.edu/organizations/offices/robert-crown-law-library"><img src="{{ STATIC_URL }}img/participating-institutions/Stanford-bw.png" alt="Stanford Law Library"></a>
-            <a href="http://www.law.ucla.edu/library/Pages/default.aspx"><img src="{{ STATIC_URL }}img/participating-institutions/UCLA-bw.png" alt="UCLA Law Library"></a>
-            <a href="http://library.law.olemiss.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/UMiss-bw.png" alt="University of Mississippi School of Law"></a>
-            <a href="http://www.law.unlv.edu/law-library/home.html"><img src="{{ STATIC_URL }}img/participating-institutions/UNLV-bw.png" alt="University of Nevada, Las Vegas, School of Law"></a>
-            <a href="http://www.sandiego.edu/law/library/"><img src="{{ STATIC_URL }}img/participating-institutions/SanDiego-bw.png" alt="Pardee Legal Research Center, University of San Diego "></a>
-            <a href="http://tarlton.law.utexas.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/UT-Austin-bw.png" alt="University of Texas, Austin, Law School"></a>
-            <a href="http://www.law.utah.edu/library//"><img src="{{ STATIC_URL }}img/participating-institutions/U-Utah-bw.png" alt="S.J. Quinney Law Library, University of Utah"></a>
-            <a href="http://www.library.vanderbilt.edu/law/"><img src="{{ STATIC_URL }}img/participating-institutions/Vanderbilt-bw.png" alt="Vanderbilt Law School"></a>
-            <a href="http://library.law.uiowa.edu"><img src="{{ STATIC_URL }}img/participating-institutions/ui-bw.png" alt="University of Iowa College of Law"></a>
-            <a href="http://www.law.pace.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/pace-bw.png" alt="Pace Law School"></a>
-        </div>
-
-        <div class="item">
-            <a href="http://courts.mi.gov/courts/michigansupremecourt/about-supreme-court/pages/directory-of-offices-and-programs.aspx"><img src="{{ STATIC_URL }}img/participating-institutions/michigan-courts-bw.png" alt="Michigan Reporter of Decisions, Michigan Supreme Court"></a>
-            <a href="http://law.indiana.edu/lawlibrary/index.shtml"><img src="{{ STATIC_URL }}img/participating-institutions/Indiana-Bloomington-bw.png" alt="Law Library, Indiana University Bloomington, Maurer School of Law"></a>
-            <a href="http://library.law.tulane.edu/screens/index.html"><img src="{{ STATIC_URL }}img/participating-institutions/tulane-bw.png" alt="Tulane Law Library, Tulane University Law School"></a>
-            <a href="http://www.law.uga.edu/library"><img src="{{ STATIC_URL }}img/participating-institutions/georgia-bw.png" alt="Alexander Campbell King Law Library, University of Georgia School of Law"></a>
-            <a href="http://www.stu.edu/law/AlexHannaLibrary/tabid/668/Default.aspx"><img src="{{ STATIC_URL }}img/participating-institutions/st-thomas-bw.png" alt="Alex A. Hanna Law Library, St. Thomas University School of Law"></a>
-            <a href="http://law.shu.edu/library/index-media.cfm"><img src="{{ STATIC_URL }}img/participating-institutions/seton-bw.png" alt="The Peter Rodino Law Library, Seton Hall Law School"></a>
-            <a href="http://www.brooklaw.edu/en/intellectuallife/library.aspx"><img src="{{ STATIC_URL }}img/participating-institutions/brooklyn-bw.png" alt="Brooklyn Law School Library"></a>
-            <a href="http://law.ggu.edu/law-library"><img src="{{ STATIC_URL }}img/participating-institutions/ggu-bw.png" alt="Golden Gate University Law Library"></a>
-            <a href="http://www.law.msu.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/michigan-state-bw.png" alt="John F. Schaefer Law Library, Michigan State University College of Law"></a>
-            <a href="http://www.law.uci.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/uci-bw.png" alt="University of California, Irvine School of Law"></a>
-        </div>
-
-        <div class="item">
-            <a href="http://www.law.virginia.edu/html/librarysite/library.htm"><img src="{{ STATIC_URL }}img/participating-institutions/uvalaw-bw.png" alt="University of Virginia School of Law"></a>
-            <a href="http://www.law.washington.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/U-Washington-bw.png" alt="University of Washington School of Law"></a>
-            <a href="http://law.wustl.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/WashU-bw.png" alt="Washington University Law"></a>
-            <a href="http://law.wm.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/William-Mary-bw.png" alt="William & Mary Law School"></a>
-            <a href="http://library.law.wisc.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/UWisc-bw.png" alt="University of Wisconsin Law Library"></a>
-            <a href="http://library.law.unc.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/unc-bw.png" alt="Kathrine R. Everett Law Library, University of North Carolina"></a>
-            <a href="http://law.widener.edu/lawlibrary.aspx"><img src="{{ STATIC_URL }}img/participating-institutions/widener-univ-bw.png" alt="Widener University School of Law"></a>
-            <a href="http://library.law.smu.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/smu-bw.png" alt="SMU Dedman School of Law"></a>
-            <a href="http://law.marquette.edu/law-library/eckstein-law-library/"><img src="{{ STATIC_URL }}img/participating-institutions/marquette-bw.png" alt="Ray & Kay Eckstein Law Library, Marquette University"></a>
-        </div>
-
-        <div class="item">
-            <a href="http://www.law.berkeley.edu/library.htm"><img src="{{ STATIC_URL }}img/participating-institutions/berkeleylaw_library2-bw.png" alt="Berkeley Law Library"></a>
-            <a href="http://law.wvu.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/wvu-logo-bw.png" alt="George R. Farmer Jr. Law Library"></a>
-            <a href="http://law.okcu.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/ocu_main_logonew_bw.png" alt="OKCU Law School"></a>
-            <a href="http://www.cst.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/CST_logo_bw.png" alt="Claremont School of Theology Library"></a>
-            <a href="http://library.princeton.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/pu_logo_trans_bw.png"></a>
-            <a href="http://www.vermontlaw.edu/academics/library"><img src="{{ STATIC_URL }}img/participating-institutions/vt_bw.png"></a>
-            <a href="http://www.kentlaw.iit.edu/library/"><img src="{{ STATIC_URL }}img/participating-institutions/ck_logo_bw.png"></a>
-            <a href="http://www.law.cuny.edu/library.html"><img src="{{ STATIC_URL }}img/participating-institutions/cuny_law_bw.png"></a>
-            <a href="http://www.suffolk.edu/law/library.php"><img src="{{ STATIC_URL }}img/participating-institutions/suffolk-law-lib.png"></a>
-        </div>
-
-        <div class="item">
-            <a href="http://law.pitt.edu/library"><img src="{{ STATIC_URL }}img/participating-institutions/pitt_law_bw.png" alt="Pitt Law Library" /></a>
-            <a href="http://law.utk.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/utenn_law_bw.png" alt="Univerisity of Tennessee at Knoxville" /></a>
-            <a href="http://law.slu.edu/library" /><img src="{{ STATIC_URL }}img/participating-institutions/slu_law_bw.png" alt="Saint Louis University Law Library" /></a>
-            <a href="http://www.willamette.edu/wucl/longlib/index.html"><img src="{{ STATIC_URL }}img/participating-institutions/williamette_bw.png" alt="Willamette University College of Law"></a>
-            <a href="http://fletcher.tufts.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/fletcher_bw.png" alt="Fletcher School"></a>
-            <a href="http://www.lls.edu/"><img src="{{ STATIC_URL }}img/participating-institutions/loyolalaw_bw.png" alt="Loyola Law School, LA"></a>
-            <a href="http://www.belmont.edu/law/"><img src="{{ STATIC_URL}}img/participating-institutions/belmont-logo-bw.png" alt="Belmont University College of Law"></a>
-            <a href="http://www.law.seattleu.edu/"><img src="{{ STATIC_URL}}img/participating-institutions/seattle-bw.png" alt="Seattle University School of Law"></a>
-            <a href="http://www.usd.edu/law/law-library"><img src="{{ STATIC_URL}}img/participating-institutions/sd-bw.png" alt="University of South Dakota School of Law, Law Library"></a>
-            <a href="http://www1.villanova.edu/content/villanova/law/library.html"><img src="{{ STATIC_URL}}img/participating-institutions/villanova-bw.png" alt="Villanova Unversity School of Law, Library"></a>
-        </div>
-        
-    </div>
-
-    <a class="left carousel-control" href="#carousel-example-generic" data-slide="prev"><span class="ui-chev-left"></span></a>
-    <a class="right carousel-control" href="#carousel-example-generic" data-slide="next"><span class="ui-chev-right"></span></a>
-
-    <ol class="carousel-indicators">
-        <li data-target="#carousel-example-generic" data-slide-to="0" class="active"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="1"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="2"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="3"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="4"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="5"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="6"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="7"></li>
-        <li data-target="#carousel-example-generic" data-slide-to="8"></li>
-    </ol>
-</div><!--carousel slide-->
+        <ol class="carousel-indicators">
+            {% for logo_group in carousel_logo_groups %}
+                <li data-target="#carousel-example-generic" data-slide-to="{{ forloop.counter0 }}" {% if forloop.first %}class="active"{% endif %}></li>
+            {% endfor %}
+        </ol>
+    </div><!--carousel slide-->
+{% endcache %}

--- a/perma_web/perma/templates/includes/partner_map.html
+++ b/perma_web/perma/templates/includes/partner_map.html
@@ -1,0 +1,10 @@
+<div id="plot-map-container"></div>
+<script>
+    var partnerPoints = [
+        {% for partner in partners %}
+            {% if partner.latitude and partner.longitude %}
+                [{{ partner.latitude }}, {{ partner.longitude }}, "{{ partner.partner_display_name|default:partner.name }}"]{% if not forloop.last %},{% endif %}
+            {% endif %}
+        {% endfor %}
+    ]
+</script>

--- a/perma_web/perma/templates/landing.html
+++ b/perma_web/perma/templates/landing.html
@@ -68,7 +68,7 @@
 				</div><!--col-sm-6-->
 				<div class="col-sm-6 _image">
 	        		<div class="content">
-						<div id="plot-map-container"></div>
+					    {% include "includes/partner_map.html" %}
 						<div class="caption">
 							<p>Perma.cc is used and supported by libraries and institutions across America.</p>
 						</div>

--- a/perma_web/perma/templatetags/carousel.py
+++ b/perma_web/perma/templatetags/carousel.py
@@ -1,0 +1,62 @@
+import logging
+from django import template
+
+logger = logging.getLogger(__name__)
+register = template.Library()
+
+
+from perma.models import Registrar
+
+@register.simple_tag(takes_context=True)
+def set_carousel_partners(context):
+    """
+        Here we check out the width and height dimensions for all our partner logos, and group them into lines
+        to show in the carousel.
+
+        We keep one line going for long-thin logos and another line going for squarish logos, and whenever
+        a line gets long enough we add it to the list of logo_groups and start a new one.
+    """
+
+    partners = context.get('partners') or Registrar.objects.filter(show_partner_status=True).exclude(logo=None)
+    wide_logo_line = []
+    wide_logo_line_width = 0
+    narrow_logo_line = []
+    narrow_logo_line_width = 0
+    logo_groups = [wide_logo_line, narrow_logo_line]
+
+    for partner in partners:
+        if not partner.logo:
+            continue
+        try:
+            proportion = float(partner.logo.width) / partner.logo.height
+        except:
+            # Can't read width/height for this image for some reason -- probably messed up file. Just skip it.
+            continue
+
+        # logo is wider than it is tall
+        if proportion > 1.5:
+            # with long-thin logos, we start a new line when the current one is 50 times as wide as tall
+            if wide_logo_line_width + proportion > 50:
+                wide_logo_line = []
+                logo_groups.append(wide_logo_line)
+                wide_logo_line_width = 0
+            wide_logo_line.append(partner)
+            wide_logo_line_width += proportion
+            partner.logo_class = ""
+            partner.thumbnail_geometry = "x50"
+
+        # logo is taller than it is wide
+        else:
+            # with squarish logos, we start a new line when the current one is eight times as wide as tall
+            if narrow_logo_line_width + proportion > 8:
+                narrow_logo_line = []
+                logo_groups.append(narrow_logo_line)
+                narrow_logo_line_width = 0
+            narrow_logo_line.append(partner)
+            narrow_logo_line_width += proportion
+            partner.logo_class = "square"
+            partner.thumbnail_geometry = "x130"
+
+    context['carousel_logo_groups'] = logo_groups
+
+    return ""

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.conf.urls import patterns, url
+from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
 
@@ -142,6 +144,10 @@ urlpatterns = patterns('perma.views',
     url(r'^%s/?$' % r'(?P<guid>[^\./]+)', 'common.single_linky', name='single_linky'),
 
 )
+
+# debug-only serving of media assets
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 handler404 = 'perma.views.common.server_error_404'
 handler500 = 'perma.views.common.server_error_500'

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -58,7 +58,10 @@ def landing(request):
         return HttpResponseRedirect(reverse('create_link'))
         
     else:
-        return render(request, 'landing.html', {'this_page': 'landing'})
+        return render(request, 'landing.html', {
+            'this_page': 'landing',
+            'partners': Registrar.objects.filter(show_partner_status=True),
+        })
 
 def about(request):
     """

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -206,6 +206,10 @@ body.modal-open {
     margin-bottom: 10px;
 	display: inline;
 	list-style-type: none;
+
+	-webkit-filter: grayscale(100%);
+	filter: gray;
+	filter: grayscale(100%);
 }
 
 

--- a/perma_web/static/js/map.js
+++ b/perma_web/static/js/map.js
@@ -13,67 +13,9 @@ $(function(){
     resizePaper();
 
     // plot points
-    var points = [
-        [38.944794, -77.095004, "Pence Law Library, Washington College of Law, American University"],
-        [42.341822, -71.195736, "Law Library at Boston College, Boston College of Law"],
-        [38.944794, -77.095004, "Pence Law Library, Washington College of Law, American University"],
-        [42.350527, -71.109665, "Pappas Law Library, Boston University School of Law"],
-        [39.953772, -75.193314, "Biddle Law Library, University of Pennsylvania Law School"],
-        [32.790682, -79.938873, "Charleston School of Law Library"],
-        [40.000906, -105.262076, "William A. Wise Law Library, Colorado Law"],
-        [40.806948, -73.960331, "Arthur W. Diamond Law Library, Columbia Law School"],
-        [42.443868, -76.485849, "Cornell University Law School"],
-        [42.349480, -71.077708, "Digital Public Library of America"],
-        [35.999711, -78.944995, "J. Michael Goodson Law Library, Duke University School of Law"],
-        [30.439591, -84.286414, "Florida State Law Research Center, Florida State University College of Law"],
-        [29.650052, -82.359510, "University of Florida Levin College of Law"],
-        [40.771128, -73.984648, "The Leo T. Kissam Memorial Library, Fordham University School of Law"],
-        [38.898086, -77.012985, "Georgetown Law Library, Georgetown Law"],
-        [42.379400, -71.119587, "Harvard Law School Library"],
-        [39.772174, -86.167720, "Ruth Lilly Law Library, Robert H. McKinney School of Law, Indiana University"],
-        [41.877710, -87.628618, "Louis L. Biro Law Library, The John Marshall Law School"],
-        [41.699725, -86.238208, "Kresge Law Library, University of Notre Dame The Law School"],
-        [34.066263, -117.647682, "College of Law Library, University of La Verne"],
-        [45.452229, -122.677615, "Paul L. Boley Law Library, Lewis & Clark Law School"],
-        [30.414529, -91.175239, "Louisiana State University Law Library, LSU Law Center"],
-        [41.897352, -87.627156, "Loyola University Chicago School of Law"],
-        [39.289763, -76.622936, "Thurgood Marshall Law Library, Francis King Carey School of Law, University of Maryland"],
-        [-37.802327, 144.960055, "Melbourne Law School Library, The University of Melbourne"],
-        [40.818056, -96.699848, "University of Nebraska College of Law"],
-        [41.896683, -87.619690, "Pritzker Legal Research Center, Northwestern Law"],
-        [39.996168, -83.008418, "Michael E. Moritz Law Library, Ohio State University"],
-        [51.757111, -1.247840, "Bodleian Law Library, Bodleian Libraries, University of Oxford"],
-        [34.037931, -118.707359, "Harnish Law Library, Pepperdine University School of Law"],
-        [37.574272, -77.541348, "William Taylor Muse Law Library, University of Richmond School of Law"],
-        [29.752922, -95.365044, "The Fred Parks Law Library, South Texas College of Law"],
-        [37.423975, -122.167550, "Robert Crown Law Library, Stanford Law School"],
-        [34.072966, -118.438463, "Hugh & Hazel Darling Law Library, UCLA School of Law"],
-        [25.720798, -80.279734, "University of Miami School of Law"],
-        [34.363963, -89.541439, "Grisham Law Library, University of Mississippi School of Law"],
-        [36.107131, -115.142426, "Wiener-Rogers Law Library, UNLV William S. Boyd School of Law"],
-        [32.771408, -117.188822, "Pardee Legal Research Center, University of San Diego"],
-        [30.289088, -97.731251, "Tarlton Law Library, Jamail Center of Legal Research, The University of Texas School of Law"],
-        [40.762004, -111.851903, "S.J. Quinney Law Library, University of Utah"],
-        [36.145869, -86.799537, "Vanderbilt Law School"],
-        [38.051897, -78.510371, "Arthur J. Morris Law Library, University of Virginia School of Law"],
-        [47.655295, -122.303745, "University of Washington School of Law"],
-        [38.649789, -90.312022, "Washington University Law"],
-        [37.264720, -76.705315, "William & Mary Law School"],
-        [43.074277, -89.401986, "University of Wisconsin Law Library"],
-        [41.311960, -72.927899, "Lillian Goldman Law Library, Yale Law School"],
-        [40.736568, -74.1665841, "Peter W. Rodino, Jr. Law Library, Seton Hall Law"],
-        [35.904912, -79.046913, "Kathrine R. Everett Law Library, University of North Carolina"],
-        [39.817224, -75.546148, "Widener University School of Law"],
-        [32.846348, -96.786086, "SMU Dedman School of Law"],
-        [33.578997, -101.886574, "Texas Tech University School of Law"],
-        [41.657435, -91.542964, "University of Iowa School of Law"],
-        [43.036906, -87.926988, "Ray & Kay Eckstein Law Library, Marquette University"],
-        [41.040253, -73.764685, "Pace Law School, Pace University"],
-        [33.646735, -117.835965, "University of California, Irvine School of Law"]
-    ];
-    for(var i = 0; i < points.length; i++){
-        //map.plot(points[i][0], points[i][1], points[i][2]);
-        map.plot(points[i][0], points[i][1]);
+    for(var i = 0; i < partnerPoints.length; i++){
+        //map.plot(partnerPoints[i][0], partnerPoints[i][1], partnerPoints[i][2]);
+        map.plot(partnerPoints[i][0], partnerPoints[i][1]);
     }
 
 });


### PR DESCRIPTION
- The partner logo carousel is now generated from the database instead of hardcoded. Logos are automatically thumbnailed and grayscaled so we don't have to upload tiny gray versions.
- The partner map is generated from the database instead of hardcoded in javascript. This requires running some sql to load the lat-lon for existing partners: https://www.dropbox.com/s/zipzrof9kh5kxtq/registrar_locations.sql?dl=0

(todo: update the fixtures so the map and carousel show something on stage)