### PR TITLE
Fix test timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ before_install:
   - cd perma_web
 
 install:
+  # faster installs, per https://github.com/nickstenning/travis-pip-cache
+  - pip install -U pip wheel
+
   - pip install -r requirements.txt
   - pip install coveralls
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,13 @@ before_script:
   - mysql -e 'SET GLOBAL wait_timeout = 36000;'
 
   - python manage.py collectstatic --noinput
+  - date
 script:
   fab test
+after_failure:
+  - date
 after_success:
+  - date
   - coveralls
 
 # See: http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade#tl%3Bdr

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -169,7 +169,7 @@ class FunctionalTest(BaseTestCase):
         self.driver = webdriver.PhantomJS(
             desired_capabilities=self.base_desired_capabilities,
         )
-        socket.setdefaulttimeout(60)
+        socket.setdefaulttimeout(120)
         self.driver.set_window_size(1024, 800)
 
     def tearDownLocal(self):

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -257,6 +257,7 @@ class FunctionalTest(BaseTestCase):
                                                    self.server_thread.port))
             return o.geturl()
 
+        from datetime import datetime; info("TIME", datetime.utcnow())
         info("Loading homepage from %s." % self.server_url)
         self.driver.get(self.server_url)
         assert_text_displayed("Perma.cc is simple") # new text on landing now

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -267,7 +267,8 @@ class FunctionalTest(BaseTestCase):
                                                    self.server_thread.port))
             return o.geturl()
 
-        from datetime import datetime; info("TIME", datetime.utcnow())
+        info("Starting functional tests at time:", datetime.datetime.utcnow())
+        
         info("Loading homepage from %s." % self.server_url)
         self.driver.get(self.server_url)
         assert_text_displayed("Perma.cc is simple") # new text on landing now

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -8,6 +8,8 @@ import re
 import datetime
 import sys
 from urlparse import urlparse
+
+from pyvirtualdisplay import Display
 from selenium import webdriver
 from selenium.common.exceptions import ElementNotVisibleException, NoSuchElementException
 import time
@@ -168,8 +170,11 @@ class FunctionalTest(BaseTestCase):
     def setUpLocal(self):
         try:
             # use Firefox if available on local system
+            self.virtual_display = Display(visible=0, size=(1024, 800))
+            self.virtual_display.start()
             self.driver = webdriver.Firefox(capabilities=self.base_desired_capabilities)
         except RuntimeError:
+            self.virtual_display = None
             self.driver = webdriver.PhantomJS(desired_capabilities=self.base_desired_capabilities)
         print("Using %s for integration tests." % (type(self.driver)))
         socket.setdefaulttimeout(30)
@@ -177,6 +182,8 @@ class FunctionalTest(BaseTestCase):
 
     def tearDownLocal(self):
         self.driver.quit()
+        if self.virtual_display:
+            self.virtual_display.stop()
 
     def tearDownSauce(self):
         print("Link to your job: https://saucelabs.com/jobs/%s" % self.driver.session_id)

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -166,10 +166,13 @@ class FunctionalTest(BaseTestCase):
         socket.setdefaulttimeout(300)  # spinning up iOS browser can take a few minutes
 
     def setUpLocal(self):
-        self.driver = webdriver.PhantomJS(
-            desired_capabilities=self.base_desired_capabilities,
-        )
-        socket.setdefaulttimeout(120)
+        try:
+            # use Firefox if available on local system
+            self.driver = webdriver.Firefox(capabilities=self.base_desired_capabilities)
+        except RuntimeError:
+            self.driver = webdriver.PhantomJS(desired_capabilities=self.base_desired_capabilities)
+        print("Using %s for integration tests." % (type(self.driver)))
+        socket.setdefaulttimeout(30)
         self.driver.set_window_size(1024, 800)
 
     def tearDownLocal(self):

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -31,7 +31,6 @@ from warcprox.controller import WarcproxController
 from warcprox.warcprox import WarcProxyHandler, WarcProxy, ProxyingRecorder
 from warcprox.warcwriter import WarcWriter, WarcWriterThread
 
-
 from django.utils import timezone
 from django.core.files.storage import default_storage
 from django.template.defaultfilters import truncatechars

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -85,7 +85,7 @@ class PermissionsTestCase(PermaTestCase):
                     ['create_link'],
 
                     ['folder_contents', {'kwargs': {'folder_id': '12345'}, 'success_status': 404}],
-                    ['user_delete_link', {'kwargs':{'guid':'1234'},'success_status':404}],
+                    ['user_delete_link', {'kwargs':{'guid':'1234-1234'},'success_status':404}],
                 ],
                 'allowed': {'test_user@example.com'},
                 'disallowed': set(),


### PR DESCRIPTION
This hopefully fixes the timeout on that one test by using Firefox instead of PhantomJS to run the integration tests.