### PR TITLE
Remove feedback form

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -219,7 +219,7 @@
         {% if new_record %}
 	        <div class="banner banner-status row _isNewRecord">
 		        <strong>Success!</strong>
-		        <span class="message verbose">Your new Perma Link is <input class="perma" type="text" value="{{ request.get_host }}{% url 'single_linky' link.guid %}"></span>
+		        <span class="message verbose">Your new Perma Link is <input class="perma" type="text" value="https://{{ request.get_host }}{% url 'single_linky' link.guid %}"></span>
 		        <span class="link-options verbose"><a href="{% url 'user_delete_link' link.guid %}">Delete</a><span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span></span>
 		        <a class="action new-link" href="{% url 'create_link' %}">Make a new Perma Link</a>
 	        </div>

--- a/perma_web/perma/templates/js_config.html
+++ b/perma_web/perma/templates/js_config.html
@@ -6,6 +6,5 @@
         ROLLBAR_ACCESS_TOKEN: "{{ ROLLBAR_CLIENT_ACCESS_TOKEN }}",
         DEBUG: {{ DEBUG|lower }}
     },
-    api_path = "/api/v" + settings.API_VERSION,
-    feedback_url = "{% url 'service_receive_feedback' %}";
+    api_path = "/api/v" + settings.API_VERSION
 </script>

--- a/perma_web/perma/tests/test_views_service.py
+++ b/perma_web/perma/tests/test_views_service.py
@@ -27,25 +27,3 @@ class ServiceViewsTestCase(PermaTestCase):
         # The service needs an email address and a link. If we don't send both we should fail
         response = self.client.post(reverse('service_email_confirm'), data={'email_address': 'test@example.com'})
         self.assertEqual(response.status_code, 400)
-
-    def test_receive_feedback(self):
-        """
-        A user can email a link through the web front end. The variables
-        are link and email address.
-        """
-
-        # We send from this email. Verify it's in our settings.
-        self.assertIn('@', settings.DEFAULT_FROM_EMAIL)
-
-        data = {'visited_page': 'http://perma.cc/something',
-                'feedback_text': 'something about example.com',
-                'broken_link': 'http://example.com'}
-
-        # TODO: write emails to files and then validate that file
-        response = self.client.post(reverse('service_receive_feedback'), data=data)
-        self.assertEqual(response.status_code, 201)
-
-        jsoned_response = json.loads(response.content)
-        self.assertEqual('true', jsoned_response['submitted'])
-        self.assertIsNotNone(jsoned_response['content'])
-

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -46,7 +46,6 @@ urlpatterns = patterns('perma.views',
     
     #Services
     url(r'^service/email-confirm/?$', 'service.email_confirm', name='service_email_confirm'),
-    url(r'^service/receive-feedback/?$', 'service.receive_feedback', name='service_receive_feedback'),
     url(r'^service/stats/users/?$', 'service.stats_users', name='service_stats_users'),
     url(r'^service/stats/links/?$', 'service.stats_links', name='service_stats_links'),
     url(r'^service/stats/storage/?$', 'service.stats_storage', name='service_stats_storage'),

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -39,46 +39,6 @@ def email_confirm(request):
 
     return HttpResponse(json.dumps(response_object), content_type="application/json", status=200)
 
-
-def receive_feedback(request):
-    """
-    Take feedback data and send it off in an email
-    """
-
-    visited_page = request.POST.get('visited_page')
-    feedback_text = request.POST.get('feedback_text')
-    broken_link = request.POST.get('broken_link')
-    broken_text = ""
-    if(broken_link):
-        broken_text = '''There was a problem creating the following Perma
-    %s
-        
-    ''' %(broken_link)
-    
-    from_address = request.POST.get('user_email')
-    content = '''
-Visited page: %s
-
-COMMENTS
---------
-%s
-
-
-%s
-''' % (visited_page, feedback_text, broken_text)
-    logger.debug(content)
-    
-    send_contact_email(
-        "New Perma feedback",
-        content,
-        from_address,
-        request
-    )
-        
-    response_object = {'submitted': 'true', 'content': content}
-
-    return HttpResponse(json.dumps(response_object), content_type="application/json", status=201)
-
 def stats_users(request):
     """
     Retrieve nightly stats for users in the DB, dump them out here so that our D3 vis can render them, real-purty-like

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -234,7 +234,6 @@ header {
 		    font-weight: 700;
 		    color: $color-blue;
 		    width: auto;
-		    width: 11.25em;
 		    text-align: center;
 		    &:focus {
 			    outline: none;

--- a/perma_web/static/js/global.js
+++ b/perma_web/static/js/global.js
@@ -18,47 +18,6 @@ $(document).ready(function() {
     // Select the input text when the user clicks the element
     $('.select-on-click').click(function() { $(this).select(); });
     
-    $('.error-row').on('click', '#report-error', function() {
-        var brokenLink = $('#rawUrl').val();
-        $('#broken-link-report').html('<strong id="broken-link">' + brokenLink + '</strong> is causing an error.');
-    });
-    
-    $('#feedbackModal').on('hidden.bs.modal', function (e) {
-        $('.feedback-form-inputs').show();
-        $('.feedback-form-submitted').hide();
-        $('#broken-link-report').html('');
-        $('form.feedback').find("input[type=email], textarea").val("");
-        $('#user_email').val(user_email);
-    });
-
-    
-    $("input#submit-feedback").click(function(){
-      var data = $('form.feedback').serializeArray();
-
-      // todo -- is this necessary with our global csrf cookie js?
-      var csrftoken = getCookie('csrftoken');
-      data.push({name: 'csrfmiddlewaretoken', value: csrftoken});
-
-      data.push({name: 'visited_page', value: $(location).attr('href')});
-      var brokenLink = $('#broken-link').text();
-      if(brokenLink)
-        data.push({name: 'broken_link', value: brokenLink});
-        $.ajax({
-            type: "POST",
-            url: feedback_url, //process to mail
-            data: data,
-            success: function(msg){
-                //$("#feedbackModal").modal('hide'); //hide popup 
-                $('.feedback-form-inputs').slideUp();
-                $('.feedback-form-submitted').fadeIn();
-            },
-            error: function(){
-                alert("failure");
-            }
-        });
-      return false;
-    });
-
     // clear popup alerts with a click
     $(document).on('click', '.popup-alert', function(){
         $(this).remove();


### PR DESCRIPTION
Unused route receive_feedback and all associated methods in service.py and globals.js

Feedback modal used to exist here: https://github.com/harvard-lil/perma/blob/7af51069e1d97d35ff0366e494eb95a4dcebdfb5/perma_web/perma/templates/base-responsive.html#L131 but it seems that we have gotten rid of it and are instead routing users to /contact.

Finishes #1342