### PR TITLE
Tell Chrome to not validate form

### DIFF
--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -14,7 +14,7 @@
         {% endfor %}
     {% endif %}
 		<div id="add-member" class="collapse {% if form.errors %}in{% endif %}">
-			<form method="post">
+			<form method="post" novalidate>
 				{% csrf_token %}
 				<h4 class="body-ch">Add a Registrar</h4>
 						<fieldset>


### PR DESCRIPTION
Chrome will try to validate our forms for us. Kind of weird. So, when we mark a form field as a url, Chrome will validate and block submission unless you add a novalidate tag to the form.

Since we're forgiving with our url field on the create page, maybe we should be here too? Added the novalidate tag (for the url) in the registrar form.

fixes #1183