### PR TITLE
Users lacking permission get 403s

### DIFF
--- a/perma_web/perma/templates/403.html
+++ b/perma_web/perma/templates/403.html
@@ -1,0 +1,16 @@
+{% extends "base-responsive.html" %}
+{% block title %} | 403 Permission Denied{% endblock %}
+
+{% block mainContent %}
+<div class="container cont-fixed">
+  <div class="row">
+    <div class="col-xs-12">
+      <h1 class="page-title">Permission Denied</h1>
+      <p class="page-dek">
+        You don't appear to have access to the requested resource. If you
+        believe you reached this page in error, please <a href="{% url 'contact' %}?subject=Permission%20Denied">contact us</a>.
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -119,8 +119,10 @@ class PermissionsTestCase(PermaTestCase):
                 for user in view.get('disallowed', all_users - view['allowed']):
                     self.log_in_user(user)
                     resp = self.client.get(url)
-                    self.assertRedirects(resp, settings.LOGIN_URL+"?next="+url, target_status_code=302,
-                                         msg_prefix="Error while confirming that %s can't view %s: " % (user, view_name))
+                    self.assertEqual(resp.status_code, 403,
+                                         "View %s returned status %s for user %s; expected %s." % (view_name, resp.status_code, user, success_status))
+                    # self.assertRedirects(resp, settings.LOGIN_URL+"?next="+url, target_status_code=302,
+                    #                      msg_prefix="Error while confirming that %s can't view %s: " % (user, view_name))
 
         # make sure that all ^manage/ views were tested
         for urlpattern in urlpatterns:

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -14,6 +14,7 @@ from django.db.models import Q
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.utils.decorators import available_attrs
+from django.contrib.auth.decorators import login_required
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ def user_passes_test_or_403(test_func):
     returns True if the user passes.
     """
     def decorator(view_func):
+        @login_required()
         @wraps(view_func, assigned=available_attrs(view_func))
         def _wrapped_view(request, *args, **kwargs):
             if not test_func(request.user):

--- a/perma_web/perma/views/error_management.py
+++ b/perma_web/perma/views/error_management.py
@@ -1,7 +1,6 @@
 import json
 
 from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404
 
@@ -10,13 +9,11 @@ from perma.utils import user_passes_test_or_403
 from ..models import UncaughtError
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def get_all(request):
     errors = UncaughtError.objects.filter(resolved=False).order_by('-created_at')[:40]
     return render(request, 'errors/view.html', {'errors': errors})
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def resolve(request):
     error = get_object_or_404(UncaughtError, pk=request.POST.get('error_id'))

--- a/perma_web/perma/views/error_management.py
+++ b/perma_web/perma/views/error_management.py
@@ -1,21 +1,23 @@
 import json
 
 from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404
+
+from perma.utils import user_passes_test_or_403
 
 from ..models import UncaughtError
 
 
 @login_required
-@user_passes_test(lambda user: user.is_staff)
+@user_passes_test_or_403(lambda user: user.is_staff)
 def get_all(request):
     errors = UncaughtError.objects.filter(resolved=False).order_by('-created_at')[:40]
     return render(request, 'errors/view.html', {'errors': errors})
 
 @login_required
-@user_passes_test(lambda user: user.is_staff)
+@user_passes_test_or_403(lambda user: user.is_staff)
 def resolve(request):
     error = get_object_or_404(UncaughtError, pk=request.POST.get('error_id'))
     error.resolved = True

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -58,29 +58,23 @@ valid_org_sorts = ['name', '-name', 'link_count', '-link_count', '-date_created'
 
 class RequireOrgOrRegOrAdminUser(object):
     """ Mixin for class-based views that requires user to be an org user, registrar user, or admin. """
-    @method_decorator(login_required)
     @method_decorator(user_passes_test_or_403(lambda user: user.is_registrar_user() or user.is_organization_user or user.is_staff))
     def dispatch(self, request, *args, **kwargs):
         return super(RequireOrgOrRegOrAdminUser, self).dispatch(request, *args, **kwargs)
 
 class RequireRegOrAdminUser(object):
     """ Mixin for class-based views that requires user to be a registrar user or admin. """
-    @method_decorator(login_required)
     @method_decorator(user_passes_test_or_403(lambda user: user.is_registrar_user() or user.is_staff))
     def dispatch(self, request, *args, **kwargs):
         return super(RequireRegOrAdminUser, self).dispatch(request, *args, **kwargs)
 
 class RequireAdminUser(object):
     """ Mixin for class-based views that requires user to be an admin. """
-    @method_decorator(login_required)
     @method_decorator(user_passes_test_or_403(lambda user: user.is_staff))
     def dispatch(self, request, *args, **kwargs):
         return super(RequireAdminUser, self).dispatch(request, *args, **kwargs)
 
 
-
-
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def stats(request, stat_type=None):
 
@@ -189,7 +183,7 @@ def stats(request, stat_type=None):
     else:
         return render(request, 'user_management/stats.html', locals())
 
-@login_required
+
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_registrar(request):
     """
@@ -243,7 +237,7 @@ def manage_registrar(request):
     })
 
 
-@login_required
+
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
 def manage_single_registrar(request, registrar_id):
     """ Edit details for a registrar. """
@@ -268,7 +262,6 @@ def manage_single_registrar(request, registrar_id):
     })
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def approve_pending_registrar(request, registrar_id):
     """ Perma admins can approve account requests from libraries """
@@ -300,7 +293,6 @@ def approve_pending_registrar(request, registrar_id):
         'this_page': 'users_registrars'})
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
 def manage_organization(request):
     """
@@ -363,7 +355,6 @@ def manage_organization(request):
     })
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
 def manage_single_organization(request, org_id):
     """ Edit organization details. """
@@ -389,7 +380,6 @@ def manage_single_organization(request, org_id):
     })
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
 def manage_single_organization_delete(request, org_id):
     """
@@ -415,76 +405,58 @@ def manage_single_organization_delete(request, org_id):
     })
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_admin_user(request):
     return list_users_in_group(request, 'admin_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_admin_user_delete(request, user_id):
     return delete_user_in_group(request, user_id, 'admin_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
 def manage_registrar_user(request):
     return list_users_in_group(request, 'registrar_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_registrar_user(request, user_id):
     return edit_user_in_group(request, user_id, 'registrar_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_registrar_user_delete(request, user_id):
     return delete_user_in_group(request, user_id, 'registrar_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_registrar_user_reactivate(request, user_id):
     return reactive_user_in_group(request, user_id, 'registrar_user')
 
-
-
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_user(request):
     return list_users_in_group(request, 'user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_user(request, user_id):
     return edit_user_in_group(request, user_id, 'user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_user_delete(request, user_id):
     return delete_user_in_group(request, user_id, 'user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_user_reactivate(request, user_id):
     return reactive_user_in_group(request, user_id, 'user')
 
-
-
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
 def manage_organization_user(request):
     return list_users_in_group(request, 'organization_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
 def manage_single_organization_user(request, user_id):
     return edit_user_in_group(request, user_id, 'organization_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_organization_user_delete(request, user_id):
     return delete_user_in_group(request, user_id, 'organization_user')
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_organization_user_reactivate(request, user_id):
     return reactive_user_in_group(request, user_id, 'organization_user')
@@ -798,7 +770,6 @@ class AddRegularUser(RequireAdminUser, BaseAddUserToGroup):
         return self.is_new, "User already exists."
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_organization_user)
 def organization_user_leave_organization(request, org_id):
     try:
@@ -824,7 +795,6 @@ def organization_user_leave_organization(request, org_id):
     return render_to_response('user_management/user_leave_confirm.html', context)
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def delete_user_in_group(request, user_id, group_name):
     """
@@ -852,7 +822,6 @@ def delete_user_in_group(request, user_id, group_name):
     return render_to_response('user_management/user_delete_confirm.html', context)
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_registrar_user() or user.is_organization_user or user.is_staff)
 def manage_single_organization_user_remove(request, user_id):
     """
@@ -875,7 +844,6 @@ def manage_single_organization_user_remove(request, user_id):
     return HttpResponseRedirect(reverse('user_management_manage_organization_user'))
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_registrar_user())
 def manage_single_registrar_user_remove(request, user_id):
     """
@@ -906,7 +874,6 @@ def manage_single_registrar_user_remove(request, user_id):
     return render_to_response('user_management/user_remove_registrar_confirm.html', context)
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_admin_user_remove(request, user_id):
     """
@@ -933,7 +900,6 @@ def manage_single_admin_user_remove(request, user_id):
     return render_to_response('user_management/user_remove_admin_confirm.html', context)
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff)
 def reactive_user_in_group(request, user_id, group_name):
     """
@@ -990,7 +956,6 @@ def settings_password(request):
     return render_to_response('user_management/settings-password.html', context)
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_registrar_user() or user.is_organization_user or user.has_registrar_pending())
 def settings_affiliations(request):
     """
@@ -1011,7 +976,6 @@ def settings_affiliations(request):
         'orgs_by_registrar': orgs_by_registrar})
 
 
-@login_required
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
 def settings_organizations_change_privacy(request, org_id):
     try:
@@ -1081,7 +1045,6 @@ def not_active(request):
 
 
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
-@login_required()
 def resend_activation(request, user_id):
     """
     Sends a user another account activation email.


### PR DESCRIPTION
Currently, if you are logged in and attempt to access a resource you don't have permission to access (e.g. test_user@example.com tries to access /manage/stats), you are redirected to the login form. The login form perceives that you are already logged in, and redirects you to the page you started at. Lather, rinse, repeat.

Here, you get a 403 "Forbidden" error instead, and are directed to a styled error page.