### PR TITLE
Custom queue for capture jobs

### DIFF
--- a/perma_web/api/authorizations.py
+++ b/perma_web/api/authorizations.py
@@ -150,6 +150,22 @@ class CurrentUserOrganizationAuthorization(CurrentUserNestedAuthorization):
         return bundle.request.user.can_edit_organization(bundle.obj)
 
 
+class CurrentUserCaptureJobAuthorization(CurrentUserNestedAuthorization):
+
+    def read_list(self, object_list, bundle):
+        if not bundle.request.user.is_authenticated():
+            raise Unauthorized()
+        return object_list.filter(link__created_by_id=bundle.request.user.pk, status__in=['pending', 'in_progress'])
+
+    def read_detail(self, object_list, bundle):
+        # It's a /schema request
+        if bundle.obj.pk is None:
+            return True
+        if not bundle.request.user.is_authenticated():
+            raise Unauthorized()
+        return bundle.obj.link.created_by == bundle.request.user
+
+
 class LinkAuthorization(AuthenticatedLinkAuthorization):
 
     def can_access(self, user, obj):

--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -333,6 +333,7 @@ class BaseLinkResource(MultipartResource, DefaultResource):
     creation_timestamp = fields.DateTimeField(attribute='creation_timestamp', readonly=True)
     url = fields.CharField(attribute='submitted_url')
     title = fields.CharField(attribute='submitted_title', blank=True)
+    warc_size = fields.IntegerField(attribute='warc_size', blank=True, null=True)
     captures = fields.ToManyField(CaptureResource, 'captures', readonly=True, full=True)
 
     class Meta(DefaultResource.Meta):

--- a/perma_web/api/tests/test_current_user_authorization.py
+++ b/perma_web/api/tests/test_current_user_authorization.py
@@ -1,4 +1,5 @@
 from .utils import ApiResourceTransactionTestCase
+from perma.tests.test_capture_job import create_capture_job
 from perma.models import LinkUser, Link
 
 
@@ -72,3 +73,24 @@ class CurrentUserAuthorizationTestCase(ApiResourceTransactionTestCase):
 
     def test_should_reject_org_detail_for_other_user(self):
         self.rejected_get(self.detail_url + 'organizations/%s/' % (self.org_member.organizations.first().pk,), user=self.regular_user)
+
+    # capture jobs
+
+    def test_should_provide_different_capture_jobs_data_relative_to_user(self):
+        create_capture_job(self.org_member)
+        create_capture_job(self.regular_user)
+
+        vm_data = self.successful_get(self.detail_url + 'capture_jobs/', user=self.org_member)
+        reg_data = self.successful_get(self.detail_url + 'capture_jobs/', user=self.regular_user)
+
+        self.assertEqual(vm_data.keys(), reg_data.keys())
+        self.assertNotEqual(vm_data['objects'], reg_data['objects'])
+
+    def test_should_allow_capture_job_detail(self):
+        job = create_capture_job(self.org_member)
+        self.successful_get(self.detail_url + 'capture_jobs/%s/' % (job.link_id,), user=self.org_member)
+
+    def test_should_reject_capture_job_detail_for_other_user(self):
+        job = create_capture_job(self.org_member)
+        self.rejected_get(self.detail_url + 'capture_jobs/%s/' % (job.link_id,), user=self.regular_user)
+

--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -1,7 +1,7 @@
 import os
 from .utils import TEST_ASSETS_DIR, ApiResourceTransactionTestCase
 from api.resources import LinkResource, PublicLinkResource
-from perma.models import Link, LinkUser, Folder
+from perma.models import Link, LinkUser, Folder, CaptureJob
 
 
 class LinkAuthorizationTestCase(ApiResourceTransactionTestCase):
@@ -42,6 +42,8 @@ class LinkAuthorizationTestCase(ApiResourceTransactionTestCase):
 
         self.patch_data = {'notes': 'These are new notes',
                            'title': 'This is a new title'}
+
+        CaptureJob.clear_cache()  # reset cache (test cases don't reset cache keys automatically)
 
     def get_public_link_url(self, link):
         return "{0}/{1}".format(self.public_list_url, link.pk)

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -2,7 +2,7 @@ import os
 import dateutil.parser
 from .utils import ApiResourceTransactionTestCase, TEST_ASSETS_DIR
 from api.resources import LinkResource, CurrentUserLinkResource, PublicLinkResource
-from perma.models import Link, LinkUser, CDXLine
+from perma.models import Link, LinkUser, CDXLine, CaptureJob
 
 
 # Use a TransactionTestCase here because archive capture is threaded
@@ -50,7 +50,8 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
             'guid',
             'creation_timestamp',
             'captures',
-            'view_count'
+            'view_count',
+            'warc_size',
         ]
         self.logged_in_fields = self.logged_out_fields + [
             'organization',
@@ -65,6 +66,8 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
             'url': self.server_url + "/test.html",
             'title': 'This is a test page'
         }
+
+        CaptureJob.clear_cache()  # reset cache (test cases don't reset cache keys automatically)
 
     def assertValidCapture(self, capture):
         """

--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -9,7 +9,9 @@ from api.resources import (LinkResource,
                            CurrentUserResource,
                            CurrentUserLinkResource,
                            CurrentUserFolderResource,
-                           CurrentUserOrganizationResource, PublicLinkResource)
+                           CurrentUserOrganizationResource,
+                           PublicLinkResource,
+                           CurrentUserCaptureJobResource)
 
 ### collateral ###
 
@@ -41,10 +43,12 @@ v1_api.register(FolderResource())
 # /user/archives
 # /user/folders
 # /user/organizations
+# /user/capture_jobs
 v1_api.register(CurrentUserResource())
 v1_api.register(CurrentUserLinkResource())
 v1_api.register(CurrentUserFolderResource())
 v1_api.register(CurrentUserOrganizationResource())
+v1_api.register(CurrentUserCaptureJobResource())
 
 ### v1a ###
 

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -142,7 +142,7 @@ class LinkAdmin(SimpleHistoryAdmin):
     list_display = ['guid', 'submitted_url', 'submitted_title', 'created_by', 'creation_timestamp','user_deleted']
     search_fields = ['guid', 'submitted_url', 'submitted_title']
     fieldsets = (
-        (None, {'fields': ('guid', 'submitted_url', 'submitted_title', 'created_by', 'creation_timestamp', 'view_count')}),
+        (None, {'fields': ('guid', 'submitted_url', 'submitted_title', 'created_by', 'creation_timestamp', 'view_count', 'warc_size')}),
         ('Visibility', {'fields': ('is_private', 'private_reason', 'is_unlisted',)}),
         ('User Delete', {'fields': ('user_deleted', 'user_deleted_timestamp',)}),
         ('Organization', {'fields': ('folders', 'notes')}),

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -167,6 +167,18 @@ class FolderAdmin(MPTTModelAdmin):
     list_filter = ['owned_by', 'organization']
 
 
+class CaptureJobAdmin(admin.ModelAdmin):
+    list_display = ['id', 'status', 'link_id', 'created_by', 'creation_timestamp', 'human']
+    list_filter = ['status']
+    raw_id_fields = ['link']
+
+    def get_queryset(self, request):
+        return super(CaptureJobAdmin, self).get_queryset(request).filter(link__user_deleted=False).select_related('link','link__created_by')
+
+    def created_by(self, obj):
+        return obj.link.created_by
+    def creation_timestamp(self, obj):
+        return obj.link.creation_timestamp
 
 # change Django defaults, because 'extra' isn't helpful anymore now you can add more with javascript
 admin.TabularInline.extra = 0
@@ -178,6 +190,7 @@ admin.site.unregister(Group)
 
 # add our models
 admin.site.register(Link, LinkAdmin)
+admin.site.register(CaptureJob, CaptureJobAdmin)
 admin.site.register(LinkUser, LinkUserAdmin)
 admin.site.register(Organization, OrganizationAdmin)
 admin.site.register(Registrar, RegistrarAdmin)

--- a/perma_web/perma/migrations/0003_capturejob.py
+++ b/perma_web/perma/migrations/0003_capturejob.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perma', '0002_auto_20160408_1603'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CaptureJob',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('status', models.CharField(default=b'pending', max_length=15, choices=[(b'pending', b'pending'), (b'in_progress', b'in_progress'), (b'completed', b'completed'), (b'deleted', b'deleted'), (b'failed', b'failed')])),
+                ('human', models.BooleanField(default=False)),
+                ('attempt', models.SmallIntegerField(default=0)),
+                ('step_count', models.FloatField(default=0)),
+                ('step_description', models.CharField(max_length=255, null=True, blank=True)),
+                ('capture_start_time', models.DateTimeField(null=True, blank=True)),
+                ('capture_end_time', models.DateTimeField(null=True, blank=True)),
+                ('link', models.OneToOneField(related_name='capture_job', to='perma.Link')),
+            ],
+        ),
+    ]

--- a/perma_web/perma/migrations/0004_auto_20160506_1632.py
+++ b/perma_web/perma/migrations/0004_auto_20160506_1632.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perma', '0003_capturejob'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicallink',
+            name='warc_size',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='link',
+            name='warc_size',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+    ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -477,9 +477,7 @@ class LinkQuerySet(QuerySet):
 LinkManager = DeletableManager.from_queryset(LinkQuerySet)
 
 
-HEADER_CHECK_TIMEOUT = 10
-# This is the PhantomJS default agent
-USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.0 (development) Safari/534.34"
+HEADER_CHECK_TIMEOUT = 10  # keeping this setting out here allows tests to override it for speed
 
 class Link(DeletableModel):
     """
@@ -531,7 +529,7 @@ class Link(DeletableModel):
             return requests.get(
                 self.safe_url,
                 verify=False,  # don't check SSL cert?
-                headers={'User-Agent': USER_AGENT, 'Accept-Encoding': '*'},
+                headers={'User-Agent': settings.CAPTURE_USER_AGENT, 'Accept-Encoding': '*'},
                 timeout=HEADER_CHECK_TIMEOUT,
                 stream=True  # we're only looking at the headers
             ).headers

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -493,6 +493,7 @@ class Link(DeletableModel):
     folders = models.ManyToManyField(Folder, related_name='links', blank=True)
     notes = models.TextField(blank=True)
     uploaded_to_internet_archive = models.BooleanField(default=False)
+    warc_size = models.IntegerField(blank=True, null=True)
 
     is_private = models.BooleanField(default=False)
     private_reason = models.CharField(max_length=10, blank=True, null=True, choices=(('policy','Robots.txt or meta tag'),('user','At user direction'),('takedown','At request of content owner')))

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1,3 +1,4 @@
+import calendar
 import hashlib
 import io
 import json
@@ -7,11 +8,13 @@ import random
 import re
 import socket
 import tempfile
-
+import time
+from contextlib import contextmanager
 from urlparse import urlparse
 import simple_history
-from hanzo import warctools
 import requests
+
+from hanzo import warctools
 from simple_history.models import HistoricalRecords
 from wand.image import Image
 from werkzeug.urls import iri_to_uri
@@ -19,8 +22,9 @@ from werkzeug.urls import iri_to_uri
 import django.contrib.auth.models
 from django.contrib.auth.models import BaseUserManager, AbstractBaseUser
 from django.conf import settings
+from django.core.cache import cache
 from django.core.files.storage import default_storage
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.utils import timezone
@@ -881,6 +885,221 @@ class Capture(models.Model):
         if not self.url:
             return None
         return u"%s%s%s" % (self.link.base_playback_url(), "id_/" if self.record_type == 'resource' else "", self.url)
+
+
+class CaptureJob(models.Model):
+    """
+        This class tracks capture jobs for purposes of:
+            (1) sorting the capture queue fairly and
+            (2) reporting status during a capture.
+    """
+    link = models.OneToOneField(Link, related_name='capture_job')
+    status = models.CharField(max_length=15,
+                              default='pending',
+                              choices=(('pending','pending'),('in_progress','in_progress'),('completed','completed'),('deleted','deleted'),('failed','failed')))
+    human = models.BooleanField(default=False)
+
+    # reporting
+    attempt = models.SmallIntegerField(default=0)
+    step_count = models.FloatField(default=0)
+    step_description = models.CharField(max_length=255, blank=True, null=True)
+    capture_start_time = models.DateTimeField(blank=True, null=True)
+    capture_end_time = models.DateTimeField(blank=True, null=True)
+
+    CACHE_KEY = 'capture_job_queue'
+
+    # Don't use the cache if we're using background celery processes and the local memory cache (presumably in the dev
+    # environment) -- caching the queue only works if all threads see the same cache.
+    USE_CACHE = settings.RUN_TASKS_ASYNC is False or 'LocMemCache' not in settings.CACHES['default']['BACKEND']
+
+    # used for testing, to find concurrency errors
+    CACHE_DELAY = 0
+    USE_LOCK = True
+
+    def __unicode__(self):
+        return u"CaptureJob %s: %s" % (self.pk, self.link_id)
+
+    def save(self, *args, **kwargs):
+        is_new = not self.pk
+        super(CaptureJob, self).save(*args, **kwargs)
+
+        # add new jobs to the job queue
+        if is_new:
+            with self.get_job_queues() as job_queues:
+                self.add_to_queue(job_queues)
+
+    @classmethod
+    @contextmanager
+    def get_job_queues(cls):
+        """
+            This is a context manager we can use to get LOCKED access to a dictionary of all pending CaptureJobs. The
+            dictionary is generated from the database the first time but then stored in the cache for faster access.
+            If a caller updates pending CaptureJobs in the database, it should also update the cache.
+            Any changes to the dictionary made by the caller will be saved back to the cache.
+
+            Example usage:
+
+                with CaptureJob.get_job_queues() as job_queues:
+                    # do atomic-access stuff with job_queues
+
+            job_queues format:
+
+                  {'human': {
+                      <user_id>: {
+                          'last_job_time':<CaptureJob.capture_start_time as integer>,
+                          'next_jobs':[<CaptureJob.pk>,<CaptureJob.pk>]
+                      },
+                      <user_id>: { ... },
+                   'robot':{ ... }
+                  }
+
+        """
+
+        with transaction.atomic():
+
+            # Use select_for_update on the first CaptureJob to claim a lock on the cache.
+            if cls.USE_LOCK:
+                lock_row = cls.objects.order_by('pk').select_for_update().first()
+
+            # try fetching queue from cache
+            job_queues = cache.get(CaptureJob.CACHE_KEY) if cls.USE_CACHE else None
+
+            # if not, regenerate cache
+            if job_queues is None:
+
+                # mark any captures as deleted where link has been deleted before capture
+                CaptureJob.objects.filter(link__user_deleted=True, status='pending').update(status='deleted')
+
+                # Grab all pending jobs in a dict by job type (human or robot) and user ID.
+                job_queues = {'human': {}, 'robot': {}}
+                pending_jobs = cls.objects.filter(status='pending').order_by('pk').select_related('link')
+                for job in pending_jobs:
+                    job.add_to_queue(job_queues)
+
+            yield job_queues
+
+            # optional delay, used solely for our concurrency tests
+            if cls.CACHE_DELAY:
+                time.sleep(cls.CACHE_DELAY)
+
+            # save any changes made by caller
+            if cls.USE_CACHE:
+                cache.set(CaptureJob.CACHE_KEY, job_queues)
+
+    def add_to_queue(self, job_queues):
+        """
+            Insert a single job in the appropriate queue.
+        """
+        job_type = 'human' if self.human else 'robot'
+        job_queue = job_queues[job_type]
+        user_id = self.link.created_by_id
+        if user_id not in job_queue:
+            last_job = CaptureJob.objects.filter(link__created_by_id=user_id).exclude(status='pending').order_by('-pk').first()
+            job_queue[user_id] = {
+                'next_jobs': [],
+                'last_job_time': last_job.capture_start_time.isoformat() if last_job else '0'
+            }
+        if self.pk not in job_queue[user_id]['next_jobs']:
+            job_queue[user_id]['next_jobs'].append(self.pk)
+
+    @classmethod
+    def sort_job_queue(cls, job_queue):
+        """
+            Sort users in a job queue by preference.
+        """
+        return sorted(
+            job_queue.iteritems(),
+            key=lambda x: (
+                x[1]['last_job_time'],  # whose previous job is oldest?
+                x[1]['next_jobs'][0])  # whose next job is oldest?
+        )
+
+    @classmethod
+    def get_next_job(cls, reserve=False):
+        """
+            Return the next job to work on, looking first at the human queue and then at the robot queue.
+
+            If `reserve=True`, mark the returned job with `status=in_progress` and remove from queue so the
+            same job can't be returned twice. Caller must make sure the job is actually processed once returned.
+        """
+        with cls.get_job_queues() as job_queues:
+
+            # look first at the human queue, or if that's empty at the robot queue
+            job_queue = job_queues['human'] or job_queues['robot']
+
+            if not job_queue:
+                return  # no jobs to process
+
+            next_user_id, next_user = cls.sort_job_queue(job_queue)[0]
+            next_job = cls.objects.get(pk=next_user['next_jobs'][0])
+
+            # mark the job as in_progress so we won't return it the next time this is called
+            if reserve:
+                # update db
+                next_job.status = 'in_progress'
+                next_job.capture_start_time = timezone.now()
+                next_job.save()
+
+                # update cache
+                next_user['next_jobs'].pop(0)
+                if next_user['next_jobs']:
+                    next_user['last_job_time'] = next_job.capture_start_time.isoformat()
+                else:
+                    del job_queue[next_user_id]
+
+            return next_job
+
+    def queue_position(self):
+        """
+            Search job_queues to calculate the queue position for this job -- how many pending jobs have to be processed
+            before this one?
+
+            Returns:
+                0 if job is not pending
+                -1 if job is pending but not in queue.
+        """
+        if self.status != 'pending':
+            return 0
+
+        # Grab the job queues and figure out which queue we're looking at -- human or robot
+        with self.get_job_queues() as job_queues:
+            pass
+        queue_position = 1
+        if self.human:
+            queue = job_queues['human']
+        else:
+            queue = job_queues['robot']
+
+            # if robot, count all of the human jobs that will have to be processed first
+            queue_position += sum(len(i['next_jobs']) for i in job_queues['human'].itervalues())
+
+        # make sure job is in queue
+        user_id = self.link.created_by_id
+        if user_id not in queue or self.pk not in queue[user_id]['next_jobs']:
+            # job isn't in queue
+            return -1
+
+        # Jobs are processed round-robin. First figure out which round this job will be in.
+        job_round = queue[user_id]['next_jobs'].index(self.pk)
+
+        # Next add all of the jobs that will be processed in previous rounds.
+        queue_position += sum(len(i['next_jobs'][:job_round]) for i in queue.itervalues())
+
+        # For the last round, this job will be reached partway through. Sort the jobs to find out which users will go
+        # first, and then add 1 for each user who will have jobs left in the final round and comes before this user.
+        sorted_jobs = self.sort_job_queue(queue)
+        sorted_user_ids = [i[0] for i in sorted_jobs]
+        queue_position += sum(1 for j in sorted_jobs[:sorted_user_ids.index(user_id)] if len(j[1]['next_jobs'])>job_round)
+
+        return queue_position
+
+    def mark_completed(self, status='completed'):
+        """
+            Record completion time and status for this job.
+        """
+        self.status = status
+        self.capture_end_time = timezone.now()
+        self.save(update_fields=['status', 'capture_end_time'])
 
 
 #########################

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -928,6 +928,11 @@ class CaptureJob(models.Model):
                 self.add_to_queue(job_queues)
 
     @classmethod
+    def clear_cache(cls):
+        """ Wipe the queue cache -- mostly useful for tests. """
+        cache.delete(cls.CACHE_KEY)
+
+    @classmethod
     @contextmanager
     def get_job_queues(cls):
         """

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -481,7 +481,8 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 
 CAPTURE_BROWSER = 'PhantomJS'  # or 'Chrome' or 'Firefox'
-
+# Default user agent is the Chrome on Linux that's most like PhantomJS 2.1.1.
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.37 Safari/537.36"
 
 ### Tastypie
 # http://django-tastypie.readthedocs.org/en/latest/settings.html

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -566,6 +566,10 @@ def proxy_capture(self, link_guid):
                 status='success',
                 content_type=content_type,
             )
+            save_fields(
+                link,
+                warc_size=default_storage.size(link.warc_storage_file())
+            )
             capture_job.mark_completed()
 
             # We only save the Capture for the favicon once the warc is stored,

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -31,12 +31,12 @@ from warcprox.controller import WarcproxController
 from warcprox.warcprox import WarcProxyHandler, WarcProxy, ProxyingRecorder
 from warcprox.warcwriter import WarcWriter, WarcWriterThread
 
-from django.utils import timezone
 from django.core.files.storage import default_storage
 from django.template.defaultfilters import truncatechars
 from django.conf import settings
+from django.utils import timezone
 
-from perma.models import WeekStats, MinuteStats, Registrar, LinkUser, Link, Organization, CDXLine, Capture
+from perma.models import WeekStats, MinuteStats, Registrar, LinkUser, Link, Organization, CDXLine, Capture, CaptureJob
 
 from perma.utils import run_task
 
@@ -131,6 +131,7 @@ def get_browser(user_agent, proxy_address, cert_path):
 def retry_on_error(func):
     """
         Decorator to catch any exceptions thrown by the given task and call retry().
+        Task must use bind=True.
     """
     @wraps(func)
     def with_retry(task, *args, **kwargs):
@@ -189,46 +190,67 @@ def parse_response(response_text):
 
 ### TASKS ##
 
+@shared_task
+def run_next_capture():
+    """ Grab and run the next CaptureJob. This will keep calling itself until there are no jobs left. """
+    capture_job = CaptureJob.get_next_job(reserve=True)
+    if not capture_job:
+        return  # no jobs waiting
+    proxy_capture.apply([capture_job.link_id])
+    run_task(run_next_capture.s())
+
+
 class ProxyCaptureTask(Task):
     """
-        After each call to proxy_capture, we check if it has failed more than max_retries times,
+        After each call to proxy_capture, we check if it has failed all of its retries,
         and if so mark pending captures as failed permanently.
     """
     abstract = True
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
-        if self.request.retries >= self.max_retries:
-            Capture.objects.filter(link_id=(args[0] if args else kwargs['link_guid']), status='pending').update(status='failed')
+        if self.request.retries == 0:
+            link_guid = args[0] if args else kwargs['link_guid']
+            Capture.objects.filter(link_id=link_guid, status='pending').update(status='failed')
+            CaptureJob.objects.get(link_id=link_guid).mark_completed('failed')
 
 @shared_task(bind=True,
-             default_retry_delay=30,  # seconds
-             max_retries=2,
-             base=ProxyCaptureTask)
+             base=ProxyCaptureTask,
+             # these have no effect, since this task is called synchronously via .apply()
+             #default_retry_delay=30,  # seconds
+             #max_retries=2,
+             )
 @retry_on_error
 @tempdir.run_in_tempdir()
-def proxy_capture(self, link_guid, user_agent=''):
+def proxy_capture(self, link_guid):
     """
-    start warcprox process. Warcprox is a MITM proxy server and needs to be running
-    before, during and after phantomjs gets a screenshot.
+    Start warcprox process. Warcprox is a MITM proxy server and needs to be running
+    before, during and after the headless browser.
 
-    Create an image from the supplied URL, write it to disk and update our asset model with the path.
-    The heavy lifting is done by PhantomJS, our headless browser.
+    Start a headless browser to capture the supplied URL. Also take a screenshot if the URL is an HTML file.
 
     This whole function runs with the local dir set to a temp dir by run_in_tempdir().
     So we can use local paths for temp files, and they'll just disappear when the function exits.
     """
+
     # basic setup
     link = Link.objects.get(guid=link_guid)
     target_url = link.safe_url
+    capture_job = link.capture_job
 
-    # allow pending tasks to be canceled outside celery by updating capture status
-    if link.primary_capture.status != "pending":
+    if link.user_deleted or link.primary_capture.status != "pending":
+        capture_job.mark_completed('deleted')
         return
 
-    # Override user_agent for now, since PhantomJS doesn't like some user agents.
-    # This user agent is the Chrome on Linux that's most like PhantomJS 2.1.1.
-    user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.37 Safari/537.36"
+    capture_job.attempt += 1
+    capture_job.save()
+
+    # Helper function to update capture_job's progress
+    def display_progress(step_count, step_description):
+        save_fields(capture_job, step_count=step_count, step_description=step_description)
+        print "%s step %s: %s" % (link_guid, step_count, step_description)
 
     print "%s: Fetching %s" % (link_guid, target_url)
+    progress = 0
+    display_progress(progress, "Starting capture")
 
     # suppress verbose warcprox logs
     logging.disable(logging.INFO)
@@ -278,7 +300,7 @@ def proxy_capture(self, link_guid, user_agent=''):
         # set up requests getter for one-off requests outside of selenium
         def proxied_get_request(url):
             return requests.get(url,
-                                headers={'User-Agent': user_agent},
+                                headers={'User-Agent': settings.CAPTURE_USER_AGENT},
                                 proxies={'http': 'http://' + proxy_address, 'https': 'http://' + proxy_address},
                                 verify=False)
 
@@ -297,8 +319,9 @@ def proxy_capture(self, link_guid, user_agent=''):
             display.start()
 
         # fetch page in the background
-        print "Fetching url."
-        browser = get_browser(user_agent, proxy_address, proxy.ca.ca_file)
+        progress += 1
+        display_progress(progress, "Fetching target URL")
+        browser = get_browser(settings.CAPTURE_USER_AGENT, proxy_address, proxy.ca.ca_file)
         browser.set_window_size(1024, 800)
 
         start_time = time.time()
@@ -324,8 +347,13 @@ def proxy_capture(self, link_guid, user_agent=''):
                     have_response = True
                     break
 
-            if time.time() - start_time > RESOURCE_LOAD_TIMEOUT:
+            wait_time = time.time() - start_time
+            if wait_time > RESOURCE_LOAD_TIMEOUT:
                 raise HaltCaptureException
+
+            progress = int(progress) + wait_time/RESOURCE_LOAD_TIMEOUT
+            display_progress(progress, "Fetching target URL")
+
             time.sleep(1)
 
         print "Finished fetching url."
@@ -389,7 +417,8 @@ def proxy_capture(self, link_guid, user_agent=''):
 
         if have_html:
             # get page title
-            print "Getting title."
+            progress = int(progress) + 1
+            display_progress(progress, "Getting page title")
             def get_title():
                 if browser.title:
                     save_fields(link, submitted_title=browser.title)
@@ -417,6 +446,8 @@ def proxy_capture(self, link_guid, user_agent=''):
 
             # scroll to bottom of page, in case that prompts anything else to load
             # TODO: This doesn't scroll horizontally or scroll frames
+            progress += .5
+            display_progress(progress, "Checking for scroll-loaded assets")
             def scroll_browser():
                 try:
                     scroll_delay = browser.execute_script("""
@@ -446,15 +477,19 @@ def proxy_capture(self, link_guid, user_agent=''):
             repeat_while_exception(scroll_browser)
 
         # make sure all requests are finished
-        print "Waiting for post-load requests."
+        progress = int(progress) + 1
+        display_progress(progress, "Waiting for post-load requests")
         start_time = time.time()
         time.sleep(1)
         while True:
             print "%s/%s finished" % (len(proxied_responses), len(proxied_requests))
             response_count = len(proxied_responses)
-            if time.time() - start_time > AFTER_LOAD_TIMEOUT:
+            wait_time = time.time() - start_time
+            if wait_time > AFTER_LOAD_TIMEOUT:
                 print "Waited %s seconds to finish post-load requests -- giving up." % AFTER_LOAD_TIMEOUT
                 break
+            progress = int(progress) + wait_time/AFTER_LOAD_TIMEOUT
+            display_progress(progress, "Waiting for post-load requests")
             time.sleep(.5)
             if response_count == len(proxied_requests):
                 break
@@ -477,7 +512,8 @@ def proxy_capture(self, link_guid, user_agent=''):
 
             # take screenshot after all requests done
             if capture_screenshot:
-                print "Taking screenshot."
+                progress += 1
+                display_progress(progress, "Taking screenshot")
                 screenshot_data = browser.get_screenshot_as_png()
                 link.screenshot_capture.write_warc_resource_record(screenshot_data)
                 save_fields(link.screenshot_capture, status='success')
@@ -517,13 +553,20 @@ def proxy_capture(self, link_guid, user_agent=''):
 
     # save generated warc file
     if have_warc:
-        print "Saving WARC."
+        progress += 1
+        display_progress(progress, "Saving web archive file")
         try:
             temp_warc_path = os.path.join(warc_writer.directory,
                                           warc_writer._f_finalname)
             with open(temp_warc_path, 'rb') as warc_file:
                 link.write_warc_raw_data(warc_file)
-                save_fields(link.primary_capture, status='success', content_type=content_type)
+
+            save_fields(
+                link.primary_capture,
+                status='success',
+                content_type=content_type,
+            )
+            capture_job.mark_completed()
 
             # We only save the Capture for the favicon once the warc is stored,
             # since the data for the favicon lives in the warc.
@@ -544,6 +587,7 @@ def proxy_capture(self, link_guid, user_agent=''):
         except Exception as e:
             print "Web Archive File creation failed for %s: %s" % (target_url, e)
             save_fields(link.primary_capture, status='failed')
+            capture_job.mark_completed('failed')
 
 
     print "%s capture done." % link_guid

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -207,7 +207,7 @@ class ProxyCaptureTask(Task):
     """
     abstract = True
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
-        if self.request.retries == 0:
+        if self.request.retries == 0 and status != 'SUCCESS':
             link_guid = args[0] if args else kwargs['link_guid']
             Capture.objects.filter(link_id=link_guid, status='pending').update(status='failed')
             CaptureJob.objects.get(link_id=link_guid).mark_completed('failed')

--- a/perma_web/perma/templates/docs/developer/index.html
+++ b/perma_web/perma/templates/docs/developer/index.html
@@ -1,5 +1,5 @@
 {% extends "base-responsive.html" %}
-{% load file_exists pipeline %}
+{% load pipeline %}
 {% block title %} | Developer Docs{% endblock %}
 
 {% block meta_description %}
@@ -19,25 +19,9 @@ Welcome to the Perma.cc developer guide.
 
 <div class="container cont-reading cont-fixed" id="developer-overview">
 	<div class="row">
-		<div class="col-sm-4 reading-toc" >
-			<ul>
-				<li class="reading-toc-chapter _active"><a href="#developer-overview">Overview</a></li>
-					<li class="reading-toc-section"><a href="#api-key">API Key</a></li>
-					<li class="reading-toc-section"><a href="#pagination">Pagination</a></li>
-					<li class="reading-toc-section"><a href="#jsonp">JSONP</a></li>
-					<li class="reading-toc-section"><a href="#examples-in-curl">Examples in cURL</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-public-archives">Public Archives</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-users">Users</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-archives">Archives</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-folders">Folders</a></li>
-			<ul>
-		</div>
+		{% include "docs/developer/toc.html" with section="overview" %}
 
 		<div class="col-sm-8 docs reading-body">
-			<div class="warning">
-				<i class="icon-exclamation-sign"></i>
-				<p class="body-text">The Perma.cc API is new and its behavior is in flux. We are currently seeking partners that want to build applications using this API. If you’re interested, <a href="{% url 'contact' %}">let’s chat</a>.</p>
-			</div>
 		
 			<h2 class="body-ah">API Overview</h2>
 			<p class="body-text">The Perma.cc API helps you create and manage archives without using your web browser.</p>
@@ -106,17 +90,7 @@ Welcome to the Perma.cc developer guide.
 
 <div class="container cont-reading cont-fixed" id="developer-public-archives">
 	<div class="row">
-		<div class="col-sm-4 reading-toc" >
-			<ul>
-				<li class="reading-toc-chapter"><a href="#developer-overview">Overview</a></li>
-				<li class="reading-toc-chapter _active"><a href="#developer-public-archives">Public Archives</a></li>
-					<li class="reading-toc-section"><a href="#get-all-public-archives">Get all public archives</a></li>
-					<li class="reading-toc-section"><a href="#get-one-archive">Get one archive</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-users">Users</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-archives">Archives</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-folders">Folders</a></li>
-			<ul>
-		</div>
+		{% include "docs/developer/toc.html" with section="public-archives" %}
 
 		<div class="col-sm-8 docs reading-body">
 		<h2 class="body-ah">Public Archives</h2>
@@ -141,20 +115,7 @@ Welcome to the Perma.cc developer guide.
 
 <div class="container cont-reading cont-fixed" id="developer-users">
 	<div class="row">
-		<div class="col-sm-4 reading-toc" >
-			<ul>
-				<li class="reading-toc-chapter"><a href="#developer-overview">Overview</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-public-archives">Public Archives</a></li>
-				<li class="reading-toc-chapter _active"><a href="#developer-users">Users</a></li>
-					<li class="reading-toc-section"><a href="#get-user-account-details">Get a user's account details</a></li>
-					<li class="reading-toc-section"><a href="#get-user-archives">Get a user's archives</a></li>
-					<li class="reading-toc-section"><a href="#get-user-folders">Get a user's folders</a></li>
-					<li class="reading-toc-section"><a href="#get-user-orgs">Get a user's organizations</a></li>
-					<li class="reading-toc-section"><a href="#get-user-shared-folders">Get a user's shared folders inside an organization</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-archives">Archives</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-folders">Folders</a></li>
-			<ul>
-		</div>
+		{% include "docs/developer/toc.html" with section="users" %}
 
 		<div class="col-sm-8 docs reading-body">
 			<h2 class="body-ah">Users</h2>
@@ -190,28 +151,20 @@ Welcome to the Perma.cc developer guide.
 			<pre>curl https://api.{{ request.get_host }}/v1/user/organizations/1/folders/?limit=1&api_key=your-api-key</pre>
 			<p class="body-text">Response.</p>
 			<pre class="prettyprint">{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 1}, "objects": [{"id": 27, "name": "Test Journal", "parent": null}]}</pre>
+
+      <h3 id="get-user-capture-jobs" class="body-bh">Get a user's ongoing capture jobs</h3>
+      <p class="body-text">List all of a user's pending or in_progress capture jobs.</p>
+      <pre>curl -v https://api.{{ request.get_host }}/v1/capture_jobs/?api_key=your-api-key</pre>
+
+			<p class="body-text">View capture status for a particular archive by GUID.</p>
+		  <pre>curl -v https://api.{{ request.get_host }}/v1/capture_jobs/ABCD-1234/?api_key=your-api-key</pre>
 		</div>
 	</div>
 </div>
 
 <div class="container cont-reading cont-fixed" id="developer-archives">
 	<div class="row">
-		<div class="col-sm-4 reading-toc" >
-			<ul>
-				<li class="reading-toc-chapter"><a href="#developer-overview">Overview</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-public-archives">Public Archives</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-users">Users</a></li>
-				<li class="reading-toc-chapter _active"><a href="#developer-archives">Archives</a></li>
-						<li class="reading-toc-section"><a href="#create-an-archive">Create an archive</a></li>
-						<li class="reading-toc-section"><a href="#view-details-of-one-archive">View the details of one archive</a></li>
-						<li class="reading-toc-section"><a href="#view-all-archives-of-one-user">View all archives associated with one user</a></li>
-						<li class="reading-toc-section"><a href="#move-to-dark-archive">Place an archive in the dark archive</a></li>
-						<li class="reading-toc-section"><a href="#edit-title-and-notes">Edit the title and notes fields of an archive</a></li>
-						<li class="reading-toc-section"><a href="#move-archive">Move an archive</a></li>
-						<li class="reading-toc-section"><a href="#delete-archive">Delete an archive</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-folders">Folders</a></li>
-			<ul>
-		</div>
+		{% include "docs/developer/toc.html" with section="archives" %}
 
 		<div class="col-sm-8 docs reading-body">
 			<h2 class="body-ah">Archives</h2>
@@ -264,20 +217,7 @@ Welcome to the Perma.cc developer guide.
 
 <div class="container cont-reading cont-fixed" id="developer-folders">
 	<div class="row">
-		<div class="col-sm-4 reading-toc" >
-			<ul>
-				<li class="reading-toc-chapter"><a href="#developer-overview">Overview</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-public-archives">Public Archives</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-users">Users</a></li>
-				<li class="reading-toc-chapter"><a href="#developer-archives">Archives</a></li>
-				<li class="reading-toc-chapter _active"><a href="#developer-folders">Folders</a></li>
-						<li class="reading-toc-section"><a href="#create-folder">Create a folder</a></li>
-						<li class="reading-toc-section"><a href="#view-folder-details">View a folder's details</a></li>
-						<li class="reading-toc-section"><a href="#rename-folder">Rename a folder</a></li>
-						<li class="reading-toc-section"><a href="#move-folder">Move a folder</a></li>
-						<li class="reading-toc-section"><a href="#delete-folder">Delete a folder</a></li>
-			<ul>
-		</div>
+		{% include "docs/developer/toc.html" with section="folders" %}
 
 		<div class="col-sm-8 docs reading-body">
 			<h2 class="body-ah">Folders</h2>
@@ -314,6 +254,27 @@ Welcome to the Perma.cc developer guide.
 			<pre>curl -X DELETE https://api.{{ request.get_host }}/v1/folders/36/?api_key=your-api-key</pre>
 			<p class="body-text">This command deleted folder 36. There will be no content in the HTTP response. You will see the a 204 HTTP status code returned.</p>
 			<pre class="prettyprint">No response. HTTP status will be 204.</pre>
+		</div>
+	</div>
+</div>
+
+<div class="container cont-reading cont-fixed" id="developer-capture-jobs">
+  <div class="row">
+    {% include "docs/developer/toc.html" with section="capture-jobs" %}
+
+		<div class="col-sm-8 docs reading-body">
+			<h2 class="body-ah">Capture Jobs</h2>
+
+      <p class="body-text">The Capture Jobs API helps you monitor the capture progress of recently submitted links.</p>
+      <p class="body-text">The base resource for this API is <code>https://api.{{ request.get_host }}/v1/capture_jobs/</code></p>
+
+      <h3 id="list-pending-jobs" class="body-bh">List pending jobs</h3>
+      <p class="body-text">List all of your pending or in_progress capture jobs using a GET</p>
+      <pre>curl -v https://api.{{ request.get_host }}/v1/capture_jobs/?api_key=your-api-key</pre>
+
+			<h3 id="view-capture-details" class="body-bh">View capture job details</h3>
+			<p class="body-text">View capture status for a particular link by GUID using a GET.</p>
+		  <pre>curl -v https://api.{{ request.get_host }}/v1/capture_jobs/ABCD-1234/?api_key=your-api-key</pre>
 		</div>
 	</div>
 </div>

--- a/perma_web/perma/templates/docs/developer/index.html
+++ b/perma_web/perma/templates/docs/developer/index.html
@@ -258,27 +258,6 @@ Welcome to the Perma.cc developer guide.
 	</div>
 </div>
 
-<div class="container cont-reading cont-fixed" id="developer-capture-jobs">
-  <div class="row">
-    {% include "docs/developer/toc.html" with section="capture-jobs" %}
-
-		<div class="col-sm-8 docs reading-body">
-			<h2 class="body-ah">Capture Jobs</h2>
-
-      <p class="body-text">The Capture Jobs API helps you monitor the capture progress of recently submitted links.</p>
-      <p class="body-text">The base resource for this API is <code>https://api.{{ request.get_host }}/v1/capture_jobs/</code></p>
-
-      <h3 id="list-pending-jobs" class="body-bh">List pending jobs</h3>
-      <p class="body-text">List all of your pending or in_progress capture jobs using a GET</p>
-      <pre>curl -v https://api.{{ request.get_host }}/v1/capture_jobs/?api_key=your-api-key</pre>
-
-			<h3 id="view-capture-details" class="body-bh">View capture job details</h3>
-			<p class="body-text">View capture status for a particular link by GUID using a GET.</p>
-		  <pre>curl -v https://api.{{ request.get_host }}/v1/capture_jobs/ABCD-1234/?api_key=your-api-key</pre>
-		</div>
-	</div>
-</div>
-
 {% endblock %}
 
 {% block scripts %}

--- a/perma_web/perma/templates/docs/developer/toc.html
+++ b/perma_web/perma/templates/docs/developer/toc.html
@@ -1,0 +1,43 @@
+<div class="col-sm-4 reading-toc" >
+  <ul>
+    <li class="reading-toc-chapter{% if section == 'overview' %} _active{% endif %}"><a href="#developer-overview">Overview</a></li>
+    {% if section == 'overview' %}
+      <li class="reading-toc-section"><a href="#api-key">API Key</a></li>
+      <li class="reading-toc-section"><a href="#pagination">Pagination</a></li>
+      <li class="reading-toc-section"><a href="#jsonp">JSONP</a></li>
+      <li class="reading-toc-section"><a href="#examples-in-curl">Examples in cURL</a></li>
+    {% endif %}
+    <li class="reading-toc-chapter{% if section == 'public-archives' %} _active{% endif %}"><a href="#developer-public-archives">Public Archives</a></li>
+    {% if section == 'public-archives' %}
+      <li class="reading-toc-section"><a href="#get-all-public-archives">Get all public archives</a></li>
+      <li class="reading-toc-section"><a href="#get-one-archive">Get one archive</a></li>
+    {% endif %}
+    <li class="reading-toc-chapter{% if section == 'users' %} _active{% endif %}"><a href="#developer-users">Users</a></li>
+    {% if section == 'users' %}
+      <li class="reading-toc-section"><a href="#get-user-account-details">Get a user's account details</a></li>
+      <li class="reading-toc-section"><a href="#get-user-archives">Get a user's archives</a></li>
+      <li class="reading-toc-section"><a href="#get-user-folders">Get a user's folders</a></li>
+      <li class="reading-toc-section"><a href="#get-user-orgs">Get a user's organizations</a></li>
+      <li class="reading-toc-section"><a href="#get-user-shared-folders">Get a user's shared folders inside an organization</a></li>
+      <li class="reading-toc-section"><a href="#get-user-capture-jobs">Get a user's ongoing capture jobs</a></li>
+    {% endif %}
+    <li class="reading-toc-chapter{% if section == 'archives' %} _active{% endif %}"><a href="#developer-archives">Archives</a></li>
+    {% if section == 'archives' %}
+      <li class="reading-toc-section"><a href="#create-an-archive">Create an archive</a></li>
+      <li class="reading-toc-section"><a href="#view-details-of-one-archive">View the details of one archive</a></li>
+      <li class="reading-toc-section"><a href="#view-all-archives-of-one-user">View all archives associated with one user</a></li>
+      <li class="reading-toc-section"><a href="#move-to-dark-archive">Place an archive in the dark archive</a></li>
+      <li class="reading-toc-section"><a href="#edit-title-and-notes">Edit the title and notes fields of an archive</a></li>
+      <li class="reading-toc-section"><a href="#move-archive">Move an archive</a></li>
+      <li class="reading-toc-section"><a href="#delete-archive">Delete an archive</a></li>
+    {% endif %}
+    <li class="reading-toc-chapter{% if section == 'folders' %} _active{% endif %}"><a href="#developer-folders">Folders</a></li>
+    {% if section == 'folders' %}
+      <li class="reading-toc-section"><a href="#create-folder">Create a folder</a></li>
+      <li class="reading-toc-section"><a href="#view-folder-details">View a folder's details</a></li>
+      <li class="reading-toc-section"><a href="#rename-folder">Rename a folder</a></li>
+      <li class="reading-toc-section"><a href="#move-folder">Move a folder</a></li>
+      <li class="reading-toc-section"><a href="#delete-folder">Delete a folder</a></li>
+    {% endif %}
+  <ul>
+</div>

--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -13,21 +13,24 @@
 
   <script>
     $(function(){
-      function addSection(name, args){
+      function fillSection(name){
+        return $.getJSON(document.location + '/' + name).then(function (data) {
+          $('#' + name).html(templates[name](data));
+        });
+      }
+
+      function addSection(name){
         $('.stats-container').append('<div class="row" id="'+name+'">Loading '+name+' ...</div>');
-        return function() {
-          console.log(name, args);
-          args = args || {};
-          return $.getJSON(document.location + '/' + name, args).then(function (data) {
-            $('#' + name).html(templates[name](data));
-          });
-        };
+        return function() { fillSection(name) };
       }
 
       chain = $.when(addSection("random")());
       chain = chain.then(addSection("days"));
       chain = chain.then(addSection("emails"));
+      chain = chain.then(addSection("job_queue"));
       chain = chain.then(addSection("celery"));
+
+      setInterval(function(){ fillSection("job_queue")}, 2000);
     });
   </script>
 {% endblock %}
@@ -81,8 +84,35 @@
       </div>
     </script>
 
+    <script id="job_queue-template" type="text/x-handlebars-template">
+    <h3 class="body-ah">Capture jobs:</h3>
+    <div class="row">
+      <div class="col-sm-4">
+        <h4>In progress:</h4>
+        {{#each active_jobs}}
+          {{ link_id }} attempt {{ attempt }}<br/>
+          {{ email }}<br/>
+          Started {{ capture_start_time }}<br/>
+          Step {{ step_count }}: {{ step_description }}<br/><br/>
+        {{/each}}
+      </div>
+      <div class="col-sm-4">
+        <h4>Human requests:</h4>
+        {{#each job_queues.human }}
+          {{ email }}: {{ count }}
+        {{/each}}
+      </div>
+      <div class="col-sm-4">
+        <h4>API requests:</h4>
+        {{#each job_queues.robot }}
+          User {{@key}}: {{this}} waiting
+        {{/each}}
+      </div>
+    </div>
+  </script>
+
     <script id="celery-template" type="text/x-handlebars-template">
-      <h3 class="body-ah">Celery queues:</h3>
+      <h3 class="body-ah">Celery task data:</h3>
       <div class="row">
         {{#each queues}}
           <div class="col-sm-6">

--- a/perma_web/perma/tests/test_capture_job.py
+++ b/perma_web/perma/tests/test_capture_job.py
@@ -1,0 +1,84 @@
+import time
+from multiprocessing.pool import ThreadPool
+
+from perma.models import *
+
+from .utils import PermaTestCase
+
+# TODO:
+# - check retry behavior
+
+def create_capture_job(user, human=True):
+    link = Link(created_by=user, submitted_url="http://example.com")
+    link.save()
+    capture_job = CaptureJob(link=link, human=human)
+    capture_job.save()
+    return capture_job
+
+class CaptureJobTestCase(PermaTestCase):
+
+    fixtures = [
+        'fixtures/users.json',
+        'fixtures/folders.json',
+    ]
+
+    def setUp(self):
+        super(CaptureJobTestCase, self).setUp()
+
+        self.user_one = LinkUser.objects.get(pk=1)
+        self.user_two = LinkUser.objects.get(pk=2)
+        self.maxDiff = None
+
+    ### HELPERS ###
+
+    def assertNextJobsMatch(self, expected_next_jobs, expected_order):
+        expected_next_jobs = [expected_next_jobs[i] for i in expected_order]
+        def get_next_job(i):
+            time.sleep(i*.1)  # make sure tasks go into queue in order, so we can check results
+            return CaptureJob.get_next_job(reserve=True)
+        next_jobs = ThreadPool(len(expected_next_jobs)).map(get_next_job, range(len(expected_next_jobs)))
+        self.assertListEqual(next_jobs, expected_next_jobs)
+
+    ### TESTS ###
+
+    def test_job_queue_order(self):
+        """ Jobs should be processed round-robin, one per user. """
+        jobs = [
+            create_capture_job(self.user_one),
+            create_capture_job(self.user_one),
+            create_capture_job(self.user_one),
+            create_capture_job(self.user_two),
+
+            create_capture_job(self.user_two, human=False),
+
+            create_capture_job(self.user_one),
+            create_capture_job(self.user_one),
+            create_capture_job(self.user_one),
+            create_capture_job(self.user_two),
+        ]
+
+        expected_order = [
+            0, 3,  # u1, u2
+            1, 8,  # u1, u2
+            2, 5, 6, 7,  # remaining u1 jobs
+            4  # robots queue
+        ]
+
+        for i, job in enumerate(jobs):
+            queue_position = job.queue_position()
+            expected_queue_position = expected_order.index(i)+1
+            self.assertEqual(queue_position, expected_queue_position, "Job %s has queue position %s, should be %s." % (i, queue_position, expected_queue_position))
+
+        CaptureJob.CACHE_DELAY = .2  # add delay to smoke out concurrency issues
+        self.assertNextJobsMatch(jobs, expected_order)
+
+    def test_job_queue_order_fails_without_lock(self):
+        """
+            If locking is disabled, our job_queue_order test should fail -- this makes sure our concurrency protection
+            is actually working.
+        """
+        temp = CaptureJob.USE_LOCK
+        CaptureJob.USE_LOCK = False
+        self.assertRaisesRegexp(AssertionError, r'^Lists differ', self.test_job_queue_order)
+        CaptureJob.USE_LOCK = temp
+

--- a/perma_web/perma/tests/test_capture_job.py
+++ b/perma_web/perma/tests/test_capture_job.py
@@ -27,7 +27,10 @@ class CaptureJobTestCase(PermaTestCase):
 
         self.user_one = LinkUser.objects.get(pk=1)
         self.user_two = LinkUser.objects.get(pk=2)
-        self.maxDiff = None
+
+        self.maxDiff = None  # let assertListEqual compare large lists
+
+        CaptureJob.clear_cache()  # reset cache (test cases don't reset cache keys automatically)
 
     ### HELPERS ###
 
@@ -43,6 +46,7 @@ class CaptureJobTestCase(PermaTestCase):
 
     def test_job_queue_order(self):
         """ Jobs should be processed round-robin, one per user. """
+
         jobs = [
             create_capture_job(self.user_one),
             create_capture_job(self.user_one),


### PR DESCRIPTION
This pull req creates a custom queue for our background capture jobs, stored in a separate model called CaptureJob with a one-to-one relationship to Link.

Changes:

- Jobs are processed round-robin, one per user, so a single user can't flood the queue.
- Jobs submitted from the website are processed before jobs submitted from the API. (API users can join the human queue by passing `human=1`, which could make sense if there's a human waiting for that particular capture -- sort of an honor system thing.)
- CaptureJob tracks start time, end time, and attempts, so we can measure how fast we are for captures and how long people are waiting in the queue.
- CaptureJob tracks current capture status, so we can show a real-time progress bar to users waiting for a capture. We can also show where a user is in the queue, if their capture hasn't started yet. (This pull does include the progress bar in the UI, but doesn't include showing users their queue position. The JS has a place where we could add it.)
- Admins can see the entire upcoming queue on the admin stats page.
- Capture process no longer throws an error if a link is deleted before the capture can begin.
- API users can fetch a list of all their pending captures.
- Link model now tracks warc file size.
- Refactor developer docs a bit so it's easier to update the table of contents.

FOR REVIEW:

It was too tricky to break all of this out into separate pull requests, but the commits are broken out into a generally sensible order for reviewing the changes -- so it might be easiest to look at each commit separately, rather than the sum of the changes.