### PR TITLE
Activation email tweaks

### DIFF
--- a/perma_web/perma/templates/user_management/activation-email.html
+++ b/perma_web/perma/templates/user_management/activation-email.html
@@ -1,0 +1,13 @@
+{% extends "base-responsive.html" %}
+{% block title %} | Activation Email Resent {% endblock %}
+
+{% block mainContent %}
+<div class="container cont-fixed">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1 class="page-title">Activation Email Resent</h1>
+      <p class="page-dek">A new activation email has been sent to {{email}}</p>
+    </div>
+  </div>
+</div>
+{% endblock mainContent %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -254,6 +254,9 @@
           {% if request.user.is_staff %}
             <p class="item-status"><a class="action" href="{% url "admin:perma_linkuser_change" listed_user.id %}">edit in admin console</a></p>
           {% endif %}
+          {% if not listed_user.is_confirmed %}
+            <p class="item-status"><a class="action" href="{% url 'user_management_resend_activation' listed_user.id %}">resend activation email</a></p>
+          {% endif %}
           <p class="item-activity">
             created {{ listed_user.date_joined|date:'F j, Y' }}
             {% if listed_user.is_confirmed %}

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -127,7 +127,8 @@ class PermissionsTestCase(PermaTestCase):
 
             # Things that are no longer needed and have become redirects or other special cases
             excluded_names = ['create_link_with_org',
-                              'link_browser',]
+                              'link_browser',
+                              'user_management_resend_activation']
 
             if urlpattern._regex.startswith(r'^manage/') and urlpattern._regex != '^manage/?$' and urlpattern.name not in excluded_names:
                 self.assertTrue(urlpattern.name in views_tested,

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -113,6 +113,7 @@ urlpatterns = [
     url(r'^manage/users/(?P<user_id>\d+)/?$', user_management.manage_single_user, name='user_management_manage_single_user'),
     url(r'^manage/users/(?P<user_id>\d+)/delete/?$', user_management.manage_single_user_delete, name='user_management_manage_single_user_delete'),
     url(r'^manage/users/(?P<user_id>\d+)/reactivate/?$', user_management.manage_single_user_reactivate, name='user_management_manage_single_user_reactivate'),
+    url(r'^manage/users/resend-activation/(?P<user_id>\d+)/?$', user_management.resend_activation, name='user_management_resend_activation'),
 
     url(r'^manage/organization-users/?$', user_management.manage_organization_user, name='user_management_manage_organization_user'),
     url(r'^manage/organization-users/add-user/?$', AddUserToOrganization.as_view(), name='user_management_organization_user_add_user'),


### PR DESCRIPTION
1) If an unconfirmed/inactive user tries to reset their password using the reset password form, they are forwarded to the "Your account is not active, click here to resend your activation email" page. Old behavior: password reset form informs the user it was successfully submitted, and that they'll will a password reset email, which is not true.

2) Adds a button next to unconfirmed/inactive users on the /manage/{users, organization-users, registrar-users} pages.
![image](https://cloud.githubusercontent.com/assets/11020492/21154916/2058504a-c13e-11e6-884f-02c55a41c6b7.png)

It resends their activation email, and takes you to a confirmation page.
![image](https://cloud.githubusercontent.com/assets/11020492/21155004/70f59e90-c13e-11e6-9014-3e9401e33870.png)
