### PR TITLE
Re-enable delete for orgs.

### DIFF
--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -475,8 +475,7 @@ class LinkResource(AuthenticatedLinkResource):
 
         self.authorized_delete_detail(self.get_object_list(bundle.request), bundle)
 
-        bundle.obj.user_deleted = True
-        bundle.obj.user_deleted_timestamp = timezone.now()
+        bundle.obj.safe_delete()
         bundle.obj.save()
 
     ###

--- a/perma_web/perma/migrations/0030_auto_20160224_2212.py
+++ b/perma_web/perma/migrations/0030_auto_20160224_2212.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perma', '0029_auto_20160203_2024'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalorganization',
+            name='user_deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='historicalorganization',
+            name='user_deleted_timestamp',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='user_deleted',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='user_deleted_timestamp',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='link',
+            name='organization',
+            field=models.ForeignKey(related_name='links', blank=True, to='perma.Organization', null=True),
+        ),
+    ]

--- a/perma_web/perma/migrations/0031_merge.py
+++ b/perma_web/perma/migrations/0031_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perma', '0030_auto_20160219_2144'),
+        ('perma', '0030_auto_20160224_2212'),
+    ]
+
+    operations = [
+    ]

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -151,12 +151,9 @@
 		            </div>
 
 		            <div class="col col-sm-4 col-no-gutter sm-align-right admin-actions">
-                        {% comment %}
-                            TEMPORARILY REMOVED WHILE WE FIX ORG DELETION
-                            {% if org.org_links < 1 %}
-                                <a class="action" href="{% url 'user_management_manage_single_organization_delete' org.id %}">delete</a>
-                            {% endif %}
-                        {% endcomment %}
+                        {% if org.org_links < 1 %}
+                            <a class="action" href="{% url 'user_management_manage_single_organization_delete' org.id %}">delete</a>
+                        {% endif %}
 			            <a class="action" href="{% url 'user_management_manage_single_organization' org.id %}">edit</a>
 			            {% if request.user.is_staff %}
 			                <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit in admin console</a>

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -52,7 +52,7 @@ class PermissionsTestCase(PermaTestCase):
                     ['user_management_manage_organization_user'],
                     ['user_management_manage_organization'],
                     ['user_management_manage_single_organization', {'kwargs':{'org_id':1}}],
-                    ['user_management_manage_single_organization_delete', {'kwargs':{'org_id':1}, 'success_status': 404}],
+                    ['user_management_manage_single_organization_delete', {'kwargs':{'org_id':1}}],
                     ['user_management_organization_user_add_user'],
                     ['user_management_manage_single_organization_user_remove', {'kwargs':{'user_id': 3},
                      'success_status': 302}],


### PR DESCRIPTION
- Org delete is now a flag, like link delete.
- Deleted orgs and links stay visible in admin.
- Add "DeletableModel" and "DeletableManager" to abstract the delete-flag pattern.
- Use `accessible_to(request.user)` to enforce access permissions in org views.