### PR TITLE
Link privacy tweaks.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -594,6 +594,9 @@ class Link(models.Model):
                     raise Exception("No valid GUID found in 100 attempts.")
                 self.guid = guid
 
+        if self.is_private and not self.private_reason:
+            self.private_reason = 'user'
+
         super(Link, self).save(*args, **kwargs)
 
         if not self.folders.count():

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -211,7 +211,7 @@
 		{% if can_view and link.is_private %}
 	        <div class="banner banner-status row _isDarchive">
 		        <strong>This record is private{% if link.private_reason == 'policy' %} by Perma.cc policy{% elif link.private_reason == 'takedown' %} at the content owner's request{% endif %}.</strong>
-                It’s only visible to libraries and your Archiving Organization.
+                It’s only visible to {% if link.organization %}members of {{ link.organization }} and the {{ link.organization.registrar }} registrar{% else %}you{% endif %}.
                 {% if link.private_reason == 'user' %}You can make this link public under 'Show record details.'{% endif %}
 	        </div>
         {% endif %}
@@ -219,7 +219,7 @@
         {% if new_record %}
 	        <div class="banner banner-status row _isNewRecord">
 		        <strong>Success!</strong>
-		        <span class="message verbose">Your new Perma Link is <input class="perma" type="text" value="{{ request.get_host }}{% url 'single_linky' link.guid %}"></input></span>
+		        <span class="message verbose">Your new Perma Link is <input class="perma" type="text" value="{{ request.get_host }}{% url 'single_linky' link.guid %}"></span>
 		        <span class="link-options verbose"><a href="{% url 'user_delete_link' link.guid %}">Delete</a><span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span></span>
 		        <a class="action new-link" href="{% url 'create_link' %}">Make a new Perma Link</a>
 	        </div>

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -35,7 +35,7 @@ class CommonViewsTestCase(PermaTestCase):
         for user in self.users:
             self.log_in_user(user)
             response = self.get('single_linky', reverse_kwargs={'kwargs': {'guid': 'ABCD-0001'}})
-            self.assertIn("only visible to libraries and your Archiving Organization.", response.content)
+            self.assertIn("This record is private.", response.content)
 
     def test_deleted(self):
         response = self.get('single_linky', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}})

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -140,9 +140,9 @@ def single_linky(request, guid):
     context = {
         'link': link,
         'can_view': request.user.can_view(link),
-        'can_edit': request.user.is_authenticated() and request.user.can_view(link),
-        'can_delete': request.user.is_authenticated() and request.user.can_delete(link),
-        'can_toggle_private': request.user.is_authenticated() and request.user.can_toggle_private(link),
+        'can_edit': request.user.can_view(link),
+        'can_delete': request.user.can_delete(link),
+        'can_toggle_private': request.user.can_toggle_private(link),
         'capture': capture,
         'next': request.get_full_path(),
         'serve_type': serve_type,


### PR DESCRIPTION
- Fix missing privacy toggle button for some users. Closes #1234.
- Clarify message about who can see private link contents. Closes #1236.