### PR TITLE
Library signup form tweaks

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1203,9 +1203,9 @@ def libraries(request):
 
         # test if both form objects that comprise the signup form are valid
         if user_form:
-           form_is_valid = user_form.is_valid() and registrar_form.is_valid()
+            form_is_valid = user_form.is_valid() and registrar_form.is_valid()
         else:
-           form_is_valid = registrar_form.is_valid()
+            form_is_valid = registrar_form.is_valid()
 
         if form_is_valid:
             new_registrar = registrar_form.save()

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1201,27 +1201,26 @@ def libraries(request):
             request.session['request_data'] = registrar_form.data
             return HttpResponseRedirect('/login?next=/libraries/')
 
-        if registrar_form.is_valid():
+        # test if both form objects that comprise the signup form are valid
+        if user_form:
+           form_is_valid = user_form.is_valid() and registrar_form.is_valid()
+        else:
+           form_is_valid = registrar_form.is_valid()
+
+        if form_is_valid:
             new_registrar = registrar_form.save()
             email_registrar_request(request, new_registrar)
-
-            if not request.user.is_authenticated():
-                if user_form.is_valid():
-                    new_user = user_form.save(commit=False)
-                    new_user.backend='django.contrib.auth.backends.ModelBackend'
-                    new_user.pending_registrar = new_registrar
-                    new_user.save()
-
-                    email_pending_registrar_user(request, new_user)
-                    return HttpResponseRedirect(reverse('register_library_instructions'))
-                else:
-                    context.update({'user_form':user_form, 'registrar_form':registrar_form})
+            if user_form:
+                new_user = user_form.save(commit=False)
+                new_user.backend='django.contrib.auth.backends.ModelBackend'
+                new_user.pending_registrar = new_registrar
+                new_user.save()
+                email_pending_registrar_user(request, new_user)
+                return HttpResponseRedirect(reverse('register_library_instructions'))
             else:
                 request.user.pending_registrar = new_registrar
                 request.user.save()
-
                 return HttpResponseRedirect(reverse('user_management_settings_affiliations'))
-
         else:
             context.update({'user_form':user_form, 'registrar_form':registrar_form})
     else:

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1179,9 +1179,7 @@ def libraries(request):
     """
     Info for libraries, allow them to request accounts
     """
-
     context = {}
-    registrar_count = Registrar.objects.approved().count()
 
     if request.method == 'POST':
         registrar_form = RegistrarForm(request.POST, prefix = "b")
@@ -1241,7 +1239,7 @@ def libraries(request):
         registrar_form.fields['website'].label = "Library website"
 
     return render_to_response("registration/sign-up-libraries.html",
-        {'user_form':user_form, 'registrar_form':registrar_form, 'registrar_count': registrar_count},
+        {'user_form':user_form, 'registrar_form':registrar_form},
         RequestContext(request))
 
 @ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)


### PR DESCRIPTION
Don't create a pending registrar if the submitted user form is invalid.
https://github.com/harvard-lil/perma/issues/1740

Also removes a couple unused lines of code.