### PR TITLE
Newrelic integration

### DIFF
--- a/app.json
+++ b/app.json
@@ -80,7 +80,6 @@
   "addons":[
     "jawsdb",
     "cloudamqp",
-    "newrelic",
     "papertrail",
     "rediscloud",
     "rollbar"

--- a/perma_web/Procfile
+++ b/perma_web/Procfile
@@ -1,3 +1,3 @@
-web: newrelic-admin run-program gunicorn --log-level debug --access-logfile - -w 1 -b 0.0.0.0:$PORT -k gevent --forwarded-allow-ips '*' perma.wsgi
-worker: newrelic-admin run-program celery -A perma worker --loglevel=info --concurrency=1 --without-gossip --without-mingle --without-heartbeat
-beat: newrelic-admin run-program celery -A perma beat --loglevel=info
+web: gunicorn --log-level debug --access-logfile - -w 1 -b 0.0.0.0:$PORT -k gevent --forwarded-allow-ips '*' perma.wsgi
+worker: celery -A perma worker --loglevel=info --concurrency=1 --without-gossip --without-mingle --without-heartbeat
+beat: celery -A perma beat --loglevel=info

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -13,7 +13,9 @@ import os
 use_newrelic = os.environ.get("USE_NEW_RELIC", False)
 if use_newrelic:
     import newrelic.agent
-    newrelic.agent.initialize(os.path.join(os.path.dirname(__file__), '../../services/newrelic/newrelic.ini'))
+    newrelic_config_file = os.environ.get('NEW_RELIC_CONFIG_FILE',
+                                          os.path.join(os.path.dirname(__file__), '../../services/newrelic/newrelic.ini'))
+    newrelic.agent.initialize(newrelic_config_file)
 
 # env setup
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "perma.settings")

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -9,25 +9,21 @@ this application via the ``WSGI_APPLICATION`` setting.
 """
 import os
 
-import newrelic
-from werkzeug.wsgi import DispatcherMiddleware
+# Newrelic setup
+use_newrelic = os.environ.get("USE_NEW_RELIC", False)
+if use_newrelic:
+    import newrelic.agent
+    newrelic.agent.initialize(os.path.join(os.path.dirname(__file__), '../../services/newrelic/newrelic.ini'))
 
-newrelic.agent.initialize('/srv/www/perma/services/newrelic/newrelic.ini')
-
-# We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
-# if running multiple sites in the same mod_wsgi process. To fix this, use
-# mod_wsgi daemon mode with each site in its own daemon process, or use
-# os.environ["DJANGO_SETTINGS_MODULE"] = "perma.settings"
+# env setup
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "perma.settings")
 os.environ.setdefault("CELERY_LOADER", "django")
 
-# This application object is used by any WSGI server configured to use this
-# file. This includes Django's development server, if the WSGI_APPLICATION
-# setting points here.
+# these imports may depend on env setup and/or newrelic setup that came earlier
+from werkzeug.wsgi import DispatcherMiddleware
 from django.core.wsgi import get_wsgi_application
 from warc_server.app import application as warc_application
 from whitenoise.django import DjangoWhiteNoise
-
 
 # subclass WhiteNoise to add missing mime types
 class PermaWhiteNoise(DjangoWhiteNoise):
@@ -35,10 +31,14 @@ class PermaWhiteNoise(DjangoWhiteNoise):
         self.EXTRA_MIMETYPES += (('image/svg+xml', '.svg'),)
         super(PermaWhiteNoise, self).__init__(*args, **kwargs)
 
-
+# set up application
 application = DispatcherMiddleware(
     PermaWhiteNoise(get_wsgi_application()),  # Django app wrapped with whitenoise to serve static assets
     {
         '/warc': warc_application,  # pywb for record playback
     }
 )
+
+# add newrelic app wrapper
+if use_newrelic:
+    application = newrelic.agent.WSGIApplicationWrapper(application)

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -8,7 +8,11 @@ this application via the ``WSGI_APPLICATION`` setting.
 
 """
 import os
+
+import newrelic
 from werkzeug.wsgi import DispatcherMiddleware
+
+newrelic.agent.initialize('/srv/www/perma/services/newrelic/newrelic.ini')
 
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -1,3 +1,10 @@
+#
+# This file is the human readable version of our requirements.
+# After updating this file, run this command to freeze the requirements into requirements.txt:
+#
+#    pip-compile --output-file requirements.txt requirements.in
+#
+
 # Package:                      # Used for:
 
 Django==1.8.11
@@ -48,6 +55,7 @@ pip-tools==1.6.4                # generating requirements.txt from requirements.
 # deployment
 gunicorn==19.3.0
 gevent==1.0.2
+newrelic==2.66.0.49
 
 # PyWB-related stuff
 surt==0.2                       # our simple CDX server to canonicalize URL

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -69,6 +69,7 @@ MarkupSafe==0.23          # via jinja2
 MySQL-python==1.2.5
 ndg-httpsclient==0.4.0    # via requests
 netaddr==0.7.12
+newrelic==2.66.0.49
 oauth2==1.5.211
 ordereddict==1.1          # via jasmine-core
 paramiko==1.17.0          # via fabric

--- a/services/heroku/extra_requirements.txt
+++ b/services/heroku/extra_requirements.txt
@@ -2,5 +2,4 @@
 # these will get added onto the end of requirements.txt by heroku-buildpack-perma
 
 dj_database_url==0.3.0
-newrelic==2.54.0.41
 rollbar==0.9.14

--- a/services/newrelic/newrelic.ini
+++ b/services/newrelic/newrelic.ini
@@ -24,11 +24,6 @@
 
 [newrelic]
 
-# You must specify the license key associated with your New
-# Relic account. This key binds the Python Agent's data to your
-# account in the New Relic service.
-license_key = 889221e414af81d4877cc57b9bfd9413ac122dfe
-
 # The application name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
@@ -52,7 +47,7 @@ monitor_mode = true
 # write out a log file, it is also possible to say "stderr" and
 # output to standard error output. This would normally result in
 # output appearing in your web server log.
-log_file = /var/log/perma/newrelic-python-agent.log
+# log_file = /var/log/perma/newrelic-python-agent.log
 
 # Sets the level of detail of messages sent to the log file, if
 # a log file location has been provided. Possible values, in
@@ -191,14 +186,14 @@ thread_profiler.enabled = true
 #
 
 [newrelic:development]
-monitor_mode = false
+monitor_mode = true
 
 [newrelic:test]
-monitor_mode = false
+monitor_mode = true
 
 [newrelic:staging]
 app_name = Python Application (Staging)
-monitor_mode = false
+monitor_mode = true
 
 [newrelic:production]
 monitor_mode = true

--- a/services/newrelic/newrelic.ini
+++ b/services/newrelic/newrelic.ini
@@ -1,0 +1,206 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+license_key = 889221e414af81d4877cc57b9bfd9413ac122dfe
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+app_name = Perma
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = true
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+log_file = /var/log/perma/newrelic-python-agent.log
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# The Python Agent communicates with the New Relic service using
+# SSL by default. Note that this does result in an increase in
+# CPU overhead, over and above what would occur for a non SSL
+# connection, to perform the encryption involved in the SSL
+# communication. This work is though done in a distinct thread
+# to those handling your web requests, so it should not impact
+# response times. You can if you wish revert to using a non SSL
+# connection, but this will result in information being sent
+# over a plain socket connection and will not be as secure.
+ssl = true
+
+# High Security Mode enforces certain security settings, and
+# prevents them from being overridden, so that no sensitive data
+# is sent to New Relic. Enabling High Security Mode means that
+# SSL is turned on, request parameters are not collected, and SQL
+# can not be sent to New Relic in its raw form. To activate High
+# Security Mode, it must be set to 'true' in this local .ini
+# configuration file AND be set to 'true' in the server-side
+# configuration in the New Relic user interface. For details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+# attributes.include = request.parameters.*
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = Python Application (Staging)
+monitor_mode = false
+
+[newrelic:production]
+monitor_mode = true
+
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
This pulls out our Heroku-specific New Relic support, and adds general New Relic support that can be enabled with an environment variable. Based on Jay's pull request but adapted to play well with stage/dev as well as prod.