### PR TITLE
Generalize year for registrar users' stats

### DIFF
--- a/perma_web/perma/templates/email/registrar_user_ping.txt
+++ b/perma_web/perma/templates/email/registrar_user_ping.txt
@@ -14,8 +14,8 @@ If any of this information is wrong, please update your registrar user informati
 Second: Below is an overview of Perma usage by those affiliated with your institution. If you have questions about these stats and the activity levels within your entity, please contact us.
 
     Perma Links created (total): {{ total_links }}
-    Perma Links created (2017): {{ this_year_links }}
-    Your most active organization: {{ most_active_org.name | default:"(no activity in your organizations this year)" }}
+    Perma Links created ({{ year }}): {{ year_links }}
+    Your most active organization ({{ year }}): {{ most_active_org.name | default:"(no activity in your organizations)" }}
 
 Third: We've observed that many questions sent to us by users are best addressed by their respective Registrars. In coming weeks, we'll be making it easier for Perma users in your community to connect with you when they have basic questions about Perma. This, in turn, will give you more visibility into how your community is using this service. Our team will remain focused on improving the Perma service and working directly with you to make sure that it meets your community’s needs.
 

--- a/perma_web/perma/tests/test_email.py
+++ b/perma_web/perma/tests/test_email.py
@@ -47,8 +47,8 @@ class EmailTestCase(PermaTestCase):
                               'registrar_id',
                               'registrar_name',
                               'registrar_users',
-                              'this_year_links',
-                              'total_links' ]
+                              'total_links',
+                              'year_links' ]
             self.assertEqual(sorted(user.keys()), expected_keys)
             for key in ['email', 'first_name', 'last_name', 'registrar_email', 'registrar_name']:
                 self.assertEqual(type(user[key]), unicode)
@@ -58,7 +58,7 @@ class EmailTestCase(PermaTestCase):
             self.assertTrue(perma_user.is_active)
             self.assertTrue(perma_user.is_confirmed)
             self.assertEqual(type(user['total_links']), long)
-            self.assertEqual(type(user['this_year_links']), int)
+            self.assertEqual(type(user['year_links']), int)
             self.assertEqual(type(user['registrar_id']), long)
             self.assertIsInstance(user['most_active_org'], (Organization, type(None)))
             self.assertEqual(type(user['registrar_users']), QuerySet)
@@ -95,7 +95,7 @@ class EmailTestCase(PermaTestCase):
                                   'RegistrarEmail',
                                   'RegistrarName',
                                   'RegistrarUsers',
-                                  'ThisYearLinks',
+                                  'YearLinks',
                                   'TotalLinks' ]
             for custom_field in user['CustomFields']:
                 self.assertEqual(type(custom_field), dict)

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -47,16 +47,20 @@ class ModelsTestCase(PermaTestCase):
         three_years_ago = datetime(now.year - 3, 1, 1)
         user = LinkUser()
         user.save()
-        link_pks = ["AAAA-AAAA", "BBBB-BBBB", "CCCC-CCCC"]
-        too_early = Link(creation_timestamp=three_years_ago, guid=link_pks[0], created_by=user)
-        too_early.save()
-        now1 = Link(creation_timestamp=now, guid=link_pks[1], created_by=user)
+        link_pks = ["AAAA-AAAA", "BBBB-BBBB", "CCCC-CCCC", "DDDD-DDDD", "EEEE-EEEE"]
+        older= Link(creation_timestamp=three_years_ago, guid=link_pks[0], created_by=user)
+        older.save()
+        old = Link(creation_timestamp=two_years_ago, guid=link_pks[1], created_by=user)
+        old.save()
+        now1 = Link(creation_timestamp=now, guid=link_pks[2], created_by=user)
         now1.save()
-        last_year1 = Link(creation_timestamp=two_years_ago, guid=link_pks[2], created_by=user)
-        last_year1.save()
+        now2 = Link(creation_timestamp=now, guid=link_pks[3], created_by=user)
+        now2.save()
+        now3 = Link(creation_timestamp=now, guid=link_pks[4], created_by=user)
+        now3.save()
 
         links = Link.objects.filter(pk__in=link_pks)
-        self.assertEqual(len(links), 3)
+        self.assertEqual(len(links), 5)
         self.assertEqual(link_count_in_time_period(links, three_years_ago, two_years_ago), 2)
 
     def test_org_link_count_this_year(self):
@@ -116,7 +120,67 @@ class ModelsTestCase(PermaTestCase):
         self.assertEqual(len(links), 4)
         self.assertEqual(r.link_count_this_year(), 3)
 
-    def test_registrar_most_active_org(self):
+    def test_most_active_org_in_time_period_no_links(self):
+        '''
+            If no orgs with links in period, should return None
+        '''
+        r = Registrar()
+        r.save()
+        o1 = Organization(registrar=r)
+        o1.save()
+        o2 = Organization(registrar=r)
+        o2.save()
+        self.assertEqual(type(most_active_org_in_time_period(r.organizations)), type(None))
+
+    def test_most_active_org_in_time_period_invalid_dates(self):
+        '''
+            If end date is before start date, should raise an exception
+        '''
+        r = Registrar()
+        r.save()
+        now = datetime(datetime.now().year, 1, 1)
+        later = datetime(datetime.now().year + 1, 1, 1)
+        with self.assertRaises(ValueError):
+            most_active_org_in_time_period(r.organizations, later, now)
+
+    def test_most_active_org_in_time_period_valid_period(self):
+        '''
+            Should include links created only in the target year
+        '''
+        now = datetime(datetime.now().year, 1, 1)
+        two_years_ago = datetime(now.year - 2, 1, 1)
+        three_years_ago = datetime(now.year - 3, 1, 1)
+
+        r = Registrar()
+        r.save()
+        o1 = Organization(registrar=r)
+        o1.save()
+        o2 = Organization(registrar=r)
+        o2.save()
+        user = LinkUser()
+        user.save()
+        link_pks = ["AAAA-AAAA", "BBBB-BBBB", "CCCC-CCCC", "DDDD-DDDD", "EEEE-EEEE"]
+
+        too_early1 = Link(creation_timestamp=three_years_ago, guid=link_pks[0], organization=o1, created_by=user)
+        too_early1.save()
+        too_early2 = Link(creation_timestamp=three_years_ago, guid=link_pks[1], organization=o1, created_by=user)
+        too_early2.save()
+
+        now1 = Link(creation_timestamp=now, guid=link_pks[2], organization=o1, created_by=user)
+        now1.save()
+        now2 = Link(creation_timestamp=now, guid=link_pks[3], organization=o2, created_by=user)
+        now2.save()
+        now3 = Link(creation_timestamp=now, guid=link_pks[4], organization=o2, created_by=user)
+        now3.save()
+
+        # organization 1 was more active in the past
+        self.assertEqual(most_active_org_in_time_period(r.organizations, three_years_ago, two_years_ago), o1)
+        # but organization 2 was more active during the period in question
+        self.assertEqual(most_active_org_in_time_period(r.organizations, two_years_ago), o2)
+        # with a total of three links, organization 1 has been more active over all
+        self.assertEqual(most_active_org_in_time_period(r.organizations), o1)
+
+    def test_registrar_most_active_org_this_year(self):
         '''
             Should return the org (whole object)with the most links
             created this year, or None if it has no orgs with links
@@ -124,7 +188,7 @@ class ModelsTestCase(PermaTestCase):
         '''
         r = Registrar()
         r.save()
-        self.assertEqual(type(r.most_active_org()), type(None))
+        self.assertEqual(type(r.most_active_org_this_year()), type(None))
 
         o1 = Organization(registrar=r)
         o1.save()
@@ -138,7 +202,7 @@ class ModelsTestCase(PermaTestCase):
         link_pks = ["AAAA-AAAA", "BBBB-BBBB", "CCCC-CCCC", "DDDD-DDDD", "EEEE-EEEE", "FFFF-FFFF"]
         too_early = Link(creation_timestamp=two_years_ago, guid=link_pks[0], created_by=user, organization=o1)
         too_early.save()
-        self.assertEqual(type(r.most_active_org()), type(None))
+        self.assertEqual(type(r.most_active_org_this_year()), type(None))
 
         now1 = Link(creation_timestamp=now, guid=link_pks[1], created_by=user, organization=o1)
         now1.save()
@@ -147,12 +211,12 @@ class ModelsTestCase(PermaTestCase):
         now3 = Link(creation_timestamp=now, guid=link_pks[3], created_by=user, organization=o2)
         now3.save()
 
-        self.assertEqual(r.most_active_org(), o1)
+        self.assertEqual(r.most_active_org_this_year(), o1)
 
         now4 = Link(creation_timestamp=now, guid=link_pks[4], created_by=user, organization=o2)
         now4.save()
         now5 = Link(creation_timestamp=now, guid=link_pks[5], created_by=user, organization=o2)
         now5.save()
 
-        self.assertEqual(r.most_active_org(), o2)
+        self.assertEqual(r.most_active_org_this_year(), o2)
 


### PR DESCRIPTION
Since we're in January, we want to be able to send registrar users 2016 stats instead of 2017. Add some abstraction and parameters to make that possible.

