### PR TITLE
bump - running tests again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 before_install:
   - cp services/travis/settings.py perma_web/perma/settings/
   - cd perma_web
+  - phantomjs --version
 install:
   - pip install -r requirements.txt
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ![](https://raw.githubusercontent.com/harvard-lil/perma/develop/perma_web/static/img/watermark.png)
 
 Perma - indelible links
+
 =====
- 
+
 Perma.cc helps authors and journals create permanent archived citations in their published work.
 
 


### PR DESCRIPTION
I'm experiencing weirdness:
- downloading latest version of phantomjs (2.1.1) breaks warc functionality on any branch (locally)
     - safe to assume this has nothing to do with `cleanup-js` code
- for some reason, only my versions fail on travis. pull requests that have been opened and run on travis after `cleanup-js` pass with no problems

----------
Alright, that was wrong! 
Tests fail on any of my local branches, so maybe I am using the wrong updated phantomjs version (it's not 2.1.1?). I don't think that it's js-related caching issues (like cleanup-js code is wrong and switching branches does not update things correctly) because I have verified that older code is being pulled in on localhost. 

----------
travis uses 1.9.8, which means (maybe) there is a difference unrelated to phantomjs between my vagrant environment and travis's, that causes 1.9.8 phantomjs to pass tests/create warcs locally but not on travis.... confusion! mystery!
https://github.com/travis-ci/travis-ci/issues/3225