### PR TITLE
Improve email handling

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -156,9 +156,13 @@ convenient to change to that directory and run `python run_tests.py`, rather tha
 kicked off by `fab test_sauce`.
 
 
-## Debugging email-related issues
+## Sending email
 
-If you're working on an email related task, the contents of emails should be dumped to the standard out courtesy of EMAIL_BACKEND in settings_dev.py.
+*All emails* should be sent using `perma.utils.send_user_email` (for an email from us to a user) or 
+`perma.utils.send_admin_email` (for an email "from" a user to us). This makes sure that `from` and `reply-to` fields
+are configured so our MTA will actually transmit the email.
+
+On the development server, emails are dumped to the standard out courtesy of EMAIL_BACKEND in settings_dev.py.
 
 
 ## Working with Celery

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -34,11 +34,7 @@ from warcprox.warcwriter import WarcWriter, WarcWriterThread
 
 from django.utils import timezone
 from django.core.files.storage import default_storage
-from django.core.mail import send_mail
-from django.template.loader import get_template
-from django.template import Context
 from django.template.defaultfilters import truncatechars
-from django.forms.models import model_to_dict
 from django.conf import settings
 
 from perma.models import WeekStats, MinuteStats, Registrar, LinkUser, Link, Organization, CDXLine, Capture

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -5,7 +5,7 @@ import struct
 import tempdir
 from datetime import datetime
 
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMessage, send_mail
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.conf import settings
@@ -161,7 +161,15 @@ def copy_file_data(from_file_handle, to_file_handle, chunk_size=1024*100):
 
 ### email ###
 
-def send_contact_email(title, content, from_address, request):
+def send_user_email(title, content, to_address):
+    send_mail(
+        title,
+        content,
+        settings.DEFAULT_FROM_EMAIL,
+        [to_address], fail_silently=False
+    )
+
+def send_admin_email(title, content, from_address, request):
     """
         Send a message on behalf of a user to the admins.
         Use reply-to for the user address so we can use email services that require authenticated from addresses.

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -31,7 +31,7 @@ from ratelimit.decorators import ratelimit
 
 from ..models import Link, Registrar, Organization, LinkUser
 from perma.forms import ContactForm
-from perma.utils import if_anonymous, send_contact_email
+from perma.utils import if_anonymous, send_admin_email
 
 logger = logging.getLogger(__name__)
 valid_serve_types = ['image', 'warc_download']
@@ -238,7 +238,7 @@ Message from user
 %s
 ''' % (form.cleaned_data['message'])
 
-            send_contact_email(
+            send_admin_email(
                 "New message from Perma contact form",
                 content,
                 from_address,

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -1,21 +1,16 @@
-import json, logging, csv, pytz
-from datetime import datetime, timedelta
+import json, logging, pytz
 
-from django.conf import settings
-from django.core.mail import send_mail
 from django.core import serializers
 from django.shortcuts import get_object_or_404
 from django.http import Http404
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
-from django.shortcuts import redirect, render_to_response
-from django.template import RequestContext
+from django.shortcuts import redirect
 from django.contrib.auth.decorators import login_required
 from django.utils import timezone
 
 from perma.models import Link, WeekStats, MinuteStats
-from perma.utils import send_contact_email, json_serial
-
+from perma.utils import json_serial, send_user_email
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +26,10 @@ def email_confirm(request):
     if not email_address or not link_url:
         return HttpResponse(status=400)
 
-    send_mail(
+    send_user_email(
         "The Perma link you requested",
         "%s \n\n(This link is the Perma link)" % link_url,
-        settings.DEFAULT_FROM_EMAIL,
-        [email_address]
+        email_address
     )
 
     response_object = {"sent": True}

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -13,7 +13,6 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth import views as auth_views
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.mail import send_mail
 from django.db.models import Count, Max, Sum
 from django.utils import timezone
 from django.utils.http import is_safe_url, cookie_date
@@ -41,7 +40,8 @@ from perma.forms import (
     SetPasswordForm, 
 )
 from perma.models import Registrar, LinkUser, Organization, Link, Capture
-from perma.utils import apply_search_query, apply_pagination, apply_sort_order, send_contact_email, filter_or_null_join
+from perma.utils import apply_search_query, apply_pagination, apply_sort_order, send_admin_email, filter_or_null_join, \
+    send_user_email
 
 logger = logging.getLogger(__name__)
 valid_member_sorts = ['last_name', '-last_name', 'date_joined', '-date_joined', 'last_login', '-last_login', 'created_links_count', '-created_links_count']
@@ -1629,11 +1629,10 @@ http://%s%s
 
     logger.debug(content)
 
-    send_mail(
+    send_user_email(
         "A Perma.cc account has been created for you",
         content,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email], fail_silently=False
+        user.email
     )
     
 
@@ -1650,11 +1649,10 @@ http://%s%s
 
 ''' % (org.name, org.name, host, reverse('user_management_settings_organizations'))
 
-    send_mail(
+    send_user_email(
         "Your Perma.cc account is now associated with {org}".format(org=org.name),
         content,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email], fail_silently=False
+        user.email
     )
 
 
@@ -1671,11 +1669,10 @@ http://%s%s
 
 ''' % (user.registrar.name, user.registrar.name, host, reverse('user_management_settings_organizations'))
 
-    send_mail(
+    send_user_email(
         "Your Perma.cc account is now associated with {registrar}".format(registrar=user.registrar.name),
         content,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email], fail_silently=False
+        user.email
     )
     
     
@@ -1700,11 +1697,10 @@ http://%s%s
 
     logger.debug(content)
 
-    send_mail(
+    send_user_email(
         "A Perma.cc account has been created for you",
         content,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email], fail_silently=False
+        user.email
     )
     
     
@@ -1723,7 +1719,7 @@ http://%s%s
 
     logger.debug(content)
 
-    send_contact_email(
+    send_admin_email(
         "Perma.cc new library registrar account request",
         content,
         pending_registrar.email,
@@ -1748,11 +1744,10 @@ http://%s%s
 
     logger.debug(content)
 
-    send_mail(
+    send_user_email(
         "Your Perma.cc library account is approved",
         content,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email], fail_silently=False
+        user.email
     )
 
 
@@ -1778,9 +1773,9 @@ This user %s
 
     logger.debug(content)
 
-    send_mail(
+    send_admin_email(
         "Perma.cc new library court account information request",
         content,
         court.email,
-        [settings.DEFAULT_FROM_EMAIL], fail_silently=False
+        request
     )


### PR DESCRIPTION
- Encapsulate email sending into `send_user_email` and `send_admin_email`. All email sending should go through one of these.
- Fixes bug with court emails coming from the wrong address.
- Also remove some unused imports.