### PR TITLE
Tweak redirect for not-logged-in bookmarklet users

### DIFF
--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -98,11 +98,8 @@ def bookmarklet_create(request):
 
     ...and passes the query string values to /manage/create/
     '''
-    path = request.get_full_path()
-    # Strip '/service/bookmarklet-create/
-    querystring = path[28:]
-    add_url = reverse('create_link')
-    add_url = add_url + querystring
+    tocapture = request.GET.get('url', '')
+    add_url = "{}?url={}".format(reverse('create_link'), tocapture)
     return redirect(add_url)
 
 # @login_required

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -16,7 +16,7 @@ def email_confirm(request):
     """
     A service that sends a message to a user about a perma link.
     """
-    
+
     email_address = request.POST.get('email_address')
     link_url = request.POST.get('link_url')
 
@@ -49,7 +49,7 @@ def stats_sums(request):
 
 def stats_now(request):
     """
-    Serve up our up-to-the-minute stats. 
+    Serve up our up-to-the-minute stats.
     Todo: make this time-zone friendly.
     """
 


### PR DESCRIPTION
Currently, if you use the bookmarket while logged out, the url gets lost during the redirect from the login form because it is url-encoded. 

Doesn't work: https://perma.cc/login?next=/manage/create%3Fv%3D1%26url%3Dhttps%253A%252F%252Fgithub.com%252Fharvard-lil%252Fperma%252Fissues%252F457

Works: https://perma.cc/login?next=/manage/create?url=https://github.com/harvard-lil/perma/issues/457

This tweaks the redirect url returned by the bookmarklet service so it works for logged-in and not-logged-in users.