### PR TITLE
Tweaks

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -127,6 +127,9 @@ def proxy_capture(self, link_guid, user_agent=''):
     link = Link.objects.get(guid=link_guid)
     target_url = link.submitted_url
 
+    # allow pending tasks to be canceled outside celery by updating capture status
+    if link.primary_capture.status != "pending":
+        return
 
     # Override user_agent for now, since PhantomJS doesn't like some user agents.
     # This user agent is the Chrome on Linux that's most like PhantomJS 1.9.8.

--- a/perma_web/static/js/pretty-print-json.js
+++ b/perma_web/static/js/pretty-print-json.js
@@ -90,7 +90,11 @@ function FormatJSON(oData, sIndent) {
 
 $( document ).ready(function() {
     $(".prettyprint").each(function() {
-		str = jQuery.parseJSON($(this).text());
-		$(this).html(FormatJSON(str));
+        try{
+            str = jQuery.parseJSON($(this).text());
+            $(this).html(FormatJSON(str));
+        }catch(e){
+            // invalid JSON
+        }
 	});
   });


### PR DESCRIPTION
- Non-JSON response examples in API docs don't cause a javascript parse error.
- Capture tasks can be manually canceled from outside by updating the status.