### PR TITLE
Set initial link_id length to 255

### DIFF
--- a/perma_web/perma/migrations/0001_initial.py
+++ b/perma_web/perma/migrations/0001_initial.py
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('urlkey', models.CharField(max_length=2100)),
                 ('raw', models.TextField()),
-                ('link_id', models.CharField(max_length=2100, null=True, db_index=True)),
+                ('link_id', models.CharField(max_length=255, null=True, db_index=True)),
 
             ],
         ),


### PR DESCRIPTION
Link_id only needs to be 255, not 2100. This avoids the 'Specified key was too long; max key length is 767 bytes' error on new databases.

Putting this in the initial migration because I’m not sure we want to apply it to prod — might take a zillion years to run.

Fixes #1501