### PR TITLE
Improved single link iframe sizing.

### DIFF
--- a/perma_web/static/js/single-link.js
+++ b/perma_web/static/js/single-link.js
@@ -4,19 +4,16 @@ $(document).ready(function() {
         $('header').toggleClass('_activeDetails');
     });    
 
-    adjustHeight();
-    $('#collapse-refresh').on('shown.bs.collapse', function () {
-        adjustHeight();
-    });
-    $('#collapse-refresh').on('hidden.bs.collapse', function () {
-        adjustHeight();
-    });
-
 	function adjustHeight() {
-	    var	headerHeight = $('header').height(),
-	    	windowHeight = $(window).height();
-	    $('iframe').height(windowHeight - headerHeight - 0);
+        var $iframe = $('iframe');
+        if($iframe.length)
+    	    $iframe.height($(window).height() - $iframe.offset().top);
 	}
+
+    adjustHeight();
+    $(window).on('resize', function () {
+        adjustHeight();
+    });
 
     $("button.darchive").click(function(){
         var $this = $(this);


### PR DESCRIPTION
This addresses the javascript part of #1245.

- Improved javascript calculation of iframe height (based on the top of the iframe instead of the bottom of the header). Removes double scrollbar in multiple browsers.
- Iframe is resized on window resize.