### PR TITLE
Fix retry on getting browser title

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -393,7 +393,7 @@ def proxy_capture(self, link_guid, user_agent=''):
                     save_fields(link, submitted_title=browser.title)
                 else:
                     title_element = browser.find_element_by_tag_name("title")
-                    save_fields(link, submitted_title=title_element.text)
+                    save_fields(link, submitted_title=title_element.get_attribute("text"))
             repeat_while_exception(get_title, timeout=10)
 
             # check meta tags

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -155,14 +155,16 @@ def add_thread(thread_list, func):
     new_thread.start()
     thread_list.append(new_thread)
 
-def repeat_while_exception(func, exception=Exception, timeout=10, sleep_time=.1):
+def repeat_while_exception(func, exception=Exception, timeout=10, sleep_time=.1, raise_after_timeout=True):
     end_time = time.time() + timeout
     while True:
         try:
             return func()
         except exception as e:
             if time.time() > end_time:
-                raise
+                if raise_after_timeout:
+                    raise
+                return
             time.sleep(sleep_time)
 
 def parse_response(response_text):
@@ -394,7 +396,7 @@ def proxy_capture(self, link_guid, user_agent=''):
                 else:
                     title_element = browser.find_element_by_tag_name("title")
                     save_fields(link, submitted_title=title_element.get_attribute("text"))
-            repeat_while_exception(get_title, timeout=10)
+            repeat_while_exception(get_title, timeout=10, raise_after_timeout=False)
 
             # check meta tags
             print "Checking meta tags."

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -392,7 +392,8 @@ def proxy_capture(self, link_guid, user_agent=''):
                 if browser.title:
                     save_fields(link, submitted_title=browser.title)
                 else:
-                    raise KeyError('No title')
+                    title_element = browser.find_element_by_tag_name("title")
+                    save_fields(link, submitted_title=title_element.text)
             repeat_while_exception(get_title, timeout=10)
 
             # check meta tags

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -391,6 +391,8 @@ def proxy_capture(self, link_guid, user_agent=''):
             def get_title():
                 if browser.title:
                     save_fields(link, submitted_title=browser.title)
+                else:
+                    raise KeyError('No title')
             repeat_while_exception(get_title, timeout=10)
 
             # check meta tags


### PR DESCRIPTION
Hi,
looking through your tasks.py I noticed that there's a bug that prevents additional attempts to get the title:

            def get_title():
                if browser.title:
                    save_fields(link, submitted_title=browser.title)

This grabs browser.title, which may contain the correct title or '' (which evaluates to False) - but it never raises an Exception! [1].

Hence, the subsequent `repeat_while_exception(get_title, timeout=10)` will never get a chance to repeat.

This tiny patch just raises a KeyError for empty titles, allowing for retries of up to 10 seconds.

[1] http://seleniumhq.github.io/selenium/docs/api/py/_modules/selenium/webdriver/remote/webdriver.html#WebDriver.title