### PR TITLE
Upgrade Pillow to 3.3.2

### DIFF
--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -39,7 +39,7 @@ django-sslserver==0.14          # For testing SSL locally.
 django-model-utils==2.2         # for tracking dirty models
 django-settings-context-processor==0.2 # make settings available in templates
 django-admin-smoke-tests==0.1.11    # basic tests for the Django admin
-Pillow==3.3.1                   # Used by the Django admin for ImageField display
+Pillow==3.3.2                   # Used by the Django admin for ImageField display
 whitenoise==3.2.2               # serve static assets
 django-simple-history==1.8.1    # track changes to certain models
 PyVirtualDisplay==0.1.5         # for capturing with non-headless browsers

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -80,7 +80,7 @@ pathtools==0.1.2          # via watchdog
 pbr==1.10.0               # via mock
 pep8==1.7.0               # via flake8
 pexpect==3.1
-Pillow==3.3.1
+Pillow==3.3.2
 pip-tools==1.7
 py==1.4.31                # via pytest
 pyasn1==0.1.9             # via cryptography, requests


### PR DESCRIPTION
We could upgrade to 3.4.0, but I thought I'd try the minimum necessary change.