### PR TITLE
Tagging for registrar model

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -27,10 +27,10 @@ class LinkInline(admin.TabularInline):
 
 class RegistrarAdmin(SimpleHistoryAdmin):
     search_fields = ['name', 'email', 'website']
-    list_display = ['name', 'status', 'email', 'website', 'show_partner_status', 'partner_display_name', 'logo', 'latitude', 'longitude', 'registrar_users', 'last_active', 'orgs_count', 'link_count',]
+    list_display = ['name', 'status', 'email', 'website', 'show_partner_status', 'partner_display_name', 'logo', 'latitude', 'longitude', 'registrar_users', 'last_active', 'orgs_count', 'link_count', 'tag_list']
     list_editable = ['show_partner_status', 'partner_display_name', 'latitude', 'longitude', 'status']
     fieldsets = (
-        (None, {'fields': ('name', 'email', 'website', 'status')}),
+        (None, {'fields': ('name', 'email', 'website', 'status', 'tags')}),
         ("Partner Display", {'fields': ('show_partner_status', 'partner_display_name', 'logo', 'latitude', 'longitude')}),
     )
     inlines = [
@@ -49,7 +49,7 @@ class RegistrarAdmin(SimpleHistoryAdmin):
             registrar_users=Count('users', distinct=True),
             last_active=Max('users__last_login', distinct=True),
             orgs_count=Count('organizations',distinct=True)
-        )
+        ).prefetch_related('tags')
     def registrar_users(self, obj):
         return obj.registrar_users
     def last_active(self, obj):
@@ -57,6 +57,8 @@ class RegistrarAdmin(SimpleHistoryAdmin):
     def orgs_count(self, obj):
         return obj.orgs_count
 
+    def tag_list(self, obj):
+        return u", ".join(o.name for o in obj.tags.all())
 
 class OrganizationAdmin(SimpleHistoryAdmin):
     fields = ['name', 'registrar']

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -35,6 +35,7 @@ from mptt.models import MPTTModel, TreeForeignKey
 from model_utils import FieldTracker
 from pywb.cdx.cdxobject import CDXObject
 from pywb.warc.cdxindexer import write_cdx_index
+from taggit.managers import TaggableManager
 
 from .utils import copy_file_data
 
@@ -96,6 +97,7 @@ class Registrar(models.Model):
     objects = RegistrarQuerySet.as_manager()
     tracker = FieldTracker()
     history = HistoricalRecords()
+    tags = TaggableManager()
 
     class Meta:
         ordering = ['name']

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -324,6 +324,7 @@ INSTALLED_APPS = (
     'djangosecure',  # force SSL -- this can be removed in Django 1.8
     'settings_context_processor',
     'simple_history',  # record model changes
+    'taggit',  # model tagging
 
     # django admin -- has to come after our apps for our admin template overrides to work
     'django.contrib.admin',

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -51,6 +51,7 @@ django-simple-history==1.8.1    # track changes to certain models
 PyVirtualDisplay==0.1.5         # for capturing with non-headless browsers
 LinkHeader==0.4.3               # memento headers for single-link pages
 pip-tools==1.6.5                # generating requirements.txt from requirements.in
+django-taggit==0.20.2           # tagging registrars
 
 # deployment
 gunicorn==19.3.0

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -38,6 +38,7 @@ django-settings-context-processor==0.2
 django-simple-history==1.8.1
 django-sslserver==0.14
 django-storages==1.1.8
+django-taggit==0.20.2
 django-tastypie==0.13.3
 Django==1.9.8             # via django-admin-smoke-tests, django-model-utils, django-mptt, django-secure, django-sslserver
 docopt==0.6.2             # via internetarchive


### PR DESCRIPTION
This adds basic tagging for registrars. We can use this for stuff like tracking counts of law school registrars, court registrars, etc.