### PR TITLE
fix - buttons spacing on settings->tools page in mobile display

### DIFF
--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -8765,6 +8765,12 @@ a.cc:active {
   color: white;
 }
 
+@media only screen and (max-width: 767px) {
+  .btn + .btn {
+    margin-left: 16px;
+  }
+}
+
 @media only screen and (min-width: 768px) {
   .btn {
     white-space: nowrap;

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -1016,6 +1016,11 @@ div.col-right {
   user-select: none;
   box-shadow: none !important;
   @include link-highlight($color-white, $color-white);
+  @include respond-mobile {
+    & + .btn {
+      margin-left: $double;
+    }
+  }
   @include respond-tablet {
     white-space: nowrap;
     margin: $double 0;


### PR DESCRIPTION
Minor bug:

<img width="1440" alt="screen shot 2017-03-13 at 2 21 57 am" src="https://cloud.githubusercontent.com/assets/10279686/23835826/f5922fba-0793-11e7-87a0-40013b94b261.png">

There should be some gap between install btn `Perma for Chrome` and btn `Install Perma for Firefox`. Added the styles to maintain visual consistency.  