### PR TITLE
Monitor celery on staging

### DIFF
--- a/perma_web/Procfile
+++ b/perma_web/Procfile
@@ -1,3 +1,3 @@
 web: gunicorn --log-level debug --access-logfile - -w 1 -b 0.0.0.0:$PORT -k gevent --forwarded-allow-ips '*' perma.wsgi
-worker: celery -A perma worker --loglevel=info --concurrency=1 --without-gossip --without-mingle --without-heartbeat
+worker: newrelic-admin run-program celery -A perma worker --loglevel=info --concurrency=1 --without-gossip --without-mingle --without-heartbeat
 beat: celery -A perma beat --loglevel=info


### PR DESCRIPTION
This is a first cut at monitoring celery with NewRelic on staging. It'll monitor celery and the Django application together; next step is to monitor them separately.