### PR TITLE
fix - attempting to catch internet archive connection errors

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -776,5 +776,5 @@ def upload_to_internet_archive(self, link_guid):
             link.internet_archive_upload_status = 'failed_permanently'
             link.save()
 
-    except ConnectionError as e:
+    except requests.ConnectionError as e:
         logger.exception("Upload to Internet Archive task failed because of a connection error. \nLink GUID: %s\nError: %s" % (link.pk, e))

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -778,3 +778,4 @@ def upload_to_internet_archive(self, link_guid):
 
     except requests.ConnectionError as e:
         logger.exception("Upload to Internet Archive task failed because of a connection error. \nLink GUID: %s\nError: %s" % (link.pk, e))
+        return


### PR DESCRIPTION
Not sure if this is correct, but I don't know how to trigger this.
Trying to add fix for this stack trace:
```
Task perma.tasks.upload_to_internet_archive with id 4529afb4-c853-410c-a633-4e6f244128d4 raised exception:
'ConnectTimeout(u"Error retrieving metadata from https://archive.org/metadata/perma_cc_T8FC-AKFK, HTTPSConnectionPool(host=\'archive.org\', port=443): Max retries exceeded with url: /metadata/perma_cc_T8FC-AKFK (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f12649b7a50>, \'Connection to archive.org timed out. (connect timeout=12)\'))",)'


Task was called with args: [] kwargs: {u'link_guid': u'T8FC-AKFK'}.

The contents of the full traceback was:

Traceback (most recent call last):
  File "/srv/www/perma-envs/perma/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/srv/www/perma-envs/perma/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/srv/www/perma/perma_web/perma/tasks.py", line 744, in upload_to_internet_archive
    item = internetarchive.get_item(identifier)
  File "/srv/www/perma-envs/perma/lib/python2.7/site-packages/internetarchive/api.py", line 98, in get_item
    return archive_session.get_item(identifier, request_kwargs=request_kwargs)
  File "/srv/www/perma-envs/perma/lib/python2.7/site-packages/internetarchive/session.py", line 195, in get_item
    item_metadata = self.get_metadata(identifier, request_kwargs)
  File "/srv/www/perma-envs/perma/lib/python2.7/site-packages/internetarchive/session.py", line 220, in get_metadata
    raise type(exc)(error_msg)
ConnectTimeout: Error retrieving metadata from https://archive.org/metadata/perma_cc_T8FC-AKFK, HTTPSConnectionPool(host='archive.org', port=443): Max retries exceeded with url: /metadata/perma_cc_T8FC-AKFK (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f12649b7a50>, 'Connection to archive.org timed out. (connect timeout=12)'))

```

fixes #1603 