### PR TITLE
Web capture improvements

### DIFF
--- a/perma_web/api/tests/test_link_validation.py
+++ b/perma_web/api/tests/test_link_validation.py
@@ -58,7 +58,7 @@ class LinkValidationTestCase(ApiResourceTransactionTestCase):
                            # http://stackoverflow.com/a/10456069/313561
                            data={'url': 'http://0.42.42.42/'})
 
-    @override_settings(MAX_HTTP_FETCH_SIZE=1024)
+    @override_settings(MAX_ARCHIVE_FILE_SIZE=1024)
     def test_should_reject_large_url(self):
         self.rejected_post(self.list_url,
                            user=self.org_user,

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -371,7 +371,6 @@ WAIT_BETWEEN_TRIES = .5 # wait between .5 and this many seconds between http req
 
 # Max file size (for our downloads)
 MAX_ARCHIVE_FILE_SIZE = 1024 * 1024 * 100  # 100 MB
-MAX_HTTP_FETCH_SIZE = 1024 * 1024  # 1 MB
 
 # Max image size for screenshots and thumbnails
 MAX_IMAGE_SIZE = 1024*1024*50  # 50 megapixels


### PR DESCRIPTION
- Capture size limits: uploads and captures now share the same size limit, set by `MAX_ARCHIVE_FILE_SIZE`.
- All requests made by warcprox must comply with our IP blacklist.
- Capture times are tightened up. New capture time limits: *something* must finish loading within 45 seconds, and then if any requests are still pending at that point, they get an additional 30 seconds.
- Audio/video background captures will be counted toward the size limit and will be stopped by the time limit, so infinite streams don't result in infinite captures.