### PR TITLE
internet archive metadata + status fixes

### DIFF
--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -541,7 +541,7 @@ class LinkResource(AuthenticatedLinkResource):
 
         bundle.obj.safe_delete()
         bundle.obj.save()
-        if bundle.obj.uploaded_to_internet_archive:
+        if bundle.obj.internet_archive_upload_status == 'completed':
             run_task(delete_from_internet_archive.s(link_guid=bundle.obj.guid))
 
     ###

--- a/perma_web/perma/migrations/0006_add_internetarchive_status.py
+++ b/perma_web/perma/migrations/0006_add_internetarchive_status.py
@@ -5,39 +5,24 @@ from django.db import migrations, models
 
 def update_upload_to_ia_field(apps, schema_editor):
     Link = apps.get_model('perma', 'Link')
-    for link in Link.objects.all():
-        if link.uploaded_to_internet_archive:
-            link.internet_archive_upload_status = 'completed'
-        elif not link.uploaded_to_internet_archive:
-            link.internet_archive_upload_status = 'not_started'
-
-        link.save()
-
+    Link.objects.filter(uploaded_to_internet_archive=True).update(internet_archive_upload_status='completed')
+    Link.objects.filter(uploaded_to_internet_archive=False).update(internet_archive_upload_status='not_started')
     HistoricalLink = apps.get_model('perma','HistoricalLink')
-    for hlink in HistoricalLink.objects.all():
-        if hlink.uploaded_to_internet_archive:
-            hlink.internet_archive_upload_status = 'completed'
-        elif not hlink.uploaded_to_internet_archive:
-            hlink.internet_archive_upload_status = 'not_started'
-
-        hlink.save()
-
+    HistoricalLink.objects.filter(uploaded_to_internet_archive=True).update(internet_archive_upload_status='completed')
+    HistoricalLink.objects.filter(uploaded_to_internet_archive=False).update(internet_archive_upload_status='not_started')
 
 def reverse_update_upload_to_ia_field(apps, schema_editor):
     Link = apps.get_model('perma', 'Link')
-    for link in Link.objects.all():
-        if link.internet_archive_upload_status == 'completed':
-            link.uploaded_to_internet_archive = True
-        else:
-            link.uploaded_to_internet_archive = False
-    link.save()
-    HistoricalLink = apps.get_model('perma', 'Link')
-    for hlink in HistoricalLink.objects.all():
-        if hlink.internet_archive_upload_status == 'completed':
-            hlink.uploaded_to_internet_archive = True
-        else:
-            hlink.uploaded_to_internet_archive = False
-    hlink.save()
+    Link.objects.filter(internet_archive_upload_status='completed').update(uploaded_to_internet_archive=True)
+    Link.objects.filter(
+        Q(internet_archive_upload_status='deleted') | Q(internet_archive_upload_status='not_started') | Q(internet_archive_upload_status='failed') | Q(internet_archive_upload_status='failed_permanently')
+        ).update(uploaded_to_internet_archive=False)
+
+    HistoricalLink = apps.get_model('perma', 'HistoricalLink')
+    HistoricalLink.objects.filter(internet_archive_upload_status='completed').update(uploaded_to_internet_archive=True)
+    HistoricalLink.objects.filter(
+        Q(internet_archive_upload_status='deleted') | Q(internet_archive_upload_status='not_started') | Q(internet_archive_upload_status='failed') | Q(internet_archive_upload_status='failed_permanently')
+        ).update(uploaded_to_internet_archive=False)
 
 class Migration(migrations.Migration):
 
@@ -49,12 +34,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='historicallink',
             name='internet_archive_upload_status',
-            field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
+            field=models.CharField(default=b'not_started', max_length=20, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
         ),
         migrations.AddField(
             model_name='link',
-            name='internet_archive_upload_status',
-            field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
+            name='internet_arc\hive_upload_status',
+            field=models.CharField(default=b'not_started', max_length=20, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
         ),
 
         migrations.RunPython(update_upload_to_ia_field, reverse_code=reverse_update_upload_to_ia_field),

--- a/perma_web/perma/migrations/0006_add_internetarchive_status.py
+++ b/perma_web/perma/migrations/0006_add_internetarchive_status.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='link',
-            name='internet_arc\hive_upload_status',
+            name='internet_archive_upload_status',
             field=models.CharField(default=b'not_started', max_length=20, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
         ),
 

--- a/perma_web/perma/migrations/0006_add_internetarchive_status.py
+++ b/perma_web/perma/migrations/0006_add_internetarchive_status.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+def update_upload_to_ia_field(apps, schema_editor):
+    Link = apps.get_model('perma', 'Link')
+    for link in Link.objects.all():
+        if link.uploaded_to_internet_archive:
+            link.internet_archive_upload_status = 'completed'
+        elif not link.uploaded_to_internet_archive:
+            link.internet_archive_upload_status = 'not_started'
+
+        link.save()
+
+    HistoricalLink = apps.get_model('perma','HistoricalLink')
+    for hlink in HistoricalLink.objects.all():
+        if hlink.uploaded_to_internet_archive:
+            hlink.internet_archive_upload_status = 'completed'
+        elif not hlink.uploaded_to_internet_archive:
+            hlink.internet_archive_upload_status = 'not_started'
+
+        hlink.save()
+
+
+def reverse_update_upload_to_ia_field(apps, schema_editor):
+    Link = apps.get_model('perma', 'Link')
+    for link in Link.objects.all():
+        if link.internet_archive_upload_status == 'completed':
+            link.uploaded_to_internet_archive = True
+        else:
+            link.uploaded_to_internet_archive = False
+    link.save()
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('perma', '0005_auto_20160513_2006'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicallink',
+            name='internet_archive_upload_status',
+            field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
+        ),
+        migrations.AddField(
+            model_name='link',
+            name='internet_archive_upload_status',
+            field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
+        ),
+
+        migrations.RunPython(update_upload_to_ia_field, reverse_code=reverse_update_upload_to_ia_field),
+
+        migrations.RemoveField(
+            model_name='historicallink',
+            name='uploaded_to_internet_archive',
+        ),
+        migrations.RemoveField(
+            model_name='link',
+            name='uploaded_to_internet_archive',
+        ),
+
+     ]
+# class Migration(migrations.Migration):
+#
+#     dependencies = [
+#         ('perma', '0006_add_internetarchive_status'),
+#     ]
+#
+#     operations = [
+#         migrations.RemoveField(
+#             model_name='historicallink',
+#             name='uploaded_to_internet_archive',
+#         ),
+#         migrations.RemoveField(
+#             model_name='link',
+#             name='uploaded_to_internet_archive',
+#         ),
+#         migrations.AddField(
+#             model_name='historicallink',
+#             name='internet_archive_upload_status',
+#             field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
+#         ),
+#         migrations.AddField(
+#             model_name='link',
+#             name='internet_archive_upload_status',
+#             field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
+#         ),
+#     ]

--- a/perma_web/perma/migrations/0006_add_internetarchive_status.py
+++ b/perma_web/perma/migrations/0006_add_internetarchive_status.py
@@ -31,6 +31,14 @@ def reverse_update_upload_to_ia_field(apps, schema_editor):
         else:
             link.uploaded_to_internet_archive = False
     link.save()
+    HistoricalLink = apps.get_model('perma', 'Link')
+    for hlink in HistoricalLink.objects.all():
+        if hlink.internet_archive_upload_status == 'completed':
+            hlink.uploaded_to_internet_archive = True
+        else:
+            hlink.uploaded_to_internet_archive = False
+    hlink.save()
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -61,29 +69,3 @@ class Migration(migrations.Migration):
         ),
 
      ]
-# class Migration(migrations.Migration):
-#
-#     dependencies = [
-#         ('perma', '0006_add_internetarchive_status'),
-#     ]
-#
-#     operations = [
-#         migrations.RemoveField(
-#             model_name='historicallink',
-#             name='uploaded_to_internet_archive',
-#         ),
-#         migrations.RemoveField(
-#             model_name='link',
-#             name='uploaded_to_internet_archive',
-#         ),
-#         migrations.AddField(
-#             model_name='historicallink',
-#             name='internet_archive_upload_status',
-#             field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
-#         ),
-#         migrations.AddField(
-#             model_name='link',
-#             name='internet_archive_upload_status',
-#             field=models.CharField(default=b'not_started', max_length=15, choices=[(b'not_started', b'not_started'), (b'completed', b'completed'), (b'failed', b'failed'), (b'failed_permanently', b'failed_permanently'), (b'deleted', b'deleted')]),
-#         ),
-#     ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -493,7 +493,10 @@ class Link(DeletableModel):
     organization = models.ForeignKey(Organization, null=True, blank=True, related_name='links')
     folders = models.ManyToManyField(Folder, related_name='links', blank=True)
     notes = models.TextField(blank=True)
-    uploaded_to_internet_archive = models.BooleanField(default=False)
+    internet_archive_upload_status = models.CharField(max_length=20,
+                                                      default='not_started',
+                                                      choices=(('not_started','not_started'),('completed','completed'),('failed','failed'),('failed_permanently','failed_permanently'),('deleted','deleted')))
+
     warc_size = models.IntegerField(blank=True, null=True)
 
     is_private = models.BooleanField(default=False)

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -741,6 +741,17 @@ def upload_to_internet_archive(self, link_guid):
 
     identifier = settings.INTERNET_ARCHIVE_IDENTIFIER_PREFIX + link_guid
     if default_storage.exists(link.warc_storage_file()):
+        item = internetarchive.get_item(identifier)
+
+        # if item already exists (but has been removed),
+        # ia won't update its metadata in upload function
+        if item.exists and item.metadata['title'] == 'Removed':
+            item.modify_metadata(metadata,
+                access_key=settings.INTERNET_ARCHIVE_ACCESS_KEY,
+                secret_key=settings.INTERNET_ARCHIVE_SECRET_KEY,
+            )
+
+
         with default_storage.open(link.warc_storage_file(), 'rb') as warc_file:
             success = internetarchive.upload(
                             identifier,

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -35,6 +35,7 @@ from django.core.files.storage import default_storage
 from django.template.defaultfilters import truncatechars
 from django.conf import settings
 from django.utils import timezone
+from django.db.models import Q
 
 from perma.models import WeekStats, MinuteStats, Registrar, LinkUser, Link, Organization, CDXLine, Capture, CaptureJob
 
@@ -686,7 +687,7 @@ def delete_from_internet_archive(self, link_guid):
             secret_key=settings.INTERNET_ARCHIVE_SECRET_KEY,
         )
 
-    link.uploaded_to_internet_archive = False
+    link.internet_archive_upload_status = 'deleted'
     link.save()
 
 @shared_task()
@@ -696,7 +697,7 @@ def upload_all_to_internet_archive():
     start_date = timezone.now() - timedelta(days=2)
     end_date   = timezone.now() - timedelta(days=1)
 
-    links = Link.objects.filter(uploaded_to_internet_archive=False, creation_timestamp__range=(start_date, end_date))
+    links = Link.objects.filter(Q(internet_archive_upload_status='not_started') | Q(internet_archive_upload_status='failed'), creation_timestamp__range=(start_date, end_date))
     for link in links:
         if link.can_upload_to_internet_archive():
             run_task(upload_to_internet_archive.s(link_guid=link.guid))
@@ -706,6 +707,10 @@ def upload_all_to_internet_archive():
 def upload_to_internet_archive(self, link_guid):
     try:
         link = Link.objects.get(guid=link_guid)
+
+        if link.internet_archive_upload_status == 'failed_permanently':
+            return
+
     except:
         print "Link %s does not exist" % link_guid
         return
@@ -735,7 +740,7 @@ def upload_to_internet_archive(self, link_guid):
 
 
     identifier = settings.INTERNET_ARCHIVE_IDENTIFIER_PREFIX + link_guid
-    try:
+    if default_storage.exists(link.warc_storage_file()):
         with default_storage.open(link.warc_storage_file(), 'rb') as warc_file:
             success = internetarchive.upload(
                             identifier,
@@ -748,15 +753,14 @@ def upload_to_internet_archive(self, link_guid):
                             verbose=True,
                         )
             if success:
-                link.uploaded_to_internet_archive = True
+                link.internet_archive_upload_status = 'completed'
                 link.save()
 
             else:
+                link.internet_archive_upload_status = 'failed'
                 self.retry(exc=Exception("Internet Archive reported upload failure."))
-                print "Failed."
 
             return success
-
-    except IOError, e:
-        print e.errno
-        return
+    else:
+        link.internet_archive_upload_status = 'failed_permanently'
+        link.save()


### PR DESCRIPTION
- we're now storing ia upload status on link models
- retrying to upload if warc exists but ia upload failed for some reason
- not retrying if warc does not exist (marking link as failed permanently)
- if archive WAS uploaded but later was deleted (made private, for instance), only the file was getting reuploaded. the metadata was not. this is now fixed — we're checking if item exists and then applying "modify_metadata" method if it's been "Removed".
I think we might need to think a little more about how we're dealing with IA. If a warc has failed to be created, do we want the metadata stored somewhere? What are all the edge cases, do we do a good job in keeping perma archives and internet archive archives in sync?
