### PR TITLE
Url width on new-link page.

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -219,7 +219,7 @@
         {% if new_record %}
 	        <div class="banner banner-status row _isNewRecord">
 		        <strong>Success!</strong>
-		        <span class="message verbose">Your new Perma Link is <input class="perma" type="text" value="https://{{ request.get_host }}{% url 'single_linky' link.guid %}"></span>
+		        <span class="message verbose">Your new Perma Link is <input class="link-field" type="text" value="https://{{ request.get_host }}{% url 'single_linky' link.guid %}"></span>
 		        <span class="link-options verbose"><a href="{% url 'user_delete_link' link.guid %}">Delete</a><span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span></span>
 		        <a class="action new-link" href="{% url 'create_link' %}">Make a new Perma Link</a>
 	        </div>

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -226,7 +226,7 @@ header {
 				}
 			}
 		}
-		input.perma {
+		.link-field {
 		    display: inline-block;
 		    border: 1px solid $color-blue;
 		    padding: 4px 8px;

--- a/perma_web/static/js/single-link.js
+++ b/perma_web/static/js/single-link.js
@@ -40,4 +40,15 @@ $(document).ready(function() {
 
         return false;
     });
+
+    // On the new-record bar, update the width of the URL input to match its contents,
+    // by copying the contents into a temporary span with the same class and measuring its width.
+    if($('._isNewRecord')){
+        var linkField = $('input.link-field');
+        linkField.after("<span class='link-field'></span>");
+        var linkSpan = $('span.link-field');
+        linkSpan.text(linkField.val());
+        linkField.width(linkSpan.width());
+        linkSpan.remove();
+    }
 });


### PR DESCRIPTION
Just a little tweak so that the width of the “Your new Perma Link is” box on the new-link page matches the actual length of the URL.