### PR TITLE
Js unit tests

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -76,6 +76,13 @@ def logs(log_dir=os.path.join(settings.PROJECT_ROOT, '../services/logs/')):
     """ Tail all logs. """
     local("tail -f %s/*" % log_dir)
 
+@task
+def jasmine():
+    """
+        Run frontend unit tests.
+        Go to 0.0.0.0:8888 in your browser to see the output.
+    """
+    local("jasmine -o 0.0.0.0 -p 8888")
 
 @task
 def init_db():

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -108,6 +108,7 @@ PIPELINE_JS = {
             'js/error-handler.js',
             'js/helpers/polyfill/string.trim.js',
             'js/helpers/general.helpers.js',
+            'js/helpers/dom.helpers.js',
             'js/global.setup.js',
         ),
         'output_filename': 'js/global-bundle.js',

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -10,9 +10,10 @@ django-ratelimit==0.3.0
 simplejson==3.3.0
 oauth2==1.5.211
 smhasher==0.150.1
+jasmine==2.4.0
 pytz==2013b
 django-mptt==0.8.0
-Werkzeug==0.9.4
+Werkzeug==0.11.1
 Fabric==1.11.1
 pexpect==3.1
 coverage==3.7.1

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -11,13 +11,15 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 apipkg==1.4               # via execnet
 argh==0.26.1              # via watchdog
+argparse==1.4.0           # via jasmine
 args==0.1.0               # via clint
 billiard==3.3.0.23        # via celery
 boto==2.29.1
 celery==3.1.20
 certauth==1.1.3
 cffi==1.6.0               # via cryptography
-chardet==2.3.0            # via pywb
+chardet==2.3              # via jasmine, pywb
+CherryPy==3.8.2           # via jasmine
 click==6.6                # via pip-tools
 clint==0.5.1              # via internetarchive
 coverage==3.7.1
@@ -44,15 +46,20 @@ enum34==1.1.4             # via cryptography, pyscss
 execnet==1.4.1            # via pytest-xdist
 Fabric==1.11.1
 first==2.0.1              # via pip-tools
+Flask==0.10.1             # via jasmine
 futures==3.0.5            # via django-pipeline
 gevent==1.0.2
+glob2==0.4.1              # via jasmine-core
 greenlet==0.4.9           # via gevent
 gunicorn==19.3.0
 httplib2==0.9.2           # via oauth2
 idna==2.1                 # via cryptography, tldextract
 internetarchive==1.0.2
 ipaddress==1.0.16         # via cryptography
-jinja2==2.8               # via pywb
+itsdangerous==0.24        # via flask
+jasmine-core==2.4.0       # via jasmine
+jasmine==2.4.0
+jinja2==2.8               # via flask, jasmine, pywb
 jsmin==2.0.9
 jsonpatch==0.4            # via internetarchive
 kombu==3.0.35             # via celery
@@ -63,6 +70,7 @@ MySQL-python==1.2.5
 ndg-httpsclient==0.4.0    # via requests
 netaddr==0.7.12
 oauth2==1.5.211
+ordereddict==1.1          # via jasmine-core
 paramiko==1.17.0          # via fabric
 pathlib==1.0.1            # via pyscss
 pathtools==0.1.2          # via watchdog
@@ -82,7 +90,7 @@ python-mimeparse==1.5.2   # via django-tastypie
 pytz==2013b0
 PyVirtualDisplay==0.1.5
 pywb==0.11.5
-PyYAML==3.11              # via pywb, watchdog
+PyYAML==3.10              # via jasmine, pywb, watchdog
 redis==2.10.1
 requests-file==1.4        # via tldextract
 requests[security]==2.10.0
@@ -90,7 +98,7 @@ sauceclient==0.1.0
 schema==0.4.0             # via internetarchive
 selenium==2.47.3
 simplejson==3.3.0
-six==1.10.0               # via cryptography, django-admin-smoke-tests, internetarchive, pip-tools, pyopenssl, pyscss, python-dateutil, requests-file
+six==1.10.0               # via cryptography, django-admin-smoke-tests, internetarchive, jasmine, pip-tools, pyopenssl, pyscss, python-dateutil, requests-file
 smhasher==0.150.1
 sorl-thumbnail==12.3
 surt==0.2
@@ -100,7 +108,7 @@ Wand==0.4
 warctools==4.9.0
 watchdog==0.8.3           # via pywb
 webencodings==0.4         # via pywb
-Werkzeug==0.9.4
+Werkzeug==0.11.1          # via flask, jasmine
 whitenoise==2.0.4
 wsgiref==0.1.2
 

--- a/perma_web/spec/javascripts/create.module.spec.js
+++ b/perma_web/spec/javascripts/create.module.spec.js
@@ -4,23 +4,96 @@ var current_user;
 describe("Test create.module.js", function() {
   beforeEach(function(){
     localStorage = {
-      setItem: function (key, val) {
-        this[key] = JSON.stringify(val);
+      setItem: function (key, val) { this[key] = val; },
       getItem: function (key) { return this[key]; }
     }
-    spyOn(localStorage, 'getItem').andReturn JSON.stringify({ 1: {"folderId":27,"orgId":1}})
   });
-  afterEach(function() {
-    localStorage = {}
-  });
-
-
   it("defines CreateModule", function(){
     expect(CreateModule).toBeDefined();
   });
-  describe("localStorage methods", function(){
+
+  describe("populateWithUrl", function(){
+    beforeEach(function(){
+      spyOn(DOMHelpers, "setInputValue");
+    });
+    it("returns the correct url when one exists", function(){
+      var intendedUrl = "http://research.uni.edu";
+      spyOn(Helpers, "getWindowLocationSearch").and.returnValue("?url="+intendedUrl);
+      var url = CreateModule.populateWithUrl();
+      expect(url).toEqual(intendedUrl);
+      expect(DOMHelpers.setInputValue).toHaveBeenCalled();
+    });
+    it("returns nothing when url does not exist", function(){
+      spyOn(Helpers, "getWindowLocationSearch").and.returnValue("");
+      var url = CreateModule.populateWithUrl();
+      expect(url).not.toBeDefined();
+      expect(DOMHelpers.setInputValue).not.toHaveBeenCalled();
+
+    })
+  });
+  describe("localStorage", function(){
+    /* ls related methods */
     it("defines ls", function(){
-      expect(ls).toBeDefined();
+      expect(CreateModule.ls).toBeDefined();
+    });
+    describe("getAll", function(){
+      it("returns set folders on getAll", function(){
+        var setFolders = {1:{"folderId":27, "orgId":4}};
+        spyOn(Helpers.localStorage, "getItem").and.returnValue(setFolders);
+        var folders = CreateModule.ls.getAll();
+        expect(folders).toEqual(setFolders);
+        expect(Helpers.localStorage.getItem).toHaveBeenCalled();
+      });
+      it("returns empty object if nothing is set", function(){
+        spyOn(Helpers.localStorage, "getItem").and.returnValue("");
+        var folders = CreateModule.ls.getAll();
+        expect(folders).toEqual({});
+      });
+    });
+
+    describe("getCurrent", function(){
+      it("returns current user folder settings when they exist", function(){
+        window.current_user = {id:1};
+        var setFolders = {1:{"folderId":27, "orgId":4}};
+        spyOn(Helpers.localStorage, "getItem").and.returnValue(setFolders);
+        var folders = CreateModule.ls.getCurrent();
+        expect(folders).toEqual(setFolders[1]);
+        expect(Helpers.localStorage.getItem).toHaveBeenCalled();
+      });
+      it("returns empty object when current user settings don't exist", function(){
+        window.current_user = {id:1};
+        var setFolders = {2:{"folderId":27, "orgId":4}};
+        spyOn(Helpers.localStorage, "getItem").and.returnValue(setFolders);
+        var folders = CreateModule.ls.getCurrent();
+        expect(folders).toEqual({});
+        expect(Helpers.localStorage.getItem).toHaveBeenCalled();
+      });
+    });
+    describe("setCurrent", function(){
+      beforeEach(function(){
+        spyOn(Helpers, "triggerOnWindow");
+        window.current_user = {id:1};
+        spyOn(CreateModule, "updateLinker");
+        spyOn(Helpers.localStorage, "setItem");
+      });
+      afterEach(function(){
+        delete window.current_user;
+      });
+      it("sets current user folderId and orgId when they exist", function(){
+        var orgId = 2, folderId = 37;
+
+        CreateModule.ls.setCurrent(orgId, folderId);
+        expect(Helpers.localStorage.setItem).toHaveBeenCalledWith("perma_selection",{1:{"folderId":folderId,"orgId":orgId}});
+        expect(CreateModule.updateLinker).toHaveBeenCalled();
+        expect(Helpers.triggerOnWindow).toHaveBeenCalledWith("dropdown.selectionChange");
+      });
+      it("sets current user folderId to default if none is provided", function(){
+        var orgId = 2;
+        CreateModule.ls.setCurrent(orgId);
+        expect(Helpers.localStorage.setItem).toHaveBeenCalledWith("perma_selection",{1:{"folderId":"default","orgId":orgId}});
+        expect(CreateModule.updateLinker).toHaveBeenCalled();
+        expect(Helpers.triggerOnWindow).toHaveBeenCalledWith("dropdown.selectionChange");
+      });
     });
   });
 });

--- a/perma_web/spec/javascripts/create.module.spec.js
+++ b/perma_web/spec/javascripts/create.module.spec.js
@@ -1,0 +1,26 @@
+var localStorage;
+var current_user;
+
+describe("Test create.module.js", function() {
+  beforeEach(function(){
+    localStorage = {
+      setItem: function (key, val) {
+        this[key] = JSON.stringify(val);
+      getItem: function (key) { return this[key]; }
+    }
+    spyOn(localStorage, 'getItem').andReturn JSON.stringify({ 1: {"folderId":27,"orgId":1}})
+  });
+  afterEach(function() {
+    localStorage = {}
+  });
+
+
+  it("defines CreateModule", function(){
+    expect(CreateModule).toBeDefined();
+  });
+  describe("localStorage methods", function(){
+    it("defines ls", function(){
+      expect(ls).toBeDefined();
+    });
+  });
+});

--- a/perma_web/spec/javascripts/create.module.spec.js
+++ b/perma_web/spec/javascripts/create.module.spec.js
@@ -2,12 +2,6 @@ var localStorage;
 var current_user;
 
 describe("Test create.module.js", function() {
-  beforeEach(function(){
-    localStorage = {
-      setItem: function (key, val) { this[key] = val; },
-      getItem: function (key) { return this[key]; }
-    }
-  });
   it("defines CreateModule", function(){
     expect(CreateModule).toBeDefined();
   });
@@ -28,8 +22,7 @@ describe("Test create.module.js", function() {
       var url = CreateModule.populateWithUrl();
       expect(url).not.toBeDefined();
       expect(DOMHelpers.setInputValue).not.toHaveBeenCalled();
-
-    })
+    });
   });
   describe("localStorage", function(){
     /* ls related methods */
@@ -94,6 +87,15 @@ describe("Test create.module.js", function() {
         expect(CreateModule.updateLinker).toHaveBeenCalled();
         expect(Helpers.triggerOnWindow).toHaveBeenCalledWith("dropdown.selectionChange");
       });
+    });
+  });
+  describe("updateLinksRemaining", function(){
+    it("changes links_remaining", function(){
+      spyOn(DOMHelpers, "changeText");
+      window.links_remaining = 10;
+      CreateModule.updateLinksRemaining(8);
+      expect(window.links_remaining).toEqual(8);
+      expect(DOMHelpers.changeText).toHaveBeenCalledWith('.links-remaining', 8);
     });
   });
 });

--- a/perma_web/spec/javascripts/error-handler.spec.js
+++ b/perma_web/spec/javascripts/error-handler.spec.js
@@ -1,0 +1,32 @@
+describe("Test error-handler.js", function() {
+  beforeEach(function() {
+    airbrake = undefined;
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
+  it("defines airbrake on init", function(){
+    expect(airbrake).not.toBeDefined();
+    ErrorHandler.init();
+    expect(airbrake).toBeDefined();
+  });
+
+  xit("triggers airbrake on error on window error", function(){
+    ErrorHandler.init();
+    expect(airbrake).toBeDefined();
+    spyOn(airbrake, "onerror");
+    try {
+      throw "Deliberate Error!";
+    } catch (e) {
+      expect(airbrake.onerror).toHaveBeenCalled();
+    }
+  });
+  xit("resolves error if it exist", function(){
+    ErrorHandler.init();
+    var newErrorObject = airbrake.notify("Horrible Mistake", {});
+    var result = ErrorHandler.resolve(1);
+  })
+});

--- a/perma_web/spec/javascripts/global.setup.spec.js
+++ b/perma_web/spec/javascripts/global.setup.spec.js
@@ -1,4 +1,4 @@
-describe("Test create.module.js", function() {
+describe("Test global.setup.js", function() {
   it("expects jquery to exist", function () {
     expect($).toBeDefined();
   });

--- a/perma_web/spec/javascripts/global.setup.spec.js
+++ b/perma_web/spec/javascripts/global.setup.spec.js
@@ -1,0 +1,9 @@
+describe("Test create.module.js", function() {
+  it("expects jquery to exist", function () {
+    expect($).toBeDefined();
+  });
+  // it("expects Helpers to be defined", function () {
+  //   expect(Helpers).toBeDefined();
+  // });
+
+});

--- a/perma_web/spec/javascripts/helpers/mock-ajax.js
+++ b/perma_web/spec/javascripts/helpers/mock-ajax.js
@@ -1,0 +1,751 @@
+/*
+
+Jasmine-Ajax - v3.2.0: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+//Module wrapper to support both browser and CommonJS environment
+(function (root, factory) {
+    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+        // CommonJS
+        var jasmineRequire = require('jasmine-core');
+        module.exports = factory(root, function() {
+            return jasmineRequire;
+        });
+    } else {
+        // Browser globals
+        window.MockAjax = factory(root, getJasmineRequireObj);
+    }
+}(typeof window !== 'undefined' ? window : global, function (global, getJasmineRequireObj) {
+
+// 
+getJasmineRequireObj().ajax = function(jRequire) {
+  var $ajax = {};
+
+  $ajax.RequestStub = jRequire.AjaxRequestStub();
+  $ajax.RequestTracker = jRequire.AjaxRequestTracker();
+  $ajax.StubTracker = jRequire.AjaxStubTracker();
+  $ajax.ParamParser = jRequire.AjaxParamParser();
+  $ajax.event = jRequire.AjaxEvent();
+  $ajax.eventBus = jRequire.AjaxEventBus($ajax.event);
+  $ajax.fakeRequest = jRequire.AjaxFakeRequest($ajax.eventBus);
+  $ajax.MockAjax = jRequire.MockAjax($ajax);
+
+  return $ajax.MockAjax;
+};
+
+getJasmineRequireObj().AjaxEvent = function() {
+  function now() {
+    return new Date().getTime();
+  }
+
+  function noop() {
+  }
+
+  // Event object
+  // https://dom.spec.whatwg.org/#concept-event
+  function XMLHttpRequestEvent(xhr, type) {
+    this.type = type;
+    this.bubbles = false;
+    this.cancelable = false;
+    this.timeStamp = now();
+
+    this.isTrusted = false;
+    this.defaultPrevented = false;
+
+    // Event phase should be "AT_TARGET"
+    // https://dom.spec.whatwg.org/#dom-event-at_target
+    this.eventPhase = 2;
+
+    this.target = xhr;
+    this.currentTarget = xhr;
+  }
+
+  XMLHttpRequestEvent.prototype.preventDefault = noop;
+  XMLHttpRequestEvent.prototype.stopPropagation = noop;
+  XMLHttpRequestEvent.prototype.stopImmediatePropagation = noop;
+
+  function XMLHttpRequestProgressEvent() {
+    XMLHttpRequestEvent.apply(this, arguments);
+
+    this.lengthComputable = false;
+    this.loaded = 0;
+    this.total = 0;
+  }
+
+  // Extend prototype
+  XMLHttpRequestProgressEvent.prototype = XMLHttpRequestEvent.prototype;
+
+  return {
+    event: function(xhr, type) {
+      return new XMLHttpRequestEvent(xhr, type);
+    },
+
+    progressEvent: function(xhr, type) {
+      return new XMLHttpRequestProgressEvent(xhr, type);
+    }
+  };
+};
+getJasmineRequireObj().AjaxEventBus = function(eventFactory) {
+  function EventBus(source) {
+    this.eventList = {};
+    this.source = source;
+  }
+
+  function ensureEvent(eventList, name) {
+    eventList[name] = eventList[name] || [];
+    return eventList[name];
+  }
+
+  function findIndex(list, thing) {
+    if (list.indexOf) {
+      return list.indexOf(thing);
+    }
+
+    for(var i = 0; i < list.length; i++) {
+      if (thing === list[i]) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  EventBus.prototype.addEventListener = function(event, callback) {
+    ensureEvent(this.eventList, event).push(callback);
+  };
+
+  EventBus.prototype.removeEventListener = function(event, callback) {
+    var index = findIndex(this.eventList[event], callback);
+
+    if (index >= 0) {
+      this.eventList[event].splice(index, 1);
+    }
+  };
+
+  EventBus.prototype.trigger = function(event) {
+    var evt;
+
+    // Event 'readystatechange' is should be a simple event.
+    // Others are progress event.
+    // https://xhr.spec.whatwg.org/#events
+    if (event === 'readystatechange') {
+      evt = eventFactory.event(this.source, event);
+    } else {
+      evt = eventFactory.progressEvent(this.source, event);
+    }
+
+    var eventListeners = this.eventList[event];
+
+    if (eventListeners) {
+      for (var i = 0; i < eventListeners.length; i++) {
+        eventListeners[i].call(this.source, evt);
+      }
+    }
+  };
+
+  return function(source) {
+    return new EventBus(source);
+  };
+};
+
+getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
+  function extend(destination, source, propertiesToSkip) {
+    propertiesToSkip = propertiesToSkip || [];
+    for (var property in source) {
+      if (!arrayContains(propertiesToSkip, property)) {
+        destination[property] = source[property];
+      }
+    }
+    return destination;
+  }
+
+  function arrayContains(arr, item) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] === item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function wrapProgressEvent(xhr, eventName) {
+    return function() {
+      if (xhr[eventName]) {
+        xhr[eventName].apply(xhr, arguments);
+      }
+    };
+  }
+
+  function initializeEvents(xhr) {
+    xhr.eventBus.addEventListener('readystatechange', wrapProgressEvent(xhr, 'onreadystatechange'));
+    xhr.eventBus.addEventListener('loadstart', wrapProgressEvent(xhr, 'onloadstart'));
+    xhr.eventBus.addEventListener('load', wrapProgressEvent(xhr, 'onload'));
+    xhr.eventBus.addEventListener('loadend', wrapProgressEvent(xhr, 'onloadend'));
+    xhr.eventBus.addEventListener('progress', wrapProgressEvent(xhr, 'onprogress'));
+    xhr.eventBus.addEventListener('error', wrapProgressEvent(xhr, 'onerror'));
+    xhr.eventBus.addEventListener('abort', wrapProgressEvent(xhr, 'onabort'));
+    xhr.eventBus.addEventListener('timeout', wrapProgressEvent(xhr, 'ontimeout'));
+  }
+
+  function unconvertibleResponseTypeMessage(type) {
+    var msg = [
+      "Can't build XHR.response for XHR.responseType of '",
+      type,
+      "'.",
+      "XHR.response must be explicitly stubbed"
+    ];
+    return msg.join(' ');
+  }
+
+  function fakeRequest(global, requestTracker, stubTracker, paramParser) {
+    function FakeXMLHttpRequest() {
+      requestTracker.track(this);
+      this.eventBus = eventBusFactory(this);
+      initializeEvents(this);
+      this.requestHeaders = {};
+      this.overriddenMimeType = null;
+    }
+
+    function findHeader(name, headers) {
+      name = name.toLowerCase();
+      for (var header in headers) {
+        if (header.toLowerCase() === name) {
+          return headers[header];
+        }
+      }
+    }
+
+    function normalizeHeaders(rawHeaders, contentType) {
+      var headers = [];
+
+      if (rawHeaders) {
+        if (rawHeaders instanceof Array) {
+          headers = rawHeaders;
+        } else {
+          for (var headerName in rawHeaders) {
+            if (rawHeaders.hasOwnProperty(headerName)) {
+              headers.push({ name: headerName, value: rawHeaders[headerName] });
+            }
+          }
+        }
+      } else {
+        headers.push({ name: "Content-Type", value: contentType || "application/json" });
+      }
+
+      return headers;
+    }
+
+    function parseXml(xmlText, contentType) {
+      if (global.DOMParser) {
+        return (new global.DOMParser()).parseFromString(xmlText, 'text/xml');
+      } else {
+        var xml = new global.ActiveXObject("Microsoft.XMLDOM");
+        xml.async = "false";
+        xml.loadXML(xmlText);
+        return xml;
+      }
+    }
+
+    var xmlParsables = ['text/xml', 'application/xml'];
+
+    function getResponseXml(responseText, contentType) {
+      if (arrayContains(xmlParsables, contentType.toLowerCase())) {
+        return parseXml(responseText, contentType);
+      } else if (contentType.match(/\+xml$/)) {
+        return parseXml(responseText, 'text/xml');
+      }
+      return null;
+    }
+
+    var iePropertiesThatCannotBeCopied = ['responseBody', 'responseText', 'responseXML', 'status', 'statusText', 'responseTimeout', 'responseURL'];
+    extend(FakeXMLHttpRequest.prototype, new global.XMLHttpRequest(), iePropertiesThatCannotBeCopied);
+    extend(FakeXMLHttpRequest.prototype, {
+      open: function() {
+        this.method = arguments[0];
+        this.url = arguments[1];
+        this.username = arguments[3];
+        this.password = arguments[4];
+        this.readyState = 1;
+        this.requestHeaders = {};
+        this.eventBus.trigger('readystatechange');
+      },
+
+      setRequestHeader: function(header, value) {
+        if(this.requestHeaders.hasOwnProperty(header)) {
+          this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
+        } else {
+          this.requestHeaders[header] = value;
+        }
+      },
+
+      overrideMimeType: function(mime) {
+        this.overriddenMimeType = mime;
+      },
+
+      abort: function() {
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = "abort";
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('abort');
+        this.eventBus.trigger('loadend');
+      },
+
+      readyState: 0,
+
+      onloadstart: null,
+      onprogress: null,
+      onabort: null,
+      onerror: null,
+      onload: null,
+      ontimeout: null,
+      onloadend: null,
+      onreadystatechange: null,
+
+      addEventListener: function() {
+        this.eventBus.addEventListener.apply(this.eventBus, arguments);
+      },
+
+      removeEventListener: function(event, callback) {
+        this.eventBus.removeEventListener.apply(this.eventBus, arguments);
+      },
+
+      status: null,
+
+      send: function(data) {
+        this.params = data;
+        this.eventBus.trigger('loadstart');
+
+        var stub = stubTracker.findStub(this.url, data, this.method);
+        if (stub) {
+          if (stub.isReturn()) {
+            this.respondWith(stub);
+          } else if (stub.isError()) {
+            this.responseError();
+          } else if (stub.isTimeout()) {
+            this.responseTimeout();
+          }
+        }
+      },
+
+      contentType: function() {
+        return findHeader('content-type', this.requestHeaders);
+      },
+
+      data: function() {
+        if (!this.params) {
+          return {};
+        }
+
+        return paramParser.findParser(this).parse(this.params);
+      },
+
+      getResponseHeader: function(name) {
+        name = name.toLowerCase();
+        var resultHeader;
+        for(var i = 0; i < this.responseHeaders.length; i++) {
+          var header = this.responseHeaders[i];
+          if (name === header.name.toLowerCase()) {
+            if (resultHeader) {
+              resultHeader = [resultHeader, header.value].join(', ');
+            } else {
+              resultHeader = header.value;
+            }
+          }
+        }
+        return resultHeader;
+      },
+
+      getAllResponseHeaders: function() {
+        var responseHeaders = [];
+        for (var i = 0; i < this.responseHeaders.length; i++) {
+          responseHeaders.push(this.responseHeaders[i].name + ': ' +
+            this.responseHeaders[i].value);
+        }
+        return responseHeaders.join('\r\n') + '\r\n';
+      },
+
+      responseText: null,
+      response: null,
+      responseType: null,
+      responseURL: null,
+
+      responseValue: function() {
+        switch(this.responseType) {
+          case null:
+          case "":
+          case "text":
+            return this.readyState >= 3 ? this.responseText : "";
+          case "json":
+            return JSON.parse(this.responseText);
+          case "arraybuffer":
+            throw unconvertibleResponseTypeMessage('arraybuffer');
+          case "blob":
+            throw unconvertibleResponseTypeMessage('blob');
+          case "document":
+            return this.responseXML;
+        }
+      },
+
+
+      respondWith: function(response) {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.responseHeaders = normalizeHeaders(response.responseHeaders, response.contentType);
+        this.readyState = 2;
+        this.eventBus.trigger('readystatechange');
+
+        this.responseText = response.responseText || "";
+        this.responseType = response.responseType || "";
+        this.responseURL = response.responseURL || null;
+        this.readyState = 4;
+        this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+
+        if ('response' in response) {
+          this.response = response.response;
+        } else {
+          this.response = this.responseValue();
+        }
+
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('load');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseTimeout: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        jasmine.clock().tick(30000);
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('timeout');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseError: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('error');
+        this.eventBus.trigger('loadend');
+      }
+    });
+
+    return FakeXMLHttpRequest;
+  }
+
+  return fakeRequest;
+};
+
+getJasmineRequireObj().MockAjax = function($ajax) {
+  function MockAjax(global) {
+    var requestTracker = new $ajax.RequestTracker(),
+      stubTracker = new $ajax.StubTracker(),
+      paramParser = new $ajax.ParamParser(),
+      realAjaxFunction = global.XMLHttpRequest,
+      mockAjaxFunction = $ajax.fakeRequest(global, requestTracker, stubTracker, paramParser);
+
+    this.install = function() {
+      if (global.XMLHttpRequest === mockAjaxFunction) {
+        throw "MockAjax is already installed.";
+      }
+
+      global.XMLHttpRequest = mockAjaxFunction;
+    };
+
+    this.uninstall = function() {
+      if (global.XMLHttpRequest !== mockAjaxFunction) {
+        throw "MockAjax not installed.";
+      }
+      global.XMLHttpRequest = realAjaxFunction;
+
+      this.stubs.reset();
+      this.requests.reset();
+      paramParser.reset();
+    };
+
+    this.stubRequest = function(url, data, method) {
+      var stub = new $ajax.RequestStub(url, data, method);
+      stubTracker.addStub(stub);
+      return stub;
+    };
+
+    this.withMock = function(closure) {
+      this.install();
+      try {
+        closure();
+      } finally {
+        this.uninstall();
+      }
+    };
+
+    this.addCustomParamParser = function(parser) {
+      paramParser.add(parser);
+    };
+
+    this.requests = requestTracker;
+    this.stubs = stubTracker;
+  }
+
+  return MockAjax;
+};
+
+getJasmineRequireObj().AjaxParamParser = function() {
+  function ParamParser() {
+    var defaults = [
+      {
+        test: function(xhr) {
+          return (/^application\/json/).test(xhr.contentType());
+        },
+        parse: function jsonParser(paramString) {
+          return JSON.parse(paramString);
+        }
+      },
+      {
+        test: function(xhr) {
+          return true;
+        },
+        parse: function naiveParser(paramString) {
+          var data = {};
+          var params = paramString.split('&');
+
+          for (var i = 0; i < params.length; ++i) {
+            var kv = params[i].replace(/\+/g, ' ').split('=');
+            var key = decodeURIComponent(kv[0]);
+            data[key] = data[key] || [];
+            data[key].push(decodeURIComponent(kv[1]));
+          }
+          return data;
+        }
+      }
+    ];
+    var paramParsers = [];
+
+    this.add = function(parser) {
+      paramParsers.unshift(parser);
+    };
+
+    this.findParser = function(xhr) {
+        for(var i in paramParsers) {
+          var parser = paramParsers[i];
+          if (parser.test(xhr)) {
+            return parser;
+          }
+        }
+    };
+
+    this.reset = function() {
+      paramParsers = [];
+      for(var i in defaults) {
+        paramParsers.push(defaults[i]);
+      }
+    };
+
+    this.reset();
+  }
+
+  return ParamParser;
+};
+
+getJasmineRequireObj().AjaxRequestStub = function() {
+  var RETURN = 0,
+      ERROR = 1,
+      TIMEOUT = 2;
+
+  function RequestStub(url, stubData, method) {
+    var normalizeQuery = function(query) {
+      return query ? query.split('&').sort().join('&') : undefined;
+    };
+
+    if (url instanceof RegExp) {
+      this.url = url;
+      this.query = undefined;
+    } else {
+      var split = url.split('?');
+      this.url = split[0];
+      this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
+    }
+
+    this.data = (stubData instanceof RegExp) ? stubData : normalizeQuery(stubData);
+    this.method = method;
+
+    this.andReturn = function(options) {
+      this.action = RETURN;
+      this.status = options.status || 200;
+
+      this.contentType = options.contentType;
+      this.response = options.response;
+      this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
+      this.responseURL = options.responseURL;
+    };
+
+    this.isReturn = function() {
+      return this.action === RETURN;
+    };
+
+    this.andError = function() {
+      this.action = ERROR;
+    };
+
+    this.isError = function() {
+      return this.action === ERROR;
+    };
+
+    this.andTimeout = function() {
+      this.action = TIMEOUT;
+    };
+
+    this.isTimeout = function() {
+      return this.action === TIMEOUT;
+    };
+
+    this.matches = function(fullUrl, data, method) {
+      var urlMatches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        urlMatches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        urlMatches = this.url === url && this.query === normalizeQuery(query);
+      }
+      var dataMatches = false;
+      if (this.data instanceof RegExp) {
+        dataMatches = this.data.test(data);
+      } else {
+        dataMatches = !this.data || this.data === normalizeQuery(data);
+      }
+      return urlMatches && dataMatches && (!this.method || this.method === method);
+    };
+  }
+
+  return RequestStub;
+};
+
+getJasmineRequireObj().AjaxRequestTracker = function() {
+  function RequestTracker() {
+    var requests = [];
+
+    this.track = function(request) {
+      requests.push(request);
+    };
+
+    this.first = function() {
+      return requests[0];
+    };
+
+    this.count = function() {
+      return requests.length;
+    };
+
+    this.reset = function() {
+      requests = [];
+    };
+
+    this.mostRecent = function() {
+      return requests[requests.length - 1];
+    };
+
+    this.at = function(index) {
+      return requests[index];
+    };
+
+    this.filter = function(url_to_match) {
+      var matching_requests = [];
+
+      for (var i = 0; i < requests.length; i++) {
+        if (url_to_match instanceof RegExp &&
+            url_to_match.test(requests[i].url)) {
+            matching_requests.push(requests[i]);
+        } else if (url_to_match instanceof Function &&
+            url_to_match(requests[i])) {
+            matching_requests.push(requests[i]);
+        } else {
+          if (requests[i].url === url_to_match) {
+            matching_requests.push(requests[i]);
+          }
+        }
+      }
+
+      return matching_requests;
+    };
+  }
+
+  return RequestTracker;
+};
+
+getJasmineRequireObj().AjaxStubTracker = function() {
+  function StubTracker() {
+    var stubs = [];
+
+    this.addStub = function(stub) {
+      stubs.push(stub);
+    };
+
+    this.reset = function() {
+      stubs = [];
+    };
+
+    this.findStub = function(url, data, method) {
+      for (var i = stubs.length - 1; i >= 0; i--) {
+        var stub = stubs[i];
+        if (stub.matches(url, data, method)) {
+          return stub;
+        }
+      }
+    };
+  }
+
+  return StubTracker;
+};
+
+
+    var jRequire = getJasmineRequireObj();
+    var MockAjax = jRequire.ajax(jRequire);
+    jasmine.Ajax = new MockAjax(global);
+
+    return MockAjax;
+}));

--- a/perma_web/spec/javascripts/support/jasmine.yml
+++ b/perma_web/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,26 @@
+src_files:
+  - "vendors/jquery/jquery.js"
+  - "vendors/p5/p5.min.js"
+  - "helpers/**/*.js"
+  - "js/*.js"
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - stylesheets/*.css
+#
+helpers:
+  - "helpers/**/*.js"
+
+spec_files:
+  - "**/*[Ss]pec.js"
+
+src_dir: "static"
+
+spec_dir: "spec/javascripts"

--- a/perma_web/spec/javascripts/support/jasmine.yml
+++ b/perma_web/spec/javascripts/support/jasmine.yml
@@ -1,7 +1,9 @@
 src_files:
   - "vendors/jquery/jquery.js"
   - "vendors/p5/p5.min.js"
-  - "helpers/**/*.js"
+  - "vendors/airbrakejs/client.min.js"
+  - "vendors/airbrakejs/instrumentation/jquery.js"
+  - "js/helpers/**/*.js"
   - "js/*.js"
 
 # stylesheets
@@ -16,11 +18,11 @@ src_files:
 #   - stylesheets/*.css
 #
 helpers:
-  - "helpers/**/*.js"
+  - "../spec/javascripts/helpers/mock-ajax.js"
 
 spec_files:
-  - "**/*[Ss]pec.js"
+  - "javascripts/*.spec.js"
 
 src_dir: "static"
 
-spec_dir: "spec/javascripts"
+spec_dir: "spec"

--- a/perma_web/static/js/create.module.js
+++ b/perma_web/static/js/create.module.js
@@ -257,7 +257,7 @@ CreateModule.populateWithUrl = function () {
   var url = location.search.split("url=")[1];
   if (url) {
     url = decodeURIComponent(url);
-    $("#rawUrl").val(url);
+    DOMHelpers.setInputValue("#rawUrl", url)
   }
 }
 

--- a/perma_web/static/js/create.module.js
+++ b/perma_web/static/js/create.module.js
@@ -314,7 +314,7 @@ CreateModule.updateAffiliationPath = function (currentOrg, path) {
 
 CreateModule.updateLinksRemaining = function (links_num) {
   links_remaining = links_num;
-  $('.links-remaining').text(links_remaining);
+  DOMHelpers.changeText('.links-remaining', links_remaining);
 }
 
 CreateModule.handleSelectionChange = function (data) {

--- a/perma_web/static/js/create.module.js
+++ b/perma_web/static/js/create.module.js
@@ -10,45 +10,39 @@ var organizations = {};
 
 /* Our globals. Look out interwebs - end */
 var CreateModule = CreateModule || {};
-var ls = ls || {};
 
+CreateModule.ls = CreateModule.ls || {};
+
+var localStorageKey = Helpers.variables.localStorageKey;
 /* Everything that needs to happen at page load - start */
 
 $(document).ready(function() {
   CreateModule.init();
   CreateModule.setupEventHandlers();
   CreateModule.populateWithUrl();
-  $('#archive-upload-confirm').modal({show: false});
-  $('#archive-upload').modal({show: false});
 });
 
 
-ls.getAll = function () {
-  var folders = JSON.parse(localStorage.getItem("perma_selection"));
+CreateModule.ls.getAll = function () {
+  var folders = Helpers.localStorage.getItem(localStorageKey);
   return folders || {};
 }
 
-ls.getCurrent = function () {
+CreateModule.ls.getCurrent = function () {
   var folders = this.getAll();
   return folders[current_user.id] || {};
 }
 
-ls.setCurrent = function (orgId, folderId) {
+CreateModule.ls.setCurrent = function (orgId, folderId) {
   folderId = folderId ? folderId : 'default';
 
   var selectedFolders = this.getAll();
   selectedFolders[current_user.id] = {'folderId' : folderId, 'orgId' : orgId };
 
-  localStorage.setItem("perma_selection",JSON.stringify(selectedFolders));
+  Helpers.localStorage.setItem(localStorageKey, selectedFolders);
   CreateModule.updateLinker();
-
-  $(window).trigger("dropdown.selectionChange");
+  Helpers.triggerOnWindow("dropdown.selectionChange");
 }
-
-
-// localStorage settings
-CreateModule.ls = ls
-
 
 // Get parameter by name
 // from https://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript

--- a/perma_web/static/js/create.module.js
+++ b/perma_web/static/js/create.module.js
@@ -57,7 +57,7 @@ CreateModule.linkIt = function (data) {
   // Success message from API. We should have a GUID now (but the
   // archive is still be generated)
   // Clear any error messages out
-  $('.error-row').remove();
+  DOMHelpers.removeElement('.error-row');
 
   new_archive.guid = data.guid;
 

--- a/perma_web/static/js/create.module.js
+++ b/perma_web/static/js/create.module.js
@@ -254,10 +254,11 @@ CreateModule.check_status = function () {
 
 /* Our polling function for the thumbnail completion - end */
 CreateModule.populateWithUrl = function () {
-  var url = location.search.split("url=")[1];
+  var url = Helpers.getWindowLocationSearch().split("url=")[1];
   if (url) {
     url = decodeURIComponent(url);
     DOMHelpers.setInputValue("#rawUrl", url)
+    return url;
   }
 }
 

--- a/perma_web/static/js/error-handler.js
+++ b/perma_web/static/js/error-handler.js
@@ -1,20 +1,22 @@
 var ErrorHandler = {};
-
-var airbrake = new airbrakeJs.Client({
-  reporter: 'xhr',
-  host: '/errors/new?'
-});
+var airbrake;
 
 ErrorHandler.resolve = function(error_id) {
   $.ajax({
     type: 'POST',
     url: '/manage/errors/resolve',
-    data: {'error_id':error_id}
+    data: {'error_id':error_id},
   });
 }
 
 ErrorHandler.init = function () {
+  airbrake = new airbrakeJs.Client({
+    reporter: 'xhr',
+    host: '/errors/new?'
+  });
+
   window.onerror = airbrake.onerror;
+
   if (window.jQuery) {
     airbrakeJs.instrumentation.jquery(airbrake, jQuery);
   }

--- a/perma_web/static/js/helpers/dom.helpers.js
+++ b/perma_web/static/js/helpers/dom.helpers.js
@@ -2,8 +2,12 @@ DOMHelpers = {}
 
 DOMHelpers.setInputValue = function(domSelector, value) {
   $(domSelector).val(value);
-}
+};
 
 DOMHelpers.removeElement = function(domSelector) {
   $(domSelector).remove();
-}
+};
+
+DOMHelpers.changeText = function(domSelector, text) {
+  $(domSelector).text(text);
+};

--- a/perma_web/static/js/helpers/dom.helpers.js
+++ b/perma_web/static/js/helpers/dom.helpers.js
@@ -1,5 +1,9 @@
 DOMHelpers = {}
 
-DOMHelpers.setInputValue = function(domSelector, url) {
-  $(domSelector).val(url);
+DOMHelpers.setInputValue = function(domSelector, value) {
+  $(domSelector).val(value);
+}
+
+DOMHelpers.removeElement = function(domSelector) {
+  $(domSelector).remove();
 }

--- a/perma_web/static/js/helpers/dom.helpers.js
+++ b/perma_web/static/js/helpers/dom.helpers.js
@@ -1,0 +1,5 @@
+DOMHelpers = {}
+
+DOMHelpers.setInputValue = function(domSelector, url) {
+  $(domSelector).val(url);
+}

--- a/perma_web/static/js/helpers/general.helpers.js
+++ b/perma_web/static/js/helpers/general.helpers.js
@@ -99,4 +99,31 @@ Helpers.isHighDensity = function() {
 
 Helpers.getWindowLocationSearch = function() {
   return window.location.search;
+};
+
+Helpers.variables = {
+  localStorageKey:"perma_selection"
+};
+
+Helpers.localStorage = {
+  getItem: function (key) {
+    var result = localStorage.getItem(key);
+    try {
+      result = JSON.parse(result);
+    } catch (e) {
+      result
+    }
+    return result;
+  },
+  setItem: function(key, value) {
+    if(typeof value !== "string") {
+      value = JSON.stringify(value);
+    }
+    localStorage.setItem(key, value);
+  }
+}
+
+
+Helpers.triggerOnWindow = function(message, data) {
+  $(window).trigger(message, data);
 }

--- a/perma_web/static/js/helpers/general.helpers.js
+++ b/perma_web/static/js/helpers/general.helpers.js
@@ -96,3 +96,7 @@ Helpers.isHighDensity = function() {
        window.matchMedia('only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 2.6/2), only screen and (min--moz-device-pixel-ratio: 1.3), only screen and (min-device-pixel-ratio: 1.3)').matches
     )) || (window.devicePixelRatio && window.devicePixelRatio > 1.3));
 }
+
+Helpers.getWindowLocationSearch = function() {
+  return window.location.search;
+}


### PR DESCRIPTION
beginning of JS unit tests! 
- added jasmine library (and jasmine ajax)
- added requirements
- added tests for create module / beginning of tests for error and general modules
- added DOMHelpers module, which is where any DOM modification should go. No other DOM modification should happen elsewhere. 
- added localStorage helpers to general helpers to silo it out for easier testing / DRY code
- to call jasmine in shell: `fab dev.jasmine`, go to 0.0.0.0:8888 to see output in your browser
- you can conversely call `jasmine-ci --browser phantomjs` for shell output


TODO: coverage report, integration into travis
finishes #1534 