### PR TITLE
Handle long unicode strings passed as URLs to link creation api

### DIFF
--- a/perma_web/api/tests/test_link_validation.py
+++ b/perma_web/api/tests/test_link_validation.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 from .utils import TEST_ASSETS_DIR, ApiResourceTransactionTestCase
 from api.resources import LinkResource
@@ -34,6 +36,14 @@ class LinkValidationTestCase(ApiResourceTransactionTestCase):
     ########
     # URLs #
     ########
+    def test_should_fail_gracefully_if_passed_long_unicode(self):
+        '''
+            See https://github.com/harvard-lil/perma/issues/1841
+        '''
+        u = u"This is a block of text that contains 64 or more characters, including one or more unicode characters like ☃"
+        self.rejected_post(self.list_url,
+                           user=self.org_user,
+                           data={'url': u})
 
     @override_settings(BANNED_IP_RANGES=["0.0.0.0/8", "127.0.0.0/8"])
     def test_should_reject_invalid_ip(self):

--- a/perma_web/api/validations.py
+++ b/perma_web/api/validations.py
@@ -101,6 +101,9 @@ class LinkValidation(DefaultValidation):
                         errors['url'] = "Couldn't load URL."
                     elif not self.is_valid_size(bundle.obj.headers):
                         errors['url'] = "Target page is too large (max size 1MB)."
+            except UnicodeError:
+                # see https://github.com/harvard-lil/perma/issues/1841
+                errors['url'] = "Unicode error while processing URL."
             except ValidationError:
                 errors['url'] = "Not a valid URL."
             except TooManyRedirects:


### PR DESCRIPTION
Fixes https://github.com/harvard-lil/perma/issues/1841

