### PR TITLE
Return queryset from get_orgs.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -232,7 +232,7 @@ class LinkUser(AbstractBaseUser):
         if self.is_staff:
             return Organization.objects.all()
             
-        return []
+        return Organization.objects.none()
         
     def get_links_remaining(self):
         today = timezone.now()


### PR DESCRIPTION
Make get_orgs return a queryset in all cases so `get_orgs().select_related()` works.