### PR TITLE
Modal position fix

### DIFF
--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -9335,9 +9335,7 @@ body.modal-open {
   .modal-dialog {
     position: relative;
     left: 50%;
-    top: 50%;
     right: auto;
-    bottom: auto;
     margin-left: -300px;
   }
 }

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -1474,9 +1474,7 @@ body.modal-open {
   @include respond-tablet {
     position: relative;
     left: 50%;
-    top: 50%;
     right: auto;
-    bottom: auto;
     margin-left: $modalWidth * -.5;
   }
 }


### PR DESCRIPTION
Let modal stay at top of screen instead of non-working vertical centering