### PR TITLE
Reset pagination for sort and filter buttons

### DIFF
--- a/perma_web/perma/templates/500.html
+++ b/perma_web/perma/templates/500.html
@@ -3,7 +3,10 @@
 
 {% block mainContent %}
 	<div class="col-xs-12 no-wide">
-		<h1 class="page-title">Looks like you broke Perma.cc.</h1>
-		<p class="page-dek">We should have told you not to do that! There’s been an internal server error (Error 500), but don’t worry, we’ll fix it. Please <a href="{% url 'contact' %}" >contact us</a> and let us know how you found yourself here. Thanks!</p>
+		<h1 class="page-title">Oops!</h1>
+		<p class="page-dek">
+      There’s been an internal server error (Error 500) preparing this page, but don’t worry, we’ll fix it.
+      Please <a href="{% url 'contact' %}" >contact us</a> and let us know how you found yourself here. Thanks!
+    </p>
 	</div>
 {% endblock %}

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -71,15 +71,15 @@
                 
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                     <li>
-                        <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
-                        <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
-                        <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
-                        <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
-                        <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
-                        <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="=last_active" %}"><i class="icon-ok"></i> Least recently active</a>
-                        <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
-                        <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string sort="link_count" %}"><i class="icon-ok"></i> Least links</a><a {% if sort == '-org_users' %}class="selected" {% endif %} href="?sort=-org_users{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Most users</a>
-                        <a {% if sort == 'org_users' %}class="selected" {% endif %} href="?{% current_query_string sort="org_users" %}"><i class="icon-ok"></i> Least users</a>
+                        <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string page='' sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
+                        <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
+                        <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
+                        <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
+                        <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
+                        <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="=last_active" %}"><i class="icon-ok"></i> Least recently active</a>
+                        <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
+                        <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i class="icon-ok"></i> Least links</a><a {% if sort == '-org_users' %}class="selected" {% endif %} href="?sort=-org_users{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Most users</a>
+                        <a {% if sort == 'org_users' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="org_users" %}"><i class="icon-ok"></i> Least users</a>
                     </li>
                   </ul>
                 </div>

--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -64,9 +64,9 @@
 
           <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
             <li>
-              <a {% if status == 'approved' %}class="selected" {% endif %}href="?{% current_query_string status="approve" %}"><i class="icon-ok"></i> Approved</a>
-              <a {% if status == 'pending' %}class="selected" {% endif %}href="?{% current_query_string status="pending" %}"><i class="icon-ok"></i> Needs approval</a>
-              <a {% if status == 'denied' %}class="selected" {% endif %}href="?{% current_query_string status="denied" %}"><i class="icon-ok"></i> Denied</a>
+              <a {% if status == 'approved' %}class="selected" {% endif %}href="?{% current_query_string page='' status="approve" %}"><i class="icon-ok"></i> Approved</a>
+              <a {% if status == 'pending' %}class="selected" {% endif %}href="?{% current_query_string page='' status="pending" %}"><i class="icon-ok"></i> Needs approval</a>
+              <a {% if status == 'denied' %}class="selected" {% endif %}href="?{% current_query_string page='' status="denied" %}"><i class="icon-ok"></i> Denied</a>
             </li>
           </ul>
         </div>
@@ -77,14 +77,14 @@
 
           <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
             <li>
-              <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
-              <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
-              <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
-              <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
-              <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
-              <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string sort="last_active" %}"><i class="icon-ok"></i> Least recently active</a>
-              <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
-              <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string sort="link_count" %}"><i class="icon-ok"></i> Least links</a>
+              <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string page='' sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
+              <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
+              <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
+              <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
+              <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
+              <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="last_active" %}"><i class="icon-ok"></i> Least recently active</a>
+              <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
+              <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i class="icon-ok"></i> Least links</a>
             </li>
           </ul>
         </div>

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -80,15 +80,15 @@
 					<a role="button" data-toggle="dropdown" data-target="#" href="/page.html">Sort <span class="caret"></span></a>
 					<ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
 						<li>
-							<a {% if sort == 'last_name' %}class="selected" {% endif %}href="?{% current_query_string sort="last_name" %}"><i class="icon-ok"></i> Last name A - Z</a>
-							<a {% if sort == '-last_name' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_name" %}"><i class="icon-ok"></i> Last name Z - A</a>
-							<a {% if sort == '-date_joined' %}class="selected" {% endif %} href="?{% current_query_string sort="-date_joined" %}"><i class="icon-ok"></i> Newest</a>
-							<a {% if sort == 'date_joined' %}class="selected" {% endif %} href="?{% current_query_string sort="date_joined" %}"><i class="icon-ok"></i> Oldest</a>
-							<a {% if sort == '-last_login' %}class="selected" {% endif %} href="?{% current_query_string sort="-last_login" %}"><i class="icon-ok"></i> Recently active</a>
-							<a {% if sort == 'last_login' %}class="selected" {% endif %} href="?{% current_query_string sort="last_login" %}"><i class="icon-ok"></i> Least recently active</a>
+							<a {% if sort == 'last_name' %}class="selected" {% endif %}href="?{% current_query_string page='' sort="last_name" %}"><i class="icon-ok"></i> Last name A - Z</a>
+							<a {% if sort == '-last_name' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_name" %}"><i class="icon-ok"></i> Last name Z - A</a>
+							<a {% if sort == '-date_joined' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-date_joined" %}"><i class="icon-ok"></i> Newest</a>
+							<a {% if sort == 'date_joined' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="date_joined" %}"><i class="icon-ok"></i> Oldest</a>
+							<a {% if sort == '-last_login' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_login" %}"><i class="icon-ok"></i> Recently active</a>
+							<a {% if sort == 'last_login' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="last_login" %}"><i class="icon-ok"></i> Least recently active</a>
 							{% if group_name == 'organization_user' %}
-								<a {% if sort == '-created_links_count' %}class="selected" {% endif %} href="?{% current_query_string sort="-created_links_count" %}"><i class="icon-ok"></i> Most links</a>
-								<a {% if sort == 'created_links_count' %}class="selected" {% endif %} href="?{% current_query_string sort="created_links_count" %}"><i class="icon-ok"></i> Least links</a>
+								<a {% if sort == '-created_links_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-created_links_count" %}"><i class="icon-ok"></i> Most links</a>
+								<a {% if sort == 'created_links_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="created_links_count" %}"><i class="icon-ok"></i> Least links</a>
 							{% endif %}
 						</li>
 					</ul>
@@ -99,9 +99,9 @@
 						<a role="button" data-toggle="dropdown" data-target="#" href="/page.html">Upgrade interest <span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
 							<li>
-								<a {% if upgrade == 'court' %}class="selected" {% endif %}href="?{% current_query_string upgrade="court" %}"><i class="icon-ok"></i> Court</a>
-								<a {% if upgrade == 'faculty' %}class="selected" {% endif %}href="?{% current_query_string upgrade="faculty" %}"><i class="icon-ok"></i> Faculty</a>
-								<a {% if upgrade == 'journal' %}class="selected" {% endif %}href="?{% current_query_string upgrade="journal" %}"><i class="icon-ok"></i> Journal</a>
+								<a {% if upgrade == 'court' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="court" %}"><i class="icon-ok"></i> Court</a>
+								<a {% if upgrade == 'faculty' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="faculty" %}"><i class="icon-ok"></i> Faculty</a>
+								<a {% if upgrade == 'journal' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="journal" %}"><i class="icon-ok"></i> Journal</a>
 							</li>
 						</ul>
 					</div>
@@ -111,11 +111,11 @@
 					<a role="button" data-toggle="dropdown" data-target="#" href="/page.html">Status <span class="caret"></span></a>
 					<ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
 						<li>
-							<a {% if status == 'active' %}class="selected" {% endif %}href="?{% current_query_string status="active" %}"><i class="icon-ok"></i> Active</a>
+							<a {% if status == 'active' %}class="selected" {% endif %}href="?{% current_query_string page='' status="active" %}"><i class="icon-ok"></i> Active</a>
 							{% if request.user.is_staff and group_name == 'user' %}
-							<a {% if status == 'deactivated' %}class="selected" {% endif %}href="?{% current_query_string status="deactivated" %}"><i class="icon-ok"></i> Deactivated</a>
+							<a {% if status == 'deactivated' %}class="selected" {% endif %}href="?{% current_query_string page='' status="deactivated" %}"><i class="icon-ok"></i> Deactivated</a>
 							{% endif %}
-							<a {% if status == 'unactivated' %}class="selected" {% endif %}href="?{% current_query_string status="unactivated" %}"><i class="icon-ok"></i> Unactivated</a>
+							<a {% if status == 'unactivated' %}class="selected" {% endif %}href="?{% current_query_string page='' status="unactivated" %}"><i class="icon-ok"></i> Unactivated</a>
 						</li>
 					</ul>
 				</div>
@@ -129,9 +129,9 @@
 								{% if orgs %}
 									{% for org in orgs %}
 										{% if organization_filter == org %}
-											<a class="selected" href="?{% current_query_string org='' %}"><i class="icon-ok"></i> {{org.name}}</a>
+											<a class="selected" href="?{% current_query_string page='' org='' %}"><i class="icon-ok"></i> {{org.name}}</a>
 										{% else %}
-											<a href="?{% current_query_string org=org.id %}"><i class="icon-ok"></i> {{org.name}}</a>
+											<a href="?{% current_query_string page='' org=org.id %}"><i class="icon-ok"></i> {{org.name}}</a>
 										{% endif %}
 									{% endfor %}
 								{% else %}
@@ -152,9 +152,9 @@
 								{% if registrars %}
 									{% for registrar in registrars %}
 										{% if registrar_filter == registrar %}
-											<a class="selected" href="?{% current_query_string registrar='' organization='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+											<a class="selected" href="?{% current_query_string page='' registrar='' organization='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
 										{% else %}
-											<a href="?{% current_query_string registrar=registrar.id organization='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+											<a href="?{% current_query_string page='' registrar=registrar.id organization='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
 										{% endif %}
 									{% endfor %}
 								{% else %}


### PR DESCRIPTION
... so user won't get an error if they're on page two of a list and add a filter that results in fewer than two pages of results.

This also softens the 500 page by removing the "you broke perma.cc" message.