### PR TITLE
Removed the link to #faculty on the FAQ page

### DIFF
--- a/perma_web/perma/templates/docs/faq.html
+++ b/perma_web/perma/templates/docs/faq.html
@@ -28,7 +28,6 @@ This section of the user guide provides answers to common questions about Perma.
         <li class="reading-toc-section"><a href="#general">General</a></li>
         <li class="reading-toc-section"><a href="#librarian">Librarians</a></li>
         <li class="reading-toc-section"><a href="#journals">Academic journals</a></li>
-        <li class="reading-toc-section"><a href="#faculty">Academic faculty</a></li>
         <li class="reading-toc-section"><a href="#technical">Technical questions</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Closes #1827.

Let me know if you have any feedback on this change or if there’s something I missed.