### PR TITLE
edit archive attributes in one place

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -187,7 +187,6 @@ PIPELINE_JS = {
     },
     'single-link': {
         'source_filenames': (
-            'js/helpers/local-datetime.js',
             'js/single-link.module.js',
 
         ),

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -196,10 +196,10 @@ PIPELINE_JS = {
     'single-link-with-permissions': {
         'source_filenames': (
             'vendors/jquery/jquery.form.min.js',
-            'js/single-link.module.js',
+            'js/single-link-with-permissions.module.js',
 
         ),
-        'output_filename': 'js/single-link-bundle.js',
+        'output_filename': 'js/single-link-with-permissions-bundle.js',
     },
 
     'doc-developer': {

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -187,14 +187,21 @@ PIPELINE_JS = {
     },
     'single-link': {
         'source_filenames': (
-            'vendors/jquery/jquery.form.min.js',
-            'js/error-handler.js',
-            'js/helpers/general.helpers.js',
+            'js/helpers/local-datetime.js',
             'js/single-link.module.js',
 
         ),
         'output_filename': 'js/single-link-bundle.js',
     },
+    'single-link-with-permissions': {
+        'source_filenames': (
+            'vendors/jquery/jquery.form.min.js',
+            'js/single-link.module.js',
+
+        ),
+        'output_filename': 'js/single-link-bundle.js',
+    },
+
     'doc-developer': {
         'source_filenames': (
             'js/helpers/pretty-print-json.js',

--- a/perma_web/perma/templates/archive/base-archive-responsive.html
+++ b/perma_web/perma/templates/archive/base-archive-responsive.html
@@ -40,8 +40,7 @@
 			</div><!--/#main-content"-->
 		</section><!--/#main-->
 
-        {% javascript 'global' %}
-        {% if can_delete %}
+        {% if can_edit %}
           {% javascript 'global' %}
         {% endif %}
 

--- a/perma_web/perma/templates/archive/base-archive-responsive.html
+++ b/perma_web/perma/templates/archive/base-archive-responsive.html
@@ -41,6 +41,9 @@
 		</section><!--/#main-->
 
         {% javascript 'global' %}
+        {% if can_delete %}
+          {% javascript 'global' %}
+        {% endif %}
 
         {% block scripts %}
         {% endblock %}

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -58,7 +58,7 @@
             <div class="col col-sm-4 _main {% if request.user.is_authenticated %}_authenticated{% else %}_unauthenticated{% endif %}">
               <div class="content">
                 <p class="title"><span class="_verbose">This is a </span>{% if link.is_private %}Private {% endif %}<span class="logo">Perma.cc</span> record</p>
-                <p class="creation"><span class="cat">{% if capture.user_upload %}Created{% else %}Captured{% endif %}</span> {{ link.creation_timestamp|local_datetime }}
+                <p class="creation"><span class="cat">{% if capture.user_upload %}Uploaded{% else %}Captured{% endif %}</span> {{ link.creation_timestamp|local_datetime }}
                   {% if serve_type != 'image' %}
                     {% if link.screenshot_capture and link.screenshot_capture.status == 'success' %}
                       <span class="action">
@@ -101,30 +101,41 @@
         <div id="collapse-details" class="details-segment ui-tray row collapse">
           <div class="tray-details">
             <dl class="tray-detail-group">
-              <dt class="tray-detail-title">Original page URL {% if capture.user_upload %}(unverified){% endif %}</dt>
+              <dt class="tray-detail-title">Source page URL {% if capture.user_upload %}(unverified){% endif %}</dt>
               <dd class="tray-detail-entry">{{link.submitted_url}}</dd>
             </dl>
 
             {% if can_edit %}
               <dl class="tray-detail-group">
-                <dt class="tray-detail-title">Original page title <span class="save-status"></span></dt>
+                <dt class="tray-detail-title">Archive title <span class="save-status"></span></dt>
                 <input name="title" class="col-sm-12 link-submitted-title" value="{{link.submitted_title}}">
               </dl>
               <dl class="tray-detail-group">
-                <dt class="tray-detail-title">Notes <span class="save-status"></span></dt>
+                <dt class="tray-detail-title">Notes <span class="label-instruction _verbose"> (only visible to you)</span><span class="save-status"></span></dt>
                 <input name="notes" class="col-sm-12 link-notes" rows="2" value="{{link.notes}}"/>
               </dl>
               {% if can_delete %}
-                <dl class="tray-detail-group">
+                <dl class="tray-detail-group temporary-options">
                   <form id="archive_upload_form">
-                    <dt class="tray-detail-title" for="file">Upload file <span class="label-instruction"> If the capture looks wrong, you can re-submit your own image in the following formats: .gif, .jpg, .pdf, and .png</span></dt>
+                    <dt class="tray-detail-title" for="file">Upload file<span class="label-asterisk">*</span> <span class="label-instruction _verbose" style="display:block;"> This will replace the existing capture. The following formats are allowed: .gif, .jpg, .pdf, and .png</span></dt>
                     <input class="col-sm-10 file" name="file" type="file" placeholder="example.png" accept=".png,.jpg,.jpeg,.gif,.pdf">
                     <span class="btn-file-upload-container">
-                      <button id="updateLinky" type="submit" class="btn-sm btn-file-upload">Upload</button>
+                      <button id="updateLinky" type="submit" class="blue-button btn-sm btn-file-upload">Upload</button>
                       <button type="reset" class="btn-sm btn-file-upload">Cancel</button>
                     </span>
                   </form>
                 </dl>
+                <dl class="tray-detail-group temporary-options">
+                  <dt class="tray-detail-title">
+                    <button class="btn-delete btn-sm blue-button"><a
+                      href="{% url 'user_delete_link' link.guid %}">
+                      Delete<span class="_verbose"> record</span>
+                    </a></button>
+                    <span class="label-asterisk">*</span>
+                  </dt>
+                  <div class="label-instruction pull-right"><span class="label-asterisk">*</span> These options are only available for the first twenty-four hours.</div>
+                </dl>
+
               {% endif %}
             {% else %}
               <dl class="tray-detail-group">
@@ -142,12 +153,6 @@
             {% endcomment %}
           </div>
           <div class="tray-actions col-sm-12">
-            {% if can_delete %}
-              <a class="btn btn-ui-small btn-dashboard user-delete"
-                href="{% url 'user_delete_link' link.guid %}">
-                Delete<span class="_verbose"> record</span>
-              </a>
-            {% endif %}
 
             {# if not request.user.is_authenticated or request.user.pk != link.created_by_id #}
               <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
@@ -183,7 +188,7 @@
           <div class="banner banner-status row _isNewRecord">
             <strong>Success!</strong>
             <span class="message verbose">Your new Perma Link is <input class="link-field" type="text" value="https://{{ request.get_host }}{% url 'single_linky' link.guid %}"></span>
-            <span class="link-options edit-link verbose">Edit<span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span></span>
+            <span class="link-options edit-link verbose"><a style="cursor:pointer;">Edit</a><span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span></span>
             <a class="action new-link" href="{% url 'create_link' %}">Make a new Perma Link</a>
           </div>
         {% endif %}

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -107,11 +107,11 @@
 
             {% if can_edit %}
               <dl class="tray-detail-group">
-                <dt class="tray-detail-title">Archive title <span class="save-status"></span></dt>
+                <dt class="tray-detail-title">Title <span class="save-status"></span></dt>
                 <input name="title" class="col-sm-12 link-submitted-title" value="{{link.submitted_title}}">
               </dl>
               <dl class="tray-detail-group">
-                <dt class="tray-detail-title">Notes <span class="label-instruction _verbose"> (only visible to you)</span><span class="save-status"></span></dt>
+                <dt class="tray-detail-title">Notes <span class="label-instruction _verbose"> (only visible to you{% if link.organization%} and your organization{% endif %})</span><span class="save-status"></span></dt>
                 <input name="notes" class="col-sm-12 link-notes" rows="2" value="{{link.notes}}"/>
               </dl>
               {% if can_delete %}
@@ -133,13 +133,13 @@
                     </a></button>
                     <span class="label-asterisk">*</span>
                   </dt>
-                  <div class="label-instruction pull-right"><span class="label-asterisk">*</span> These options are only available for the first twenty-four hours.</div>
+                  <div class="label-instruction pull-right temporary-instructions"><span class="label-asterisk">*</span> These options are only available for the first twenty-four hours.</div>
                 </dl>
 
               {% endif %}
             {% else %}
               <dl class="tray-detail-group">
-                <dt class="tray-detail-title">Original page title</dt>
+                <dt class="tray-detail-title">Title</dt>
                 <dd class="tray-detail-entry">{{link.submitted_title}}</dd>
               </dl>
             {% endif %}
@@ -154,9 +154,9 @@
           </div>
           <div class="tray-actions col-sm-12">
 
-            {# if not request.user.is_authenticated or request.user.pk != link.created_by_id #}
+            {% if not can_edit %}
               <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
-            {# endif #}
+            {% endif %}
             {# user edit buttons #}
             {% if can_toggle_private %}
               <button class="btn btn-ui-small btn-dashboard darchive"><span class="_verbose">Mark as </span>{% if link.is_private %}Public{% else %}Private{% endif %}</button>

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -99,69 +99,68 @@
         </div>
 
         <div id="collapse-details" class="details-segment ui-tray row collapse">
-            <div class="tray-details">
-            	<dl class="tray-detail-group">
-            		<dt class="tray-detail-title">Original page URL {% if capture.user_upload %}(unverified){% endif %}</dt>
-            		<dd class="tray-detail-entry">{{link.submitted_url}}</dd>
-				</dl>
-            	<dl class="tray-detail-group">
-					<dt class="tray-detail-title">Original page title</dt>
-            		<dd class="tray-detail-entry">{{link.submitted_title}}</dd>
-            	</dl>
-            	<dl class="tray-detail-group">
-            		<dt class="tray-detail-title">Record creation date</dt>
-            		<dd class="tray-detail-entry">{{ link.creation_timestamp|local_datetime }}</dd>
-				</dl>
-
-                {% comment %}
-                    {% if link.organization %}
-                    <dl class="tray-detail-group">
-                        <dt class="tray-detail-title">Archiving Organization</dt>
-                        <dd class="tray-detail-entry">{{ link.organization }}</dd>
-                    </dl>
-                    {% endif %}
-                {% endcomment %}
-
-                <!--
-                <p class="fp">Perma.cc is a web archiving service developed by the Library Innovation Lab at Harvard University. The data captured in the archived Perma.cc record is the copyright of its original creators. Neither Harvard University nor the archiving individual are responsible for its content. <a href="http://perma.cc/about">More about Perma.cc.</a></p>
-                -->
-
-            </div>
-            <div class="tray-actions">
-
-                {# user edit buttons #}
-                {% if can_toggle_private %}
-                    <button class="btn btn-ui-small btn-dashboard darchive"><span class="_verbose">Mark as </span>{% if link.is_private %}Public{% else %}Private{% endif %}</button>
-                    {% if request.user.is_staff %}
-                        {% if link.is_private %}
-                            (Private reason: {{ link.get_private_reason_display }})
-                        {% else %}
-                            <select name="private_reason">
-                                <option value="user"> At user direction</option>
-                                <option value="policy"> robots.txt or noarchive meta tag</option>
-                                <option value="takedown"> At content owner's request</option>
-                            </select>
-                        {% endif %}
-                    {% endif %}
+          <div class="tray-details">
+            <dl class="tray-detail-group">
+              <dt class="tray-detail-title">Original page URL {% if capture.user_upload %}(unverified){% endif %}</dt>
+              <dd class="tray-detail-entry">{{link.submitted_url}}</dd>
+            </dl>
+            <dl class="tray-detail-group">
+              <dt class="tray-detail-title">Original page title</dt>
+              <dd class="tray-detail-entry">{{link.submitted_title}}</dd>
+            </dl>
+            <dl class="tray-detail-group">
+              <dt class="tray-detail-title">Record creation date</dt>
+              <dd class="tray-detail-entry">{{ link.creation_timestamp|local_datetime }}</dd>
+            </dl>
+            {% comment %}
+              {% if link.organization %}
+                <dl class="tray-detail-group">
+                  <dt class="tray-detail-title">Archiving Organization</dt>
+                  <dd class="tray-detail-entry">{{ link.organization }}</dd>
+                </dl>
+              {% endif %}
+            {% endcomment %}
+          </div>
+          <div class="tray-actions">
+            {# user edit buttons #}
+            {% if can_toggle_private %}
+              <button class="btn btn-ui-small btn-dashboard darchive"><span class="_verbose">Mark as </span>{% if link.is_private %}Public{% else %}Private{% endif %}</button>
+              {% if request.user.is_staff %}
+                {% if link.is_private %}
+                  (Private reason: {{ link.get_private_reason_display }})
+                {% else %}
+                  <select name="private_reason">
+                    <option value="user"> At user direction</option>
+                    <option value="policy"> robots.txt or noarchive meta tag</option>
+                    <option value="takedown"> At content owner's request</option>
+                  </select>
                 {% endif %}
+              {% endif %}
+            {% endif %}
 
-                {% if can_delete %}
-                    <a class="btn btn-ui-small btn-dashboard user-delete" href="{% url 'user_delete_link' link.guid %}">Delete<span class="_verbose"> record</span></a>
-                    <a class="btn btn-ui-small btn-dashboard user-edit" onclick="return SingleLinkModule.upload_form();">Edit<span class="_verbose"> record</a>
-                {% endif %}
+            {% if can_delete %}
+              <a class="btn btn-ui-small btn-dashboard user-delete"
+                href="{% url 'user_delete_link' link.guid %}">
+                Delete<span class="_verbose"> record</span>
+              </a>
+              <a class="btn btn-ui-small btn-dashboard user-edit"
+                onclick="return SingleLinkModule.upload_form();">
+                Edit<span class="_verbose"> record
+              </a>
+            {% endif %}
 
-                {# if not request.user.is_authenticated or request.user.pk != link.created_by_id #}
-                <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
-                {# endif #}
-            </div>
+            {# if not request.user.is_authenticated or request.user.pk != link.created_by_id #}
+            <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
+            {# endif #}
+          </div>
         </div>
-		
-		{% if can_view and link.is_private %}
-	        <div class="banner banner-status row _isDarchive">
-		        <strong>This record is private{% if link.private_reason == 'policy' %} by Perma.cc policy{% elif link.private_reason == 'takedown' %} at the content owner's request{% endif %}.</strong>
+
+        {% if can_view and link.is_private %}
+          <div class="banner banner-status row _isDarchive">
+            <strong>This record is private{% if link.private_reason == 'policy' %} by Perma.cc policy{% elif link.private_reason == 'takedown' %} at the content owner's request{% endif %}.</strong>
                 It’s only visible to {% if link.organization %}members of {{ link.organization }} and the {{ link.organization.registrar }} registrar{% else %}you{% endif %}.
                 {% if link.private_reason == 'user' %}You can make this link public under 'Show record details.'{% endif %}
-	        </div>
+          </div>
         {% endif %}
        
         {% if new_record %}

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -203,5 +203,10 @@
         var current_user = {id:"{{request.user.id}}"};
     </script>
 
-    {% javascript 'single-link' %}
+    {% if can_edit %}
+      {% javascript 'single-link-with-permissions' %}
+    {% else %}
+      {% javascript 'single-link' %}
+    {% endif %}
+
 {% endblock %}

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -117,7 +117,7 @@
               {% if can_delete %}
                 <dl class="tray-detail-group">
                   <form id="archive_upload_form">
-                    <dt class="tray-detail-title" for="file">Upload file <span class="label-instruction"> If the capture looks wrong, you can re-submit your own image in the following formats: .gif, .jpg, .pdf, and .png allowed</span></dt>
+                    <dt class="tray-detail-title" for="file">Upload file <span class="label-instruction"> If the capture looks wrong, you can re-submit your own image in the following formats: .gif, .jpg, .pdf, and .png</span></dt>
                     <input class="col-sm-10 file" name="file" type="file" placeholder="example.png" accept=".png,.jpg,.jpeg,.gif,.pdf">
                     <span class="btn-file-upload-container">
                       <button id="updateLinky" type="submit" class="btn-sm btn-file-upload">Upload</button>

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -104,10 +104,26 @@
               <dt class="tray-detail-title">Original page URL {% if capture.user_upload %}(unverified){% endif %}</dt>
               <dd class="tray-detail-entry">{{link.submitted_url}}</dd>
             </dl>
-            <dl class="tray-detail-group">
-              <dt class="tray-detail-title">Original page title</dt>
-              <dd class="tray-detail-entry">{{link.submitted_title}}</dd>
-            </dl>
+            {% if can_edit %}
+            <span class="save-status"></span>
+              <dl class="tray-detail-group">
+                <div class="form-group">
+                  <label class="tray-detail-title">Original page title</label>
+                  <input name="title" class="link-submitted-title" value="{{link.submitted_title}}">
+                </div>
+              </dl>
+              <dl class="tray-detail-group">
+                <div class="form-group">
+                  <label class="tray-detail-title">Notes</label>
+                  <textarea name="notes" class="link-notes" rows="6" value="{{link.notes}}"></textarea>
+                </div>
+              </dl>
+            {% else %}
+              <dl class="tray-detail-group">
+                <dt class="tray-detail-title">Original page title</dt>
+                <dd class="tray-detail-entry">{{link.submitted_title}}</dd>
+              </dl>
+            {% endif %}
             <dl class="tray-detail-group">
               <dt class="tray-detail-title">Record creation date</dt>
               <dd class="tray-detail-entry">{{ link.creation_timestamp|local_datetime }}</dd>
@@ -122,6 +138,20 @@
             {% endcomment %}
           </div>
           <div class="tray-actions">
+            {% if can_delete %}
+              <a class="btn btn-ui-small btn-dashboard user-delete"
+                href="{% url 'user_delete_link' link.guid %}">
+                Delete<span class="_verbose"> record</span>
+              </a>
+              <a class="btn btn-ui-small btn-dashboard btn-warning user-edit"
+                onclick="return SingleLinkModule.upload_form();">
+                Edit<span class="_verbose"> record
+              </a>
+            {% endif %}
+
+            {# if not request.user.is_authenticated or request.user.pk != link.created_by_id #}
+              <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
+            {# endif #}
             {# user edit buttons #}
             {% if can_toggle_private %}
               <button class="btn btn-ui-small btn-dashboard darchive"><span class="_verbose">Mark as </span>{% if link.is_private %}Public{% else %}Private{% endif %}</button>
@@ -138,20 +168,6 @@
               {% endif %}
             {% endif %}
 
-            {% if can_delete %}
-              <a class="btn btn-ui-small btn-dashboard user-delete"
-                href="{% url 'user_delete_link' link.guid %}">
-                Delete<span class="_verbose"> record</span>
-              </a>
-              <a class="btn btn-ui-small btn-dashboard user-edit"
-                onclick="return SingleLinkModule.upload_form();">
-                Edit<span class="_verbose"> record
-              </a>
-            {% endif %}
-
-            {# if not request.user.is_authenticated or request.user.pk != link.created_by_id #}
-            <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
-            {# endif #}
           </div>
         </div>
 

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -58,7 +58,7 @@
             <div class="col col-sm-4 _main {% if request.user.is_authenticated %}_authenticated{% else %}_unauthenticated{% endif %}">
               <div class="content">
                 <p class="title"><span class="_verbose">This is a </span>{% if link.is_private %}Private {% endif %}<span class="logo">Perma.cc</span> record</p>
-                <p class="creation"><span class="cat">{% if capture.user_upload %}Uploaded{% else %}Captured{% endif %}</span> {{ link.creation_timestamp|local_datetime:"F j, Y" }}
+                <p class="creation"><span class="cat">{% if capture.user_upload %}Created{% else %}Captured{% endif %}</span> {{ link.creation_timestamp|local_datetime }}
                   {% if serve_type != 'image' %}
                     {% if link.screenshot_capture and link.screenshot_capture.status == 'success' %}
                       <span class="action">
@@ -104,30 +104,34 @@
               <dt class="tray-detail-title">Original page URL {% if capture.user_upload %}(unverified){% endif %}</dt>
               <dd class="tray-detail-entry">{{link.submitted_url}}</dd>
             </dl>
+
             {% if can_edit %}
-            <span class="save-status"></span>
               <dl class="tray-detail-group">
-                <div class="form-group">
-                  <label class="tray-detail-title">Original page title</label>
-                  <input name="title" class="link-submitted-title" value="{{link.submitted_title}}">
-                </div>
+                <dt class="tray-detail-title">Original page title <span class="save-status"></span></dt>
+                <input name="title" class="col-sm-12 link-submitted-title" value="{{link.submitted_title}}">
               </dl>
               <dl class="tray-detail-group">
-                <div class="form-group">
-                  <label class="tray-detail-title">Notes</label>
-                  <textarea name="notes" class="link-notes" rows="6" value="{{link.notes}}"></textarea>
-                </div>
+                <dt class="tray-detail-title">Notes <span class="save-status"></span></dt>
+                <input name="notes" class="col-sm-12 link-notes" rows="2" value="{{link.notes}}"/>
               </dl>
+              {% if can_delete %}
+                <dl class="tray-detail-group">
+                  <form id="archive_upload_form">
+                    <dt class="tray-detail-title" for="file">Upload file <span class="label-instruction"> If the capture looks wrong, you can re-submit your own image in the following formats: .gif, .jpg, .pdf, and .png allowed</span></dt>
+                    <input class="col-sm-10 file" name="file" type="file" placeholder="example.png" accept=".png,.jpg,.jpeg,.gif,.pdf">
+                    <span class="btn-file-upload-container">
+                      <button id="updateLinky" type="submit" class="btn-sm btn-file-upload">Upload</button>
+                      <button type="reset" class="btn-sm btn-file-upload">Cancel</button>
+                    </span>
+                  </form>
+                </dl>
+              {% endif %}
             {% else %}
               <dl class="tray-detail-group">
                 <dt class="tray-detail-title">Original page title</dt>
                 <dd class="tray-detail-entry">{{link.submitted_title}}</dd>
               </dl>
             {% endif %}
-            <dl class="tray-detail-group">
-              <dt class="tray-detail-title">Record creation date</dt>
-              <dd class="tray-detail-entry">{{ link.creation_timestamp|local_datetime }}</dd>
-            </dl>
             {% comment %}
               {% if link.organization %}
                 <dl class="tray-detail-group">
@@ -137,15 +141,11 @@
               {% endif %}
             {% endcomment %}
           </div>
-          <div class="tray-actions">
+          <div class="tray-actions col-sm-12">
             {% if can_delete %}
               <a class="btn btn-ui-small btn-dashboard user-delete"
                 href="{% url 'user_delete_link' link.guid %}">
                 Delete<span class="_verbose"> record</span>
-              </a>
-              <a class="btn btn-ui-small btn-dashboard btn-warning user-edit"
-                onclick="return SingleLinkModule.upload_form();">
-                Edit<span class="_verbose"> record
               </a>
             {% endif %}
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -170,7 +170,7 @@ def single_linky(request, guid):
     context = {
         'link': link,
         'can_view': request.user.can_view(link),
-        'can_edit': request.user.can_view(link),
+        'can_edit': request.user.can_edit(link),
         'can_delete': request.user.can_delete(link),
         'can_toggle_private': request.user.can_toggle_private(link),
         'capture': capture,

--- a/perma_web/spec/javascripts/single.link.permissions.module.spec.js
+++ b/perma_web/spec/javascripts/single.link.permissions.module.spec.js
@@ -1,0 +1,5 @@
+describe("Test single-link-with-permissions.module.js", function() {
+  it("defines SingleLinkModule", function(){
+    expect(SingleLinkModule).toBeDefined();
+  });
+});

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -1056,18 +1056,18 @@ p.fp {
 }
 
 .tray-actions {
-	padding-top: $double;
-    padding-bottom: $double;
-    background-color: $color-background;
-    text-align: left;
-    padding-left: $double;
-    padding-right: $grid;
-	margin-top: $half;
-	overflow: auto;
-	@include respond-desktop {
-	    padding-left: $grid * 3;
-	    padding-right: $double;
-	}
+  padding-top: $double;
+  padding-bottom: $double;
+  background-color: $color-background;
+  text-align: left;
+  padding-left: $double;
+  padding-right: $grid;
+  margin-top: -1px;
+  overflow: auto;
+  @include respond-desktop {
+    padding-left: $grid * 3;
+    padding-right: $double;
+  }
 }
 
 ._verbose, 
@@ -1682,5 +1682,9 @@ body.modal-open {
     padding: 7px;
     border: 0px;
     font-weight: 300;
+  }
+  .temporary-instructions {
+    position: relative;
+    top: -6px;
   }
 }

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -1643,16 +1643,22 @@ body.modal-open {
   font-family: $font-hed-alt;
   font-weight: 400;
   color: $color-trans-gray;
-  display: block;
   @include respond-mobile {
     float: right;
     display: inline-block;
   }
 }
-
+.label-asterisk {
+  font-size: 13px;
+  margin-left: 3px;
+  color: $color-orange;
+}
 #collapse-details {
   .tray-detail-title {
     margin-bottom: 5px;
+  }
+  .temporary-options {
+    background-color: $color-trans-whispergray;
   }
   input {
     padding-left: 6px;
@@ -1667,12 +1673,14 @@ body.modal-open {
     margin-left: 5px;
   }
   .btn-file-upload {
-    padding: 7px;
-    border: 0px;
     background-color: $color-trans-lightgray;
   }
-  #updateLinky {
+  .blue-button {
     background: $color-blue;
     color: white;
+    font-size: 12px;
+    padding: 7px;
+    border: 0px;
+    font-weight: 300;
   }
 }

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -1651,8 +1651,35 @@ body.modal-open {
   font-weight: 400;
   color: $color-trans-gray;
   display: block;
-  @include respond-tablet {
+  @include respond-mobile {
     float: right;
     display: inline-block;
+  }
+}
+
+#collapse-details {
+  .tray-detail-title {
+    margin-bottom: 5px;
+  }
+  input {
+    padding-left: 6px;
+  }
+  .save-status {
+    color: $color-orange;
+    margin-top: 0;
+    margin-left: .7em;
+    font-weight: 700;
+  }
+  .btn-file-upload-container {
+    margin-left: 5px;
+  }
+  .btn-file-upload {
+    padding: 7px;
+    border: 0px;
+    background-color: $color-trans-lightgray;
+  }
+  #updateLinky {
+    background: $color-blue;
+    color: white;
   }
 }

--- a/perma_web/static/js/single-link-with-permissions.js
+++ b/perma_web/static/js/single-link-with-permissions.js
@@ -1,0 +1,103 @@
+var SingleLinkModule = {};
+
+$(document).ready(function(){
+  SingleLinkModule.init();
+  SingleLinkModule.setupEventHandlers();
+});
+
+SingleLinkModule.init = function () {
+  SingleLinkModule.adjustTopMargin();
+  if($('._isNewRecord')) { SingleLinkModule.handleNewRecord(); }
+};
+
+SingleLinkModule.handleNewRecord = function () {
+  // On the new-record bar, update the width of the URL input to match its contents,
+  // by copying the contents into a temporary span with the same class and measuring its width.
+
+  var linkField = $('input.link-field');
+  linkField.after("<span class='link-field'></span>");
+  var linkSpan = $('span.link-field');
+  linkSpan.text(linkField.val());
+  linkField.width(linkSpan.width());
+  linkSpan.remove();
+
+}
+
+SingleLinkModule.setupEventHandlers = function () {
+  $("#details-button, .edit-link").click( function () {
+    SingleLinkModule.handleShowDetails($(this));
+    return false;
+  });
+
+  $("button.darchive").click( function(){
+    SingleLinkModule.handleDarchiving($(this));
+    return false;
+  });
+
+  $('#archive_upload_form')
+    .submit(function(e) {
+      e.preventDefault();
+      var url = "/archives/"+archive.guid+"/";
+      var data = {};
+      data['file'] = $('#archive_upload_form').find('.file')[0].files[0];
+
+      var requestArgs = {
+        contentType: false,
+        processData: false
+      };
+      if (window.FormData) {
+        Helpers.sendFormData("PATCH", url, data, requestArgs)
+        .done(function(data){
+          location=location;
+        });
+      } else {
+        $('#upload-error').text('Your browser version does not allow for this action. Please use a more modern browser.');
+      }
+    });
+
+  $(window).on('resize', function () { SingleLinkModule.adjustTopMargin(); });
+}
+
+SingleLinkModule.handleShowDetails = function () {
+  $this = $("#details-button");
+  var showingDetails = $this.text().match("Show");
+  $this.text(showingDetails && showingDetails.length > 0 ? "Hide record details" : "Show record details");
+  $('header').toggleClass('_activeDetails');
+}
+
+SingleLinkModule.adjustTopMargin = function () {
+  var $wrapper = $('.capture-wrapper');
+  var headerHeight = $('header').height();
+  $wrapper.css('margin-top', headerHeight);
+}
+
+
+SingleLinkModule.handleDarchiving = function (context) {
+  var $this = context;
+  if (!$this.hasClass('disabled')){
+    var prev_text = $this.text(),
+      currently_private = prev_text.indexOf('Public') > -1,
+      private_reason = currently_private ? null : $('select[name="private_reason"]').val() || 'user';
+
+    $this.addClass('disabled');
+    $this.text('Updating ...');
+
+    Helpers.apiRequest('PATCH', '/archives/' + archive.guid + '/', {is_private: !currently_private, private_reason: private_reason}, {
+      success: function(){
+        window.location.reload(true);
+      },
+      error: function(jqXHR){
+        $this.removeClass('disabled');
+        $this.text(prev_text);
+      }
+    });
+  }
+}
+
+SingleLinkModule.upload_form = function () {
+  $('#linky-confirm').modal('hide');
+  $('#upload-error').text('');
+  $('#archive_upload_form').removeAttr('action').removeAttr('method');
+  $('#archive-upload').modal('show');
+  return false;
+}

--- a/perma_web/static/js/single-link-with-permissions.module.js
+++ b/perma_web/static/js/single-link-with-permissions.module.js
@@ -1,4 +1,6 @@
 var SingleLinkModule = {};
+var saveBufferSeconds = 0.5,
+  timeouts = {};
 
 $(document).ready(function(){
   SingleLinkModule.init();
@@ -55,6 +57,20 @@ SingleLinkModule.setupEventHandlers = function () {
       }
     });
 
+  $('#collapse-details')
+    .find('input')
+    .on('input propertychange change', function () {
+      var inputarea = $(this);
+      SingleLinkModule.saveInput(inputarea);
+    });
+
+  $('#collapse-details')
+    .find('textarea')
+    .on('textchange', function () {
+      var textarea = $(this);
+      SingleLinkModule.saveInput(textarea);
+    });
+
   $(window).on('resize', function () { SingleLinkModule.adjustTopMargin(); });
 }
 
@@ -99,4 +115,16 @@ SingleLinkModule.upload_form = function () {
   $('#archive_upload_form').removeAttr('action').removeAttr('method');
   $('#archive-upload').modal('show');
   return false;
+}
+
+SingleLinkModule.saveInput = function (inputElement) {
+  var statusElement = $('.save-status')[0];
+  $(statusElement).html('Saving...');
+
+  var data = {};
+  data["title"] = $(inputElement[0]).val();
+  Helpers.apiRequest("PATCH", '/archives/' + archive.guid + '/', data)
+    .done(function(data){
+      $(statusElement).html('Saved!');
+    });
 }

--- a/perma_web/static/js/single-link-with-permissions.module.js
+++ b/perma_web/static/js/single-link-with-permissions.module.js
@@ -71,7 +71,6 @@ SingleLinkModule.adjustTopMargin = function () {
   $wrapper.css('margin-top', headerHeight);
 }
 
-
 SingleLinkModule.handleDarchiving = function (context) {
   var $this = context;
   if (!$this.hasClass('disabled')){

--- a/perma_web/static/js/single-link-with-permissions.module.js
+++ b/perma_web/static/js/single-link-with-permissions.module.js
@@ -9,6 +9,7 @@ $(document).ready(function(){
 
 SingleLinkModule.init = function () {
   SingleLinkModule.adjustTopMargin();
+  SingleLinkModule.changeUploadBtnStatus(true);
   if($('._isNewRecord')) { SingleLinkModule.handleNewRecord(); }
 };
 
@@ -22,7 +23,12 @@ SingleLinkModule.handleNewRecord = function () {
   linkSpan.text(linkField.val());
   linkField.width(linkSpan.width());
   linkSpan.remove();
+}
 
+SingleLinkModule.changeUploadBtnStatus = function(disableStatus) {
+  // if disableStatus is false, enable.
+  // if disableStatus is true, disable.
+  $('#updateLinky').prop('disabled', disableStatus);
 }
 
 SingleLinkModule.setupEventHandlers = function () {
@@ -35,6 +41,14 @@ SingleLinkModule.setupEventHandlers = function () {
     SingleLinkModule.handleDarchiving($(this));
     return false;
   });
+
+  $("input:file").change(function (){
+    var fileName = $(this).val();
+    var disableStatus = fileName ? false : true;
+    SingleLinkModule.changeUploadBtnStatus(disableStatus);
+  });
+
+  $("button:reset").click(function(){ SingleLinkModule.changeUploadBtnStatus(true); });
 
   $('#archive_upload_form')
     .submit(function(e) {
@@ -57,7 +71,7 @@ SingleLinkModule.setupEventHandlers = function () {
 }
 
 SingleLinkModule.submitFile = function () {
-  $('#updateLinky').prop('disabled', true);
+  SingleLinkModule.changeUploadBtnStatus(true);
   var url = "/archives/"+archive.guid+"/";
   var data = {};
   data['file'] = $('#archive_upload_form').find('.file')[0].files[0];

--- a/perma_web/static/js/single-link.module.js
+++ b/perma_web/static/js/single-link.module.js
@@ -1,108 +1,27 @@
 var SingleLinkModule = {};
 
-$(document).ready(function(){
-  SingleLinkModule.init();
-  SingleLinkModule.setupEventHandlers();
-});
-
 SingleLinkModule.init = function () {
   SingleLinkModule.adjustTopMargin();
-  if($('._isNewRecord')) { SingleLinkModule.handleNewRecord(); }
+  var button = document.getElementById("details-button");
+  button.onclick = function () {
+    SingleLinkModule.handleShowDetails(button);
+    return false;
+  };
 };
 
-SingleLinkModule.handleNewRecord = function () {
-  // On the new-record bar, update the width of the URL input to match its contents,
-  // by copying the contents into a temporary span with the same class and measuring its width.
-
-  var linkField = $('input.link-field');
-  linkField.after("<span class='link-field'></span>");
-  var linkSpan = $('span.link-field');
-  linkSpan.text(linkField.val());
-  linkField.width(linkSpan.width());
-  linkSpan.remove();
-
-}
-
-SingleLinkModule.setupEventHandlers = function () {
-  $("#details-button, .edit-link").click( function () {
-    SingleLinkModule.handleShowDetails($(this));
-    return false;
-  });
-
-  $("button.darchive").click( function(){
-    SingleLinkModule.handleDarchiving($(this));
-    return false;
-  });
-
-  $('#archive_upload_form')
-    .submit(function(e) {
-      e.preventDefault();
-      var url = "/archives/"+archive.guid+"/";
-      var data = {};
-      data['file'] = $('#archive_upload_form').find('.file')[0].files[0];
-
-      var requestArgs = {
-        contentType: false,
-        processData: false
-      };
-      if (window.FormData) {
-        Helpers.sendFormData("PATCH", url, data, requestArgs)
-        .done(function(data){
-          location=location;
-        });
-      } else {
-        $('#upload-error').text('Your browser version does not allow for this action. Please use a more modern browser.');
-      }
-    });
-
-  $(window).on('resize', function () { SingleLinkModule.adjustTopMargin(); });
-}
-
 SingleLinkModule.handleShowDetails = function () {
-  $this = $("#details-button");
-  var showingDetails = $this.text().match("Show");
-  $this.text(showingDetails && showingDetails.length > 0 ? "Hide record details" : "Show record details");
-  $('header').toggleClass('_activeDetails');
+  var el = document.getElementById("details-button");
+  var showingDetails = el.textContent.match("Show");
+  showingDetails && showingDetails.length > 0 ? "Hide record details" : "Show record details"
+  var header = document.getElementsByTagName('header')[0];
+  header.classList.toggle('_activeDetails');
 }
 
 SingleLinkModule.adjustTopMargin = function () {
-  var $wrapper = $('.capture-wrapper');
-  var headerHeight = $('header').height();
-  $wrapper.css('margin-top', headerHeight);
+  var button = document.getElementById("details-button");
+  var wrapper = document.getElementsByClassName("capture-wrapper")[0];
+  var headerHeight = document.getElementsByTagName('header')[0].clientHeight;
+  wrapper.style.marginTop = headerHeight;
 }
 
-SingleLinkModule.handleDarchiving = function (context) {
-  var $this = context;
-  $this.text($this.text() == "Show record details" ? "Hide record details" : "Show record details");
-  $('header').toggleClass('_activeDetails');
-}
-
-SingleLinkModule.handleDarchiving = function (context) {
-  var $this = context;
-  if (!$this.hasClass('disabled')){
-    var prev_text = $this.text(),
-      currently_private = prev_text.indexOf('Public') > -1,
-      private_reason = currently_private ? null : $('select[name="private_reason"]').val() || 'user';
-
-    $this.addClass('disabled');
-    $this.text('Updating ...');
-
-    Helpers.apiRequest('PATCH', '/archives/' + archive.guid + '/', {is_private: !currently_private, private_reason: private_reason}, {
-      success: function(){
-        window.location.reload(true);
-      },
-      error: function(jqXHR){
-        $this.removeClass('disabled');
-        $this.text(prev_text);
-      }
-    });
-  }
-}
-
-SingleLinkModule.upload_form = function () {
-  $('#linky-confirm').modal('hide');
-  $('#upload-error').text('');
-  $('#archive_upload_form').removeAttr('action').removeAttr('method');
-  $('#archive-upload').modal('show');
-  return false;
-}
+SingleLinkModule.init();


### PR DESCRIPTION
also includes: 
- not sending any scripts to user if user has no editing permissions 
- moved full date to top blue bar (otherwise it was getting repeated in the archive info dropdown)
- moved updating archive with image to general archive info dropdown. Not showing another modal on top.

finishes #1519 
<img width="1278" alt="screen shot 2016-06-01 at 4 54 13 pm" src="https://cloud.githubusercontent.com/assets/1494102/15725352/7dbc67a8-2819-11e6-9a46-57ad87b33c44.png">

