### PR TITLE
Tweak to task for sending the email that pings registrar users

### DIFF
--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -80,14 +80,15 @@ def send_user_email_copy_admins(title, from_address, to_addresses, request, temp
 ### Collect user data, bundled for emails ###
 ###
 
-def registrar_users_plus_stats(destination=None):
+def registrar_users_plus_stats(destination=None, registrars=None):
     '''
         Returns all active registrar users plus assorted metadata as
         a list of dicts. If destination=cm, info is formatted for
         ingest by Campaign Monitor.
     '''
     users = []
-    registrars = Registrar.objects.all()
+    if type(registrars) == type(None):
+        registrars = Registrar.objects.all()
     for registrar in registrars:
         registrar_users = LinkUser.objects.filter(registrar = registrar.pk,
                                                   is_active = True,

--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -87,7 +87,7 @@ def registrar_users_plus_stats(destination=None, registrars=None):
         ingest by Campaign Monitor.
     '''
     users = []
-    if type(registrars) == type(None):
+    if registrars is None:
         registrars = Registrar.objects.all()
     for registrar in registrars:
         registrar_users = LinkUser.objects.filter(registrar = registrar.pk,

--- a/perma_web/perma/tests/test_email.py
+++ b/perma_web/perma/tests/test_email.py
@@ -8,7 +8,7 @@ from django.db.models.query import QuerySet
 from django.http import HttpRequest
 
 from perma.email import registrar_users_plus_stats, users_to_unsubscribe, send_user_email_copy_admins
-from perma.models import LinkUser, Organization
+from perma.models import LinkUser, Organization, Registrar
 
 from .utils import PermaTestCase
 
@@ -36,6 +36,7 @@ class EmailTestCase(PermaTestCase):
         '''
         r_list = registrar_users_plus_stats()
         self.assertEqual(type(r_list), list)
+        self.assertGreater(len(r_list), 0)
         for user in r_list:
             self.assertEqual(type(user), dict)
             expected_keys = [ 'email',
@@ -63,12 +64,22 @@ class EmailTestCase(PermaTestCase):
             for user in user['registrar_users']:
                 self.assertEqual(type(user), LinkUser)
 
+    def test_registrar_users_plus_stats_specific_registrars(self):
+        '''
+            Returns data in the expected format.
+        '''
+        r_list = registrar_users_plus_stats(registrars=Registrar.objects.filter(email='library@university.edu'))
+        self.assertEqual(type(r_list), list)
+        self.assertEqual(len(r_list), 1)
+        self.assertEqual(r_list[0]['registrar_email'], 'library@university.edu')
+
     def test_registrar_users_plus_stats_cm(self):
         '''
             Returns data in the expected format for Campaign Monitor.
         '''
         r_list = registrar_users_plus_stats(destination="cm")
         self.assertEqual(type(r_list), list)
+        self.assertGreater(len(r_list), 0)
         for user in r_list:
             self.assertEqual(type(user), dict)
             self.assertEqual(sorted(user.keys()), ['CustomFields','EmailAddress','Name' ])


### PR DESCRIPTION
Instead of sending to all eligible registrar users, allow filters to be passed in to the fab task:
limit_to, limit_by_tag, exclude, and exclude_by_tag

This gives us a little more control over the sending process, including the ability to send a test email in production, just to be extra careful, and the ability to resend to an arbitrary subset of registrars' users.