### PR TITLE
MINOR: count links tagged as meta-tag-failures on the stats page.

### DIFF
--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -16,6 +16,8 @@
     <script id="random-template" type="text/x-handlebars-template">
       <h3 class="body-ah">Random:</h3>
 
+      <br>
+
       <div class="row">
         <div class="col-sm-3">Total links:</div>
         <div class="col-sm-9">{{ total_link_count }}</div>
@@ -47,6 +49,13 @@
       </div>
 
       <div class="row">
+        <div class="col-sm-3">Links tagged "meta-tag-retrieval-failure":</div>
+        <div class="col-sm-9">{{ links_w_meta_failure_tag }} ({{ tagged_meta_failure_percentage_of_total }}% of total)</div>
+      </div>
+
+      <hr>
+
+      <div class="row">
         <div class="col-sm-3">Total users:</div>
         <div class="col-sm-1">{{ total_user_count }}</div>
       </div>
@@ -55,6 +64,8 @@
         <div class="col-sm-3">Unconfirmed users:</div>
         <div class="col-sm-9">{{ unconfirmed_user_count }} ({{ unconfirmed_user_percentage }}%)</div>
       </div>
+
+      <br>
     </script>
 
     <script id="days-template" type="text/x-handlebars-template">

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -139,6 +139,7 @@ def stats(request, stat_type=None):
             'private_policy': Link.objects.filter(is_private=True, private_reason='policy').count(),
             'private_takedown': Link.objects.filter(is_private=True, private_reason='takedown').count(),
             'private_meta_failure': Link.objects.filter(is_private=True, private_reason='failure').count(),
+            'links_w_meta_failure_tag': Link.objects.filter(tags__name__in=['meta-tag-retrieval-failure']).count(),
             'total_user_count': LinkUser.objects.count(),
             'unconfirmed_user_count': LinkUser.objects.filter(is_confirmed=False).count()
         }
@@ -151,6 +152,7 @@ def stats(request, stat_type=None):
         out['private_takedown_percentage_of_private'] = round(100.0*out['private_takedown']/out['private_link_count'], 1) if out['private_link_count'] else 0
         out['private_meta_failure_percentage_of_total'] = round(100.0*out['private_meta_failure']/out['total_link_count'], 1) if out['total_link_count'] else 0
         out['private_meta_failure_percentage_of_private'] = round(100.0*out['private_meta_failure']/out['private_link_count'], 1) if out['private_link_count'] else 0
+        out['tagged_meta_failure_percentage_of_total'] = round(100.0*out['links_w_meta_failure_tag']/out['total_link_count'], 1) if out['total_link_count'] else 0
 
         out['unconfirmed_user_percentage'] = round(100.0*out['unconfirmed_user_count']/out['total_user_count'], 1) if out['total_user_count'] else 0
 


### PR DESCRIPTION
<img width="552" alt="stats" src="https://cloud.githubusercontent.com/assets/11020492/24418830/55018d5a-13bb-11e7-9d37-3166f1fb46e7.png">
