### PR TITLE
Send contact form messages from org users to registrar users 

### DIFF
--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -29,11 +29,11 @@ def send_user_email(to_address, template, context):
     return success_count
 
 # def send_mass_user_email(template, recipients):
-    '''
-        Opens a single connection to the mail server and sends many emails.
-        Pass in recipients as a list of tuples (email, context):
-        [('recipient@example.com', {'first_name': 'Joe', 'last_name': 'Yacoboski' }), (), ...]
-    '''
+    # '''
+    #     Opens a single connection to the mail server and sends many emails.
+    #     Pass in recipients as a list of tuples (email, context):
+    #     [('recipient@example.com', {'first_name': 'Joe', 'last_name': 'Yacoboski' }), (), ...]
+    # '''
     # to_send = []
     # for recipient in recipients:
     #     to_address, context = recipient

--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -3,7 +3,7 @@ from createsend import Subscriber, List
 from collections import defaultdict
 
 from django.conf import settings
-from django.core.mail import EmailMessage, send_mail, send_mass_mail
+from django.core.mail import EmailMessage, send_mail
 from django.template.loader import render_to_string
 
 from .models import Registrar, LinkUser
@@ -28,27 +28,27 @@ def send_user_email(to_address, template, context):
     )
     return success_count
 
-def send_mass_user_email(template, recipients):
+# def send_mass_user_email(template, recipients):
     '''
         Opens a single connection to the mail server and sends many emails.
         Pass in recipients as a list of tuples (email, context):
         [('recipient@example.com', {'first_name': 'Joe', 'last_name': 'Yacoboski' }), (), ...]
     '''
-    to_send = []
-    for recipient in recipients:
-        to_address, context = recipient
-        email_text = render_to_string(template, context)
-        title, email_text = email_text.split("\n\n", 1)
-        title = title.split("TITLE: ")[-1]
-        to_send.append(( title,
-                         email_text,
-                         settings.DEFAULT_FROM_EMAIL,
-                         [to_address]))
+    # to_send = []
+    # for recipient in recipients:
+    #     to_address, context = recipient
+    #     email_text = render_to_string(template, context)
+    #     title, email_text = email_text.split("\n\n", 1)
+    #     title = title.split("TITLE: ")[-1]
+    #     to_send.append(( title,
+    #                      email_text,
+    #                      settings.DEFAULT_FROM_EMAIL,
+    #                      [to_address]))
 
-    success_count = send_mass_mail(tuple(to_send), fail_silently=False)
-    return success_count
+    # success_count = send_mass_mail(tuple(to_send), fail_silently=False)
+    # return success_count
 
-def send_admin_email(title, from_address, request, template="email/default.txt", context={}, referer=''):
+def send_admin_email(title, from_address, request, template="email/default.txt", context={}):
     """
         Send a message on behalf of a user to the admins.
         Use reply-to for the user address so we can use email services that require authenticated from addresses.
@@ -59,6 +59,21 @@ def send_admin_email(title, from_address, request, template="email/default.txt",
         settings.DEFAULT_FROM_EMAIL,
         [settings.DEFAULT_FROM_EMAIL],
         headers={'Reply-To': from_address}
+    ).send(fail_silently=False)
+
+def send_user_email_copy_admins(title, from_address, to_addresses, request, template="email/default.txt", context={}):
+    """
+        Send a message on behalf of a user to another user, cc'ing
+        the sender and the Perma admins.
+        Use reply-to for the user address so we can use email services that require authenticated from addresses.
+    """
+    EmailMessage(
+        title,
+        render_to_string(template, context=context, request=request),
+        settings.DEFAULT_FROM_EMAIL,
+        to_addresses,
+        cc=[settings.DEFAULT_FROM_EMAIL, from_address],
+        reply_to=[from_address]
     ).send(fail_silently=False)
 
 ###

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -230,6 +230,7 @@ class ContactForm(forms.Form):
         return self.cleaned_data['subject'] or "New message from Perma contact form"
 
     email = forms.EmailField(label="Your email address")
-    subject = forms.CharField(required=False)
+    registrar = forms.ChoiceField(choices = (), label = 'Your library')
+    subject = forms.CharField(widget=forms.HiddenInput, required=False)
     message = forms.CharField(widget=forms.Textarea)
     referer = forms.URLField(widget=forms.HiddenInput, required=False)

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -432,3 +432,6 @@ WEBPACK_LOADER = {
 # campaign monitor)
 CAMPAIGN_MONITOR_AUTH = {'api_key':'fake'}
 CAMPAIGN_MONITOR_REGISTRAR_LIST = 'fake'
+
+# Directs contact form to registrar users under certain circumstances
+CONTACT_REGISTRARS = False

--- a/perma_web/perma/templates/contact-thanks.html
+++ b/perma_web/perma/templates/contact-thanks.html
@@ -13,7 +13,7 @@
       <h1 class="page-title">Thanks!</h1>
       {% if registrar %}
         <p class="page-dek">Your message was successfully sent to {{registrar.name}} and the Perma.cc team:</p>
-        <ul class="page-dek">{% for user in registrar_users %}
+        <ul class="page-dek">{% for user in registrar.active_registrar_users %}
          <li>{{user.get_full_name}} ({{user.email}})</li>{% endfor %}
          <li>info@perma.cc</li>
         </ul>

--- a/perma_web/perma/templates/contact-thanks.html
+++ b/perma_web/perma/templates/contact-thanks.html
@@ -9,9 +9,17 @@
 
 <div class="container cont-fixed">
   <div class="row">
-    <div class="col-sm-9">
-      <h1 class="page-title">Thanks</h1>
-      <p class="page-dek">Your message was successfully sent to the Perma.cc team.</p>
+    <div class="col-xs-12">
+      <h1 class="page-title">Thanks!</h1>
+      {% if registrar %}
+        <p class="page-dek">Your message was successfully sent to {{registrar.name}} and the Perma.cc team:</p>
+        <ul class="page-dek">{% for user in registrar_users %}
+         <li>{{user.get_full_name}} ({{user.email}})</li>{% endfor %}
+         <li>info@perma.cc</li>
+        </ul>
+      {% else %}
+        <p class="page-dek">Your message was successfully sent to the Perma.cc team.</p>
+      {% endif %}
     </div><!--col -->
   </div><!--row-->
 </div><!--container-->

--- a/perma_web/perma/templates/contact.html
+++ b/perma_web/perma/templates/contact.html
@@ -8,22 +8,22 @@
 {% block mainContent %}
 
 <div class="container cont-fixed">
-
-    <div class="row">
-		<div class="col-sm-12">
-			<h1 class="page-title">Contact</h1>
-            <p class="page-dek">This form is the easiest way to start a dialog with Perma.cc. If you prefer email, you can write to us at <a href="mailto:info@perma.cc">info@perma.cc</a>.</p>
-            <p class="page-dek">Save yourself some time. Is your question one of our <a href="{% url 'docs_faq' %}">Frequently Asked Questions?</a> Do you have questions about <a href="{% url 'sign_up' %}">setting up a Perma.cc account?</a> Have you looked at our <a href="{% url 'docs' %}">Perma.cc Guide</a>? The answer may be right at your fingertips!</p>
-        </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <h1 class="page-title">Contact</h1>
+        {% if request.user.is_organization_user %}<p class="page-dek">This form is the easiest way to start a dialog with Perma.cc support at your library.</p>
+        {% else %}<p class="page-dek">This form is the easiest way to start a dialog with Perma.cc.</p>{% endif %}
+        <p class="page-dek">Save yourself some time. Is your question one of our <a href="{% url 'docs_faq' %}">Frequently Asked Questions?</a> Do you have questions about <a href="{% url 'sign_up' %}">setting up a Perma.cc account?</a> Have you looked at our <a href="{% url 'docs' %}">Perma.cc Guide</a>? The answer may be right at your fingertips!</p>
+      </div>
     </div> <!-- row -->
-    <div class="row">
-		<div class="col-sm-6 contact-form">
-            <form action="{% url 'contact' %}" method="post" role="form">
-                {% csrf_token %}
-                {% include "includes/fieldset.html" with form_classes="fg-100" %}
-                <button type="submit" class="btn">Send</button>
-            </form>
-		</div><!--col -->
-	</div><!--row-->
+  <div class="row">
+    <div class="col-sm-6 contact-form">
+      <form action="{% url 'contact' %}" method="post" role="form">
+        {% csrf_token %}
+        {% include "includes/fieldset.html" with form_classes="fg-100" %}
+        <button type="submit" class="btn">Send</button>
+      </form>
+    </div><!--col -->
+  </div><!--row-->
 </div><!--container-->
 {% endblock mainContent %}

--- a/perma_web/perma/templates/contact.html
+++ b/perma_web/perma/templates/contact.html
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-sm-12">
       <h1 class="page-title">Contact</h1>
-        {% if request.user.is_organization_user %}<p class="page-dek">This form is the easiest way to start a dialog with Perma.cc support at your library.</p>
+        {% if request.user.is_supported_by_registrar %}<p class="page-dek">This form is the easiest way to start a dialog with Perma.cc support at your library.</p>
         {% else %}<p class="page-dek">This form is the easiest way to start a dialog with Perma.cc.</p>{% endif %}
         <p class="page-dek">Save yourself some time. Is your question one of our <a href="{% url 'docs_faq' %}">Frequently Asked Questions?</a> Do you have questions about <a href="{% url 'sign_up' %}">setting up a Perma.cc account?</a> Have you looked at our <a href="{% url 'docs' %}">Perma.cc Guide</a>? The answer may be right at your fingertips!</p>
       </div>

--- a/perma_web/perma/templates/email/registrar_contact.txt
+++ b/perma_web/perma/templates/email/registrar_contact.txt
@@ -1,0 +1,12 @@
+{% extends "email/admin/contact.txt" %}
+{% block content %}
+One of your users sent you the following message using the Perma.cc contact form, http://perma.cc/contact.
+
+If you need help addressing their concerns, please contact info@perma.cc for assistance.
+
+
+
+Message from user
+--------
+{{ message }}
+{% endblock%}

--- a/perma_web/perma/tests/test_email.py
+++ b/perma_web/perma/tests/test_email.py
@@ -2,14 +2,33 @@ import random
 from createsend import Subscriber
 from mock import patch, Mock
 
+from django.conf import settings
+from django.core import mail
 from django.db.models.query import QuerySet
+from django.http import HttpRequest
 
-from perma.email import registrar_users_plus_stats, users_to_unsubscribe
+from perma.email import registrar_users_plus_stats, users_to_unsubscribe, send_user_email_copy_admins
 from perma.models import LinkUser, Organization
 
 from .utils import PermaTestCase
 
 class EmailTestCase(PermaTestCase):
+
+    def test_send_user_email_copy_admins(self):
+        send_user_email_copy_admins(
+            "title",
+            "from@example.com",
+            ["to@example.com"],
+            HttpRequest(),
+            "email/default.txt",
+            {"message": "test message"}
+        )
+        self.assertEqual(len(mail.outbox),1)
+        message = mail.outbox[0]
+        self.assertEqual(message.from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEqual(message.cc, [settings.DEFAULT_FROM_EMAIL, "from@example.com"])
+        self.assertEqual(message.to, ["to@example.com"])
+        self.assertEqual(message.reply_to, ["from@example.com"])
 
     def test_registrar_users_plus_stats(self):
         '''

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -1,17 +1,30 @@
 from django.conf import settings
 from django.core import mail
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from perma.urls import urlpatterns
+from perma.models import LinkUser, Registrar
 
 from .utils import PermaTestCase
 
 from bs4 import BeautifulSoup
+from urllib import urlencode
 
+@override_settings(CONTACT_REGISTRARS=True)
 class CommonViewsTestCase(PermaTestCase):
 
     def setUp(self):
-        self.users = ['test_user@example.com', 'test_org_user@example.com', 'test_registrar_user@example.com', 'test_admin_user@example.com']
+        self.users = ['test_user@example.com', 'test_org_user@example.com', 'multi_registrar_org_user@example.com', 'test_registrar_user@example.com', 'test_admin_user@example.com']
+        self.from_email = 'example@example.com'
+        self.custom_subject = 'Just some subject here'
+        self.message_text = 'Just some message here.'
+        self.refering_page = 'http://elsewhere.com'
+        self.our_address = settings.DEFAULT_FROM_EMAIL
+        self.subject_prefix = '[perma-contact] '
+        self.flag = "zzzz-zzzz"
+        self.flag_message = "http://perma.cc/{} contains material that is inappropriate.".format(self.flag)
+        self.flag_subject = "Reporting Inappropriate Content"
 
     def test_public_views(self):
         # test static template views
@@ -64,19 +77,15 @@ class CommonViewsTestCase(PermaTestCase):
         response = self.client.get(reverse('single_linky', kwargs={'guid': 'ABCD-0006'}))
         self.assertRedirects(response, reverse('single_linky', kwargs={'guid': '3SLN-JHX9'}))
 
-    # Contact Form
 
-    def test_contact_render(self):
-        '''
-            Does the contact form render as expected?
-        '''
-        message = "Just a little message"
-        subject = "A subject in the GET params"
-        flag = "zzzz-zzzz"
-        flag_message = "http://perma.cc/{} contains material that is inappropriate.".format(flag)
-        flag_subject = "Reporting Inappropriate Content"
+    ###
+    ###   Does the contact form render as expected?
+    ###
 
-        ## check all fields are blank with normal access
+    def test_contact_blank_when_logged_out(self):
+        '''
+            Check correct fields are blank for logged out user
+        '''
         response = self.get('contact').content
         soup = BeautifulSoup(response, 'html.parser')
         inputs = soup.select('input')
@@ -93,126 +102,262 @@ class CommonViewsTestCase(PermaTestCase):
             self.assertIn(textarea['name'],['message'])
             self.assertEqual(textarea.text, "\r\n")
 
-        ## check subject line, message, read in from GET params
-        response = self.get('contact', query_params={ 'message': message,
-                                                      'subject': subject }).content
-        soup = BeautifulSoup(response, 'html.parser')
-        subject_field = soup.find('input', {'name': 'subject'})
-        self.assertEqual(subject_field.get('value', ''), subject)
-        message_field = soup.find('textarea', {'name': 'message'})
-        self.assertEqual(message_field.text, "\r\n" + message)
-
-        ## check flag read in from GET params, and that it's subject/message override other GET params
-        response = self.get('contact', query_params={ 'flag': flag,
-                                                      'message': message,
-                                                      'subject': subject }).content
-        soup = BeautifulSoup(response, 'html.parser')
-        subject_field = soup.find('input', {'name': 'subject'})
-        self.assertEqual(subject_field.get('value', ''), flag_subject)
-        message_field = soup.find('textarea', {'name': 'message'})
-        self.assertEqual(message_field.text, "\r\n" + flag_message)
-
-
-    def test_contact_submit(self):
+    def test_contact_blank_regular(self):
         '''
-            Does the contact form submit as expected?
+            Check correct fields are blank for regular user
         '''
-        from_email = 'example@example.com'
-        custom_subject = 'Just some subject here'
-        message_text = 'Just some message here.'
-        refering_page = 'http://elsewhere.com'
+        response = self.get('contact', user="test_user@example.com").content
+        soup = BeautifulSoup(response, 'html.parser')
+        inputs = soup.select('input')
+        # Two csrf inputs: one by logout button, one in this form
+        self.assertEqual(len(inputs), 4 + 1)
+        for input in inputs:
+            self.assertIn(input['name'],['csrfmiddlewaretoken', 'referer', 'email', 'subject'])
+            if input['name'] in ['csrfmiddlewaretoken', 'email']:
+                self.assertTrue(input.get('value', ''))
+            else:
+                self.assertFalse(input.get('value', ''))
+        textareas = soup.select('textarea')
+        self.assertEqual(len(textareas), 1)
+        for textarea in textareas:
+            self.assertIn(textarea['name'],['message'])
+            self.assertEqual(textarea.text, "\r\n")
 
-        our_address = settings.DEFAULT_FROM_EMAIL
-        subject_prefix = '[perma-contact] '
-        expected_emails_sent = 0
+    def test_contact_blank_registrar(self):
+        '''
+            Check correct fields are blank for registrar user
+        '''
+        response = self.get('contact', user="test_registrar_user@example.com").content
+        soup = BeautifulSoup(response, 'html.parser')
+        inputs = soup.select('input')
+        # Two csrf inputs: one by logout button, one in this form
+        self.assertEqual(len(inputs), 4 + 1)
+        for input in inputs:
+            self.assertIn(input['name'],['csrfmiddlewaretoken', 'referer', 'email', 'subject'])
+            if input['name'] in ['csrfmiddlewaretoken', 'email']:
+                self.assertTrue(input.get('value', ''))
+            else:
+                self.assertFalse(input.get('value', ''))
+        textareas = soup.select('textarea')
+        self.assertEqual(len(textareas), 1)
+        for textarea in textareas:
+            self.assertIn(textarea['name'],['message'])
+            self.assertEqual(textarea.text, "\r\n")
 
-        ###
-        ### Success expected
-        ###
+    def test_contact_blank_single_reg_org_user(self):
+        '''
+            Check correct fields are blank for a single-registrar org user
+        '''
+        response = self.get('contact', user="test_org_user@example.com").content
+        soup = BeautifulSoup(response, 'html.parser')
+        inputs = soup.select('input')
+        # Two csrf inputs: one by logout button, one in this form
+        self.assertEqual(len(inputs), 5 + 1)
+        for input in inputs:
+            self.assertIn(input['name'],['csrfmiddlewaretoken', 'referer', 'email', 'subject', 'registrar'])
+            if input['name'] in ['csrfmiddlewaretoken', 'email', 'registrar']:
+                self.assertTrue(input.get('value', ''))
+            else:
+                self.assertFalse(input.get('value', ''))
+        textareas = soup.select('textarea')
+        self.assertEqual(len(textareas), 1)
+        for textarea in textareas:
+            self.assertIn(textarea['name'],['message'])
+            self.assertEqual(textarea.text, "\r\n")
 
-        ## All fields, including custom subject and referer
-        # submit
-        self.submit_form('contact',
-                          data = { 'email': from_email,
-                                   'message': message_text,
-                                   'subject': custom_subject,
-                                   'referer': refering_page },
-                                    success_url=reverse('contact_thanks'))
-        expected_emails_sent += 1
+    def test_contact_blank_multi_reg_org_user(self):
+        '''
+            Check correct fields are blank for a multi-registrar org user
+        '''
+        response = self.get('contact', user="multi_registrar_org_user@example.com").content
+        soup = BeautifulSoup(response, 'html.parser')
+        inputs = soup.select('input')
+        # Two csrf inputs: one by logout button, one in this form
+        self.assertEqual(len(inputs), 4 + 1)
+        for input in inputs:
+            self.assertIn(input['name'],['csrfmiddlewaretoken', 'referer', 'email', 'subject'])
+            if input['name'] in ['csrfmiddlewaretoken', 'email']:
+                self.assertTrue(input.get('value', ''))
+            else:
+                self.assertFalse(input.get('value', ''))
+        textareas = soup.select('textarea')
+        self.assertEqual(len(textareas), 1)
+        for textarea in textareas:
+            self.assertIn(textarea['name'],['message'])
+            self.assertEqual(textarea.text, "\r\n")
+        selects = soup.select('select')
+        self.assertEqual(len(selects), 1)
+        for select in selects:
+            self.assertIn(select['name'],['registrar'])
+            self.assertGreaterEqual(len(select.find_all("option")), 2)
 
-        # check contents of sent email
-        self.assertEqual(len(mail.outbox), expected_emails_sent)
-        message = mail.outbox[expected_emails_sent - 1]
-        self.assertIn(message_text, message.body)
-        self.assertIn("Referring Page: " + refering_page, message.body)
-        self.assertIn("Affiliations: (none)", message.body)
-        self.assertEqual(message.subject, subject_prefix + custom_subject)
-        self.assertEqual(message.from_email, our_address)
-        self.assertEqual(message.recipients(), [our_address])
-        self.assertDictEqual(message.extra_headers, {'Reply-To': from_email})
+    def check_contact_params(self, soup):
+        subject_field = soup.find('input', {'name': 'subject'})
+        self.assertEqual(subject_field.get('value', ''), self.custom_subject)
+        message_field = soup.find('textarea', {'name': 'message'})
+        self.assertEqual(message_field.text, "\r\n" + self.message_text)
 
-        ## All fields except custom subject and referer
-        # submit
-        self.submit_form('contact',
-                          data = { 'email': from_email,
-                                   'message': message_text },
-                          success_url=reverse('contact_thanks'))
-        expected_emails_sent += 1
+    def test_contact_params_regular(self):
+        '''
+            Check subject line, message, read in from GET params
+        '''
+        for user in self.users + [None]:
+            response = self.get('contact', query_params={ 'message': self.message_text,
+                                                          'subject': self.custom_subject, },
+                                           user=user).content
+            self.check_contact_params(BeautifulSoup(response, 'html.parser'))
 
-        # check contents of sent email
-        self.assertEqual(len(mail.outbox), expected_emails_sent)
-        message = mail.outbox[expected_emails_sent - 1]
-        self.assertIn(message_text, message.body)
-        self.assertIn("Referring Page: ", message.body)
-        self.assertIn("Affiliations: (none)", message.body)
-        self.assertEqual(message.subject, subject_prefix + 'New message from Perma contact form')
-        self.assertEqual(message.from_email, our_address )
-        self.assertEqual(message.recipients(), [our_address])
-        self.assertDictEqual(message.extra_headers, {'Reply-To': from_email})
+    def check_contact_flags(self, soup):
+        subject_field = soup.find('input', {'name': 'subject'})
+        self.assertEqual(subject_field.get('value', ''), self.flag_subject)
+        message_field = soup.find('textarea', {'name': 'message'})
+        self.assertEqual(message_field.text, "\r\n" + self.flag_message)
 
-        ## Repeat while logged in as org user; verify email only differs by listing affiliations
-        # submit
-        self.submit_form('contact',
-                          data = { 'email': from_email,
-                                   'message': message_text },
-                          success_url=reverse('contact_thanks'),
-                          user='test_another_library_org_user@example.com')
-        expected_emails_sent += 1
+    def test_contact_flags(self):
+        '''
+            Check flag read in from GET params, and that its subject/message override other GET params
+        '''
+        for user in self.users + [None]:
+            response = self.get('contact', query_params={ 'flag': self.flag,
+                                                          'message': self.message_text,
+                                                          'subject': self.custom_subject },
+                                           user=user).content
+            self.check_contact_flags(BeautifulSoup(response, 'html.parser'))
 
-        # check contents of sent email
-        self.assertEqual(len(mail.outbox), expected_emails_sent)
-        message = mail.outbox[expected_emails_sent -1]
-        self.assertIn("Affiliations: Another Library&#39;s Journal (Another Library), A Third Journal (Test Library)", message.body)
-        subbed = message.body.replace("Another Library&#39;s Journal (Another Library), A Third Journal (Test Library)", "(none)")
-        self.assertEqual(subbed, mail.outbox[expected_emails_sent - 2].body)
 
-        ## Repeat while logged in as registrar user; verify email only differs by listing affiliations
-        # submit
-        self.submit_form('contact',
-                          data = { 'email': from_email,
-                                   'message': message_text },
-                          success_url=reverse('contact_thanks'),
-                          user='test_registrar_user@example.com')
-        expected_emails_sent += 1
+    ###
+    ###   Does the contact form submit as expected?
+    ###
 
-        # check contents of sent email
-        self.assertEqual(len(mail.outbox), expected_emails_sent)
-        message = mail.outbox[expected_emails_sent -1]
-        self.assertIn("Affiliations: Test Library (Registrar)", message.body)
-        subbed = message.body.replace("Test Library (Registrar)", "(none)")
-        self.assertEqual(subbed, mail.outbox[expected_emails_sent - 3].body)
-
-        ###
-        ### Failure expected
-        ###
-
-        # Blank submission should fail and request email address and message.
-        # We should get the contact page back.
+    def test_contact_standard_submit_fail(self):
+        '''
+            Blank submission should fail and, for most users, request
+            email address and message.
+            We should get the contact page back.
+        '''
         response = self.submit_form('contact',
                                      data = { 'email': '',
                                               'message': '' },
                                      error_keys = ['email', 'message'])
         self.assertEqual(response.request['PATH_INFO'], reverse('contact'))
+
+    def test_contact_org_user_submit_fail(self):
+        '''
+            Org users are special. Blank submission should fail
+            and request email address, message, and registrar.
+            We should get the contact page back.
+        '''
+        response = self.submit_form('contact',
+                                     data = { 'email': '',
+                                              'message': '' },
+                                     user='test_org_user@example.com',
+                                     error_keys = ['email', 'message', 'registrar'])
+        self.assertEqual(response.request['PATH_INFO'], reverse('contact'))
+
+    def test_contact_standard_submit_required(self):
+        '''
+            All fields, including custom subject and referer
+        '''
+        self.submit_form('contact',
+                          data = { 'email': self.from_email,
+                                   'message': self.message_text,
+                                   'subject': self.custom_subject,
+                                   'referer': self.refering_page },
+                          success_url=reverse('contact_thanks'))
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn(self.message_text, message.body)
+        self.assertIn("Referring Page: " + self.refering_page, message.body)
+        self.assertIn("Affiliations: (none)", message.body)
+        self.assertEqual(message.subject, self.subject_prefix + self.custom_subject)
+        self.assertEqual(message.from_email, self.our_address)
+        self.assertEqual(message.recipients(), [self.our_address])
+        self.assertDictEqual(message.extra_headers, {'Reply-To': self.from_email})
+
+    def test_contact_standard_submit_no_optional(self):
+        '''
+            All fields except custom subject and referer
+        '''
+        self.submit_form('contact',
+                          data = { 'email': self.from_email,
+                                   'message': self.message_text },
+                          success_url=reverse('contact_thanks'))
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn(self.message_text, message.body)
+        self.assertIn("Referring Page: ", message.body)
+        self.assertIn("Affiliations: (none)", message.body)
+        self.assertEqual(message.subject, self.subject_prefix + 'New message from Perma contact form')
+        self.assertEqual(message.from_email, self.our_address )
+        self.assertEqual(message.recipients(), [self.our_address])
+        self.assertDictEqual(message.extra_headers, {'Reply-To': self.from_email})
+
+    def test_contact_org_user_submit_invalid(self):
+        '''
+            Org users get extra fields. Registrar must be a valid choice.
+            We should get the contact page back.
+        '''
+        response = self.submit_form('contact',
+                                     data = { 'email': self.from_email,
+                                              'message': self.message_text,
+                                              'registrar': 'not_a_real_registrar@example.com'},
+                                     user='test_org_user@example.com',
+                                     error_keys = ['registrar'])
+        self.assertEqual(response.request['PATH_INFO'], reverse('contact'))
+
+    def test_contact_org_user_submit(self):
+        '''
+            Should be sent to registrar users.
+        '''
+        registrar = 'library@university.edu'
+        registrar_users = LinkUser.objects.filter(
+            registrar__email=registrar,
+            is_active=True
+        )
+        success = reverse('contact_thanks') + "?{}".format(urlencode({'registrar': Registrar.objects.get(email=registrar).pk}))
+        expected_emails = 0
+        for user in ['test_org_user@example.com', 'multi_registrar_org_user@example.com']:
+            self.submit_form('contact',
+                              data = { 'email': self.from_email,
+                                       'message': self.message_text,
+                                       'registrar': registrar },
+                              user=user,
+                              success_url=success)
+
+            expected_emails +=1
+            self.assertEqual(len(mail.outbox), expected_emails)
+            message = mail.outbox[expected_emails -1]
+            self.assertIn(self.message_text, message.body)
+            self.assertEqual(message.from_email, self.our_address )
+            self.assertEqual(message.to, [user.email for user in registrar_users])
+            self.assertEqual(message.cc, [self.our_address, self.from_email] )
+            self.assertEqual(message.reply_to, [self.from_email])
+
+    def test_contact_org_user_affiliation_string(self):
+        '''
+            Verify org affiliations are printed correctly
+        '''
+        self.submit_form('contact',
+                          data = { 'email': self.from_email,
+                                   'message': self.message_text,
+                                   'registrar': 'library@university2.edu' },
+                          user='test_another_library_org_user@example.com')
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn("Affiliations: Another Library&#39;s Journal (Another Library), A Third Journal (Test Library)", message.body)
+
+    def test_contact_reg_user_affiliation_string(self):
+        '''
+            Verify registrar affiliations are printed correctly
+        '''
+        self.submit_form('contact',
+                          data = { 'email': self.from_email,
+                                   'message': self.message_text },
+                          user='test_registrar_user@example.com')
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn("Affiliations: Test Library (Registrar)", message.body)
 
     def test_about_partner_list(self):
         '''

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     url(r'^privacy-policy/?$', DirectTemplateView.as_view(template_name='privacy_policy.html'), name='privacy_policy'),
     url(r'^contingency-plan/?$', DirectTemplateView.as_view(template_name='contingency_plan.html'), name='contingency_plan'),
     url(r'^contact/?$', common.contact, name='contact'),
-    url(r'^contact/thanks/?$', DirectTemplateView.as_view(template_name='contact-thanks.html'), name='contact_thanks'),
+    url(r'^contact/thanks/?$', common.contact_thanks, name='contact_thanks'),
     #   url(r'^is500/?$', DirectTemplateView.as_view(template_name='500.html'), name='is500'),
     #	url(r'^is404/?$', DirectTemplateView.as_view(template_name='404.html'), name='is404'),
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -7,8 +7,10 @@ from ratelimit.decorators import ratelimit
 from datetime import timedelta
 from wsgiref.handlers import format_date_time
 from ua_parser import user_agent_parser
+from urllib import urlencode
 
 from django.core.files.storage import default_storage
+from django.forms import widgets
 from django.template import RequestContext
 from django.http import HttpResponseForbidden
 from django.shortcuts import render_to_response, render, get_object_or_404
@@ -23,7 +25,7 @@ from django.views.decorators.cache import cache_control
 from ..models import Link, Registrar, Organization, LinkUser
 from ..forms import ContactForm
 from ..utils import if_anonymous, ratelimit_ip_key
-from ..email import send_admin_email
+from ..email import send_admin_email, send_user_email_copy_admins
 
 logger = logging.getLogger(__name__)
 valid_serve_types = ['image', 'warc_download']
@@ -206,40 +208,77 @@ def contact(request):
     """
     Our contact form page
     """
+    def affiliation_string():
+        affiliation_string = ''
+        if request.user.is_authenticated():
+            if request.user.registrar:
+                affiliation_string = "{} (Registrar)".format(request.user.registrar.name)
+            else:
+                affiliations = ["{} ({})".format(org.name, org.registrar.name) for org in request.user.organizations.all().order_by('registrar')]
+                if affiliations:
+                    affiliation_string = ', '.join(affiliations)
+        return affiliation_string
+
+    def handle_registrar_fields(form):
+        if getattr(request.user, 'is_organization_user', ''):
+            registrars = set(org.registrar for org in request.user.organizations.all())
+            if len(registrars) > 1:
+                form.fields['registrar'].choices = [(registrar.email, registrar.name) for registrar in registrars]
+            if len(registrars) == 1:
+                form.fields['registrar'].widget = widgets.HiddenInput()
+                email = registrars.pop().email
+                form.fields['registrar'].initial = email
+                form.fields['registrar'].choices = [(email,email)]
+        else:
+            del form.fields['registrar']
+        return form
+
+    def should_send_to_registrar():
+        return settings.CONTACT_REGISTRARS and \
+               getattr(request.user, 'is_organization_user', '')
 
     if request.method == 'POST':
-        form = ContactForm(request.POST)
+        form = handle_registrar_fields(ContactForm(request.POST))
         if form.is_valid():
-            # If our form is valid, let's generate and email to our contact folks
-
+            # Assemble info for email
             from_address = form.cleaned_data['email']
             subject = "[perma-contact] " + form.cleaned_data['subject']
-            referer = form.cleaned_data['referer']
-
-            affiliation_string = ''
-            if request.user.is_authenticated():
-                if request.user.registrar:
-                    affiliation_string = "{} (Registrar)".format(request.user.registrar.name)
-                else:
-                    affiliations = ["{} ({})".format(org.name, org.registrar.name) for org in request.user.organizations.all().order_by('registrar')]
-                    if affiliations:
-                        affiliation_string = ', '.join(affiliations)
-
-            send_admin_email(
-                subject,
-                from_address,
-                request,
-                'email/admin/contact.txt',
-                {
-                    "message": form.cleaned_data['message'],
-                    "from_address": from_address,
-                    "referer": referer,
-                    "affiliation_string": affiliation_string
-                },
-                referer
-            )
-            # redirect to a new URL:
-            return HttpResponseRedirect(reverse('contact_thanks'))
+            context = {
+                "message": form.cleaned_data['message'],
+                "from_address": from_address,
+                "referer": form.cleaned_data['referer'],
+                "affiliation_string": affiliation_string()
+            }
+            if should_send_to_registrar():
+                # Send to all active registar users for registrar and cc Perma
+                reg_email = form.cleaned_data['registrar']
+                registrar_users = LinkUser.objects.filter(
+                  registrar__email=reg_email,
+                  is_active=True
+                )
+                send_user_email_copy_admins(
+                    subject,
+                    from_address,
+                    [user.email for user in registrar_users],
+                    request,
+                    'email/registrar_contact.txt',
+                    context
+                )
+                # redirect to a new URL:
+                return HttpResponseRedirect(
+                    reverse('contact_thanks') + "?{}".format(urlencode({'registrar': Registrar.objects.get(email=reg_email).pk}))
+                )
+            else:
+                # Send only to the admins
+                send_admin_email(
+                    subject,
+                    from_address,
+                    request,
+                    'email/admin/contact.txt',
+                    context
+                )
+                # redirect to a new URL:
+                return HttpResponseRedirect(reverse('contact_thanks'))
         else:
             context = RequestContext(request, {'form': form})
             return render_to_response('contact.html', context)
@@ -257,17 +296,30 @@ def contact(request):
 
         subject = request.GET.get('subject', '')
         message = request.GET.get('message', '')
-        flagged_archive_guid = request.GET.get('flag', '')
 
+        flagged_archive_guid = request.GET.get('flag', '')
         if flagged_archive_guid:
             subject = 'Reporting Inappropriate Content'
             message = 'http://perma.cc/%s contains material that is inappropriate.' % flagged_archive_guid
 
-
-        form = ContactForm(initial={'message': message,
-                                    'subject': subject,
-                                    'referer': request.META.get('HTTP_REFERER', ''),
-                                    })
+        form = handle_registrar_fields(
+            ContactForm(
+                initial={
+                    'message': message,
+                    'subject': subject,
+                    'referer': request.META.get('HTTP_REFERER', ''),
+                    'email': getattr(request.user, 'email', '')
+                }
+            )
+        )
 
         context = RequestContext(request, {'form': form})
         return render_to_response('contact.html', context)
+
+def contact_thanks(request):
+    """
+    When a user hits a rate limit, send them here.
+    """
+    registrar = Registrar.objects.filter(pk=request.GET.get('registrar', '-1')).first()
+    registrar_users = LinkUser.objects.filter(registrar=registrar, is_active=True)
+    return render(request, 'contact-thanks.html', {'registrar': registrar, 'registrar_users': registrar_users})


### PR DESCRIPTION
All is unchanged for not-logged-in users, regular users, and registrar users.

Org users associated with a single org still see the normal contact form, but a hidden field naming their registrar is included in the form:
![image](https://cloud.githubusercontent.com/assets/11020492/21024418/7154df58-bd52-11e6-8c7f-dbfe9b2ec4fc.png)

Org users associated with multiple orgs are presented with a drop down list:
![image](https://cloud.githubusercontent.com/assets/11020492/21024492/b6606b94-bd52-11e6-83b4-abffd15f1174.png)

If, in config, CONTACT_REGISTRARS = True (False by default via common.py), then when the form is submitted, an email is sent to all the active registrar users associated with the org, and both Perma and the sender are cc'ed. And, the user is delivered at a customized thank you page, listing the names and email addresses of everyone who has been emailed:



In all other situations, an email is sent to Perma as usual, and the normal thanks page is displayed.
![image](https://cloud.githubusercontent.com/assets/11020492/21024813/e1bf8468-bd53-11e6-812e-dd51fa4bd17f.png)

