### PR TITLE
fix - added http protocol to image url metatag

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -15,16 +15,16 @@
   <meta name="robots" content="noindex, noimageindex">
 
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ link_url }}">
+  <meta property="og:url" content="{{ protocol }}{{ link_url }}">
   <meta property="og:title" content="{{ link.submitted_title }}">
   <meta property="og:description" content="{{ link.submitted_description }}">
-  <meta property="og:image" content="{{ request.get_host }}{{ STATIC_URL }}img/sharing/blue_logo.png">
+  <meta property="og:image" content="{{ protocol }}{{ request.get_host }}{{ STATIC_URL }}img/sharing/blue_logo.png">
 
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:url" content="{{ link_url }}">
+  <meta name="twitter:url" content="{{ protocol }}{{ link_url }}">
   <meta name="twitter:title" content="{{ link.submitted_title }}">
   <meta name="twitter:description" content="{{ link.submitted_description }}">
-  <meta name="twitter:image" content="{{ request.get_host }}{{ STATIC_URL }}img/sharing/blue_logo.png">
+  <meta name="twitter:image" content="{{ protocol }}{{ request.get_host }}{{ STATIC_URL }}img/sharing/blue_logo.png">
 
 {% endblock %}
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -180,7 +180,8 @@ def single_linky(request, guid):
         'new_record': new_record,
         'this_page': 'single_link',
         'max_size': max_size,
-        'link_url': protocol + settings.HOST + '/' + link.guid,
+        'link_url': settings.HOST + '/' + link.guid,
+        'protocol': protocol,
     }
 
     response = render(request, 'archive/single-link.html', context)


### PR DESCRIPTION
image meta tag fails for both twitter and facebook
to fix the warning: `Object at URL 'https://perma-dev.org/CD3H-CCV3' of type 'website' is invalid because the given value 'perma-dev.org/static/img/sharing/blue_logo.png' for property 'og:image:url' could not be parsed as type 'url'.
`