### PR TITLE
Fix Django 1.9 errors on stage

### DIFF
--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -45,8 +45,6 @@ class LinkAuthorizationTestCase(ApiResourceTransactionTestCase):
         self.patch_data = {'notes': 'These are new notes',
                            'title': 'This is a new title'}
 
-        CaptureJob.clear_cache()  # reset cache (test cases don't reset cache keys automatically)
-
     def get_public_link_url(self, link):
         return "{0}/{1}".format(self.public_list_url, link.pk)
 

--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -1,7 +1,7 @@
 import os
 from .utils import TEST_ASSETS_DIR, ApiResourceTransactionTestCase
 from api.resources import LinkResource, PublicLinkResource
-from perma.models import Link, LinkUser, Folder, CaptureJob, Capture, CDXLine
+from perma.models import Link, LinkUser, Folder, Capture, CDXLine
 from django.utils import timezone
 from datetime import timedelta
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -68,9 +68,6 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
             'title': 'This is a test page'
         }
 
-        CaptureJob.clear_cache()  # reset cache (test cases don't reset cache keys automatically)
-        cache.clear()
-
     def assertValidCapture(self, capture):
         """
             Make sure capture matches WARC contents.

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -2,8 +2,7 @@ import os
 import dateutil.parser
 from .utils import ApiResourceTransactionTestCase, TEST_ASSETS_DIR
 from api.resources import LinkResource, CurrentUserLinkResource, PublicLinkResource
-from perma.models import Link, LinkUser, CDXLine, CaptureJob
-from django.core.cache import cache
+from perma.models import Link, LinkUser, CDXLine
 
 
 # Use a TransactionTestCase here because archive capture is threaded

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -108,6 +108,12 @@ class ApiResourceTestCaseMixin(ResourceTestCaseMixin, SimpleTestCase):
         settings.MEDIA_ROOT = self._media_org
         shutil.rmtree(self._media_tmp)
 
+        # wipe cache -- see https://niwinz.github.io/django-redis/latest/#_testing_with_django_redis
+        from django_redis import get_redis_connection
+        get_redis_connection("default").flushall()
+
+        return super(PermaTestCase, self).tearDown()
+
     def get_credentials(self, user=None):
         user = user or self.user
         return "ApiKey %s" % user.api_key.key

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -112,7 +112,7 @@ class ApiResourceTestCaseMixin(ResourceTestCaseMixin, SimpleTestCase):
         from django_redis import get_redis_connection
         get_redis_connection("default").flushall()
 
-        return super(PermaTestCase, self).tearDown()
+        return super(ApiResourceTestCaseMixin, self).tearDown()
 
     def get_credentials(self, user=None):
         user = user or self.user

--- a/perma_web/perma/settings/deployments/settings_heroku.py
+++ b/perma_web/perma/settings/deployments/settings_heroku.py
@@ -74,20 +74,14 @@ AWS_QUERYSTRING_AUTH = False
 # archive creation
 PHANTOMJS_LOG = 'phantomjs.log' # this will just get thrown away
 
-# parse redis url
-import redis.connection
-_parsed_redis_url = redis.connection.ConnectionPool.from_url(os.environ.get('REDISCLOUD_URL')).connection_kwargs
-
 # caching
-#KEY_VALUE_STORE = simplekv.memory.redisstore.RedisStore(redis.StrictRedis.from_url(os.environ.get('REDISCLOUD_URL')))
-CACHES['default']['LOCATION'] = "%s:%s:%s" % (_parsed_redis_url['host'], _parsed_redis_url['port'], _parsed_redis_url['db'])
-CACHES['default']['OPTIONS']['PASSWORD'] = _parsed_redis_url['password']
+CACHES['default']['LOCATION'] = os.environ.get('REDISCLOUD_URL')
 
-# thumbnail redis server
-THUMBNAIL_REDIS_DB = _parsed_redis_url['db']
-THUMBNAIL_REDIS_PASSWORD = _parsed_redis_url['password']
-THUMBNAIL_REDIS_HOST = _parsed_redis_url['host']
-THUMBNAIL_REDIS_PORT = _parsed_redis_url['port']
+# # thumbnail redis server
+# THUMBNAIL_REDIS_DB = _parsed_redis_url['db']
+# THUMBNAIL_REDIS_PASSWORD = _parsed_redis_url['password']
+# THUMBNAIL_REDIS_HOST = _parsed_redis_url['host']
+# THUMBNAIL_REDIS_PORT = _parsed_redis_url['port']
 
 
 ### OVERRIDE THESE WITH ENV VARS ###

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -38,13 +38,12 @@ THUMBNAIL_REDIS_PORT = '6379'
 # caching
 # in dev, Django will use the default in-memory cache
 CACHES = {
-    'default': {
-        'BACKEND': 'redis_cache.cache.RedisCache',
-        'LOCATION': '127.0.0.1:6379:0',
-        'OPTIONS': {
-            'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
-            #'PASSWORD': 'secretpassword',  # Optional
-            'IGNORE_EXCEPTIONS': True,  # since this is just a cache, we don't want to show errors if redis is offline for some reason
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/0",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "IGNORE_EXCEPTIONS": True,  # since this is just a cache, we don't want to show errors if redis is offline for some reason
         }
     }
 }

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -58,3 +58,18 @@ BROKER_BACKEND = 'memory'
 #         'NAME': None
 #     }
 # }
+
+
+
+# Use production cache setup, except with fakeredis backend
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "REDIS_CLIENT_CLASS": "fakeredis.FakeStrictRedis",
+        }
+    }
+}
+

--- a/perma_web/perma/tests/test_capture_job.py
+++ b/perma_web/perma/tests/test_capture_job.py
@@ -30,8 +30,6 @@ class CaptureJobTestCase(PermaTestCase):
 
         self.maxDiff = None  # let assertListEqual compare large lists
 
-        CaptureJob.clear_cache()  # reset cache (test cases don't reset cache keys automatically)
-
     ### HELPERS ###
 
     def assertNextJobsMatch(self, expected_next_jobs, expected_order):

--- a/perma_web/perma/tests/utils.py
+++ b/perma_web/perma/tests/utils.py
@@ -12,6 +12,13 @@ class PermaTestCase(TransactionTestCase):
                 'fixtures/folders.json',
                 'fixtures/archive.json']
 
+    def tearDown(self):
+        # wipe cache -- see https://niwinz.github.io/django-redis/latest/#_testing_with_django_redis
+        from django_redis import get_redis_connection
+        get_redis_connection("default").flushall()
+
+        return super(PermaTestCase, self).tearDown()
+
     def log_in_user(self, user, password='pass'):
         self.client.logout()
         if hasattr(user, 'email'):

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -38,7 +38,7 @@ django-tastypie==0.13.3         # API framework
 -e git://github.com/harvard-lil/django-tastypie-extendedmodelresource.git@a1586e4e34079dafda77be279f4ad4b8eaca10c3#egg=django-tastypie-extendedmodelresource
 sorl-thumbnail==12.3			# Used to create our thumbnails
 redis==2.10.5					# Needed to bind with Redis. Supports our sorl thumbnails in production
-django-redis==3.7.2             # use redis as django's cache backend
+django-redis==4.4.3             # use redis as django's cache backend
 django-forms-bootstrap==3.0.1   # produce Bootstrap compatable forms
 django-secure==1.0.1            # Force SSL -- this can be removed in Django 1.8
 django-sslserver==0.14          # For testing SSL locally.
@@ -56,7 +56,6 @@ pip-tools==1.6.5                # generating requirements.txt from requirements.
 gunicorn==19.3.0
 gevent==1.0.2
 newrelic==2.66.0.49
-flake8==2.5.4                   # code linting
 
 # PyWB-related stuff
 -e git://github.com/ikreymer/pywb.git@e28f29430219b4a26374bf2a18d0128de91607cd#egg=pywb  # pywb v0.31
@@ -67,6 +66,8 @@ flake8==2.5.4                   # code linting
 django-storages==1.1.8
 boto==2.29.1
 
-# sauce integration testing
+# testing
 sauceclient==0.1.0
 pytest-xdist==1.10
+fakeredis==0.7.0                # simulate redis backend for tests
+flake8==2.5.4                   # code linting

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -47,6 +47,7 @@ ecdsa==0.13               # via paramiko
 enum34==1.1.4             # via cryptography, pyscss
 execnet==1.4.1            # via pytest-xdist
 Fabric==1.11.1
+fakeredis==0.7.0
 first==2.0.1              # via pip-tools
 flake8==2.5.4
 Flask==0.10.1             # via jasmine

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -33,7 +33,7 @@ django-mptt==0.8.0
 django-pipeline-compass==0.1.5
 django-pipeline==1.5.4
 django-ratelimit==1.0.0
-django-redis==3.7.2
+django-redis==4.4.3
 django-secure==1.0.1
 django-settings-context-processor==0.2
 django-simple-history==1.8.1

--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -12,7 +12,6 @@ import requests
 from surt import surt
 
 # configure Django
-from lockss.models import Mirror
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "perma.settings")
 import django
@@ -24,6 +23,7 @@ from django.template.loader import get_template
 from django.core.files.storage import default_storage
 from django.core.exceptions import DisallowedHost
 from django.core.cache import cache as django_cache
+from django.apps import apps
 
 from pywb.cdx.cdxserver import CDXServer
 from pywb.cdx.cdxsource import CDXSource
@@ -39,8 +39,10 @@ from pywb.webapp.views import MementoTimemapView
 from pywb.webapp.pywb_init import create_wb_router
 from pywb.utils.wbexception import NotFoundException
 
-from perma.models import CDXLine, Link
-
+# Use lazy model imports because Django models aren't ready yet when this file is loaded by wsgi.py
+CDXLine = apps.get_model('perma', 'CDXLine')
+Link = apps.get_model('perma', 'Link')
+Mirror = apps.get_model('lockss', 'Mirror')
 
 import logging
 logger = logging.getLogger(__name__)
@@ -344,6 +346,7 @@ class CachedLoader(BlockLoader):
 
             # try fetching from each mirror in the LOCKSS network, in random order
             if settings.USE_LOCKSS_REPLAY:
+
                 mirrors = Mirror.get_cached_mirrors()
                 random.shuffle(mirrors)
 


### PR DESCRIPTION
- Lazy load models in pywb_config.py -- Django 1.9 is more picky about how soon you can import models.
- Upgrade django-redis to 4.4.3.
- Set tests to use django-redis and fakeredis so this error wouldn't make it past our tests next time.