### PR TITLE
Just return from upload_to_internet_archive

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -856,7 +856,7 @@ def upload_to_internet_archive(self, link_guid):
                     link.internet_archive_upload_status = 'failed'
                     self.retry(exc=Exception("Internet Archive reported upload failure."))
 
-                return success
+                return
         else:
             link.internet_archive_upload_status = 'failed_permanently'
             link.save()


### PR DESCRIPTION
This solves a problem exposed when changing from RabbitMQ to SQS: 

`'<MaybeEncodingError: Error sending result: \'\'[<Response [200]>]\'\'. Reason: \'\'TypeError("can\\\'t pickle generator objects",)\'\'.>'`