### PR TITLE
Use pip-sync for deploys

### DIFF
--- a/perma_web/fabfile/deploy.py
+++ b/perma_web/fabfile/deploy.py
@@ -113,7 +113,7 @@ def release_to_stage():
 
 @task
 def pip_install():
-    run_as_web_user("pip install -r requirements.txt")
+    run_as_web_user("pip-sync")
 
 @task
 def restart_server():


### PR DESCRIPTION
Makes sure that installed packages match requirements.txt — no extras. Avoids problems with src packages masking site-packages or vice versa.