### PR TITLE
Fix pywb django templates

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -16,12 +16,17 @@ def run_django(port="0.0.0.0:8000"):
     """
         Run django test server on open port, so it's accessible outside Vagrant.
     """
-    commands = [
-        # This causes a documented memory leak: commented out for convenience.
-        # Turn on if you need it.
-        # 'celery -A perma worker --loglevel=info -B',
-        'npm start'
-    ]
+    commands = []
+
+    if settings.RUN_TASKS_ASYNC:
+        print("Starting background celery process. Warning: this has a documented memory leak, and developing with"
+              " RUN_TASKS_ASYNC=False is usually easier unless you're specifically testing a Django-Celery interaction.")
+        commands.append('celery -A perma worker --loglevel=info -B')
+
+    # Only run the webpack background process in debug mode -- with debug False, dev server uses static assets,
+    # and running webpack just messes up the webpack stats file.
+    if settings.DEBUG:
+        commands.append('npm start')
 
     proc_list = [subprocess.Popen(command, shell=True, stdout=sys.stdout, stderr=sys.stderr) for command in commands]
 

--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -323,9 +323,13 @@ class PermaMementoTimemapView(MementoTimemapView):
 
 
 class PermaTemplateView(object):
+    """
+        Class to render Django templates for Pywb views. Uses a fake request from the Django testing library
+        to get Django to render a template without a real Django request object available.
+    """
     def __init__(self, filename):
         self.filename = filename
-        self.fake_request = RequestFactory().get('/fake')
+        self.fake_request = RequestFactory(HTTP_HOST=settings.WARC_HOST).get('/fake')
 
     def render_response(self, status='200 OK', content_type='text/html; charset=utf-8', **template_kwargs):
         template_context = dict(


### PR DESCRIPTION
Fixes #1917

@rebeccacremona: check out the tweak to `fab run` here. To test this I had to set DEBUG=False, which I realized is incompatible with running webpack in the background. So I threw in a conditional for that and also a conditional for the celery background task. Does checking RUN_TASKS_ASYNC seem like a good approach here?