### PR TITLE
Redirect logged in user on login page

### DIFF
--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -121,7 +121,7 @@ class PermissionsTestCase(PermaTestCase):
                 for user in view.get('disallowed', all_users - view['allowed']):
                     self.log_in_user(user)
                     resp = self.client.get(url)
-                    self.assertRedirects(resp, settings.LOGIN_URL+"?next="+url,
+                    self.assertRedirects(resp, settings.LOGIN_URL+"?next="+url, target_status_code=302,
                                          msg_prefix="Error while confirming that %s can't view %s: " % (user, view_name))
 
         # make sure that all ^manage/ views were tested


### PR DESCRIPTION
- Refactor our limited_login view to wrap Django’s builtin login view rather than duplicating it.

- Add a check that forwards the user from the login page if they are already logged in.

Fixes #1593