### PR TITLE
Fix email template

### DIFF
--- a/perma_web/perma/templates/email/user_added_to_registrar.txt
+++ b/perma_web/perma/templates/email/user_added_to_registrar.txt
@@ -1,5 +1,5 @@
-TITLE: Your Perma.cc account is now associated with {{ registrar }}
+TITLE: Your Perma.cc account is now associated with {{ form.cleaned_data.registrar }}
 
-Your Perma.cc account has been associated with {{ registrar }}.  You now manage all organizations under your registrar.  If this is a mistake, visit your account settings page to leave this registrar.
+Your Perma.cc account has been associated with {{ form.cleaned_data.registrar }}.  You now manage all organizations under your registrar.  If this is a mistake, visit your account settings page to leave this registrar.
 
 {{ account_settings_page }}


### PR DESCRIPTION
Registrar-upgraded email template in my last pull wasn’t filling in the registrar name properly, d’oh.