### PR TITLE
Avoid timezone warnings in fixtures.

### DIFF
--- a/perma_web/fixtures/users.json
+++ b/perma_web/fixtures/users.json
@@ -7,7 +7,7 @@
       "name": "Test Library",
       "email": "library@university.edu",
       "website": "http://university.edu/library",
-      "date_created": "2013-06-26",
+      "date_created": "2013-06-26T00:00:00Z",
       "show_partner_status": true,
       "latitude": "42.3770",
       "longitude": "-71.1167"
@@ -21,7 +21,7 @@
       "name": "Another Library",
       "email": "library@university2.edu",
       "website": "http://university2.edu/library",
-      "date_created": "2014-07-27"
+      "date_created": "2014-07-27T00:00:00Z"
     }
   },
   {
@@ -32,7 +32,7 @@
       "name": "A Third Library",
       "email": "library@university3.edu",
       "website": "http://university3.edu/library",
-      "date_created": "2016-10-25",
+      "date_created": "2016-10-25T00:00:00Z",
       "show_partner_status": true,
       "latitude": "41.3163",
       "longitude": "-72.9223"
@@ -45,7 +45,7 @@
       "name": "Test Journal",
       "registrar": 1,
       "shared_folder": 27,
-      "date_created": "2013-06-26"
+      "date_created": "2013-06-26T00:00:00Z"
     }
   },
   {
@@ -55,7 +55,7 @@
       "name": "Another Journal",
       "registrar": 1,
       "shared_folder": 28,
-      "date_created": "2013-06-26"
+      "date_created": "2013-06-26T00:00:00Z"
     }
   },
   {
@@ -65,7 +65,7 @@
       "name": "A Third Journal",
       "registrar": 1,
       "shared_folder": 31,
-      "date_created": "2013-06-26"
+      "date_created": "2013-06-26T00:00:00Z"
     }
   },
   {
@@ -75,7 +75,7 @@
       "name": "Another Library's Journal",
       "registrar": 2,
       "shared_folder": 40,
-      "date_created": "2014-07-27"
+      "date_created": "2014-07-27T00:00:00Z"
     }
   },
   {
@@ -88,7 +88,7 @@
       "last_login": "2013-07-23T18:55:41Z",
       "password": "pbkdf2_sha256$10000$BK8BC1FXesBM$I+R1mquCsp5PWrHsHfv+6xuUNO560YEPqdbzWZFNzlo=",
       "email": "test_admin_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Admin",
       "last_name": "User",
       "root_folder": 22
@@ -104,7 +104,7 @@
       "last_login": "2013-07-23T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "test_registrar_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Registrar",
       "last_name": "User",
       "root_folder": 23
@@ -120,7 +120,7 @@
       "last_login": "2013-07-23T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_org_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Organization",
       "last_name": "User",
       "root_folder": 24
@@ -135,7 +135,7 @@
       "last_login": "2013-07-23T18:55:25Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Regular",
       "last_name": "User",
       "root_folder": 25
@@ -151,7 +151,7 @@
       "last_login": "2013-07-23T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_org_rando_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Org-Rando",
       "last_name": "User",
       "root_folder": 26
@@ -167,7 +167,7 @@
       "last_login": "2013-07-23T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_another_org_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Another-Org",
       "last_name": "User",
       "root_folder": 32
@@ -183,7 +183,7 @@
       "last_login": "2013-07-23T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_another_library_org_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Another-Library",
       "last_name": "Organization-User",
       "root_folder": 41
@@ -198,7 +198,7 @@
       "last_login": "2013-07-23T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_requested_registrar_account@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "Requested",
       "last_name": "Registrar",
       "pending_registrar": 2
@@ -214,7 +214,7 @@
       "last_login": "2013-07-23T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "another_library_user@example.com",
-      "date_joined": "2013-06-26",
+      "date_joined": "2013-06-26T00:00:00Z",
       "first_name": "AnotherLibrary",
       "last_name": "User",
       "root_folder": 42
@@ -230,7 +230,7 @@
       "last_login": "2013-07-23T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "multi_registrar_org_user@example.com",
-      "date_joined": "2016-10-17",
+      "date_joined": "2016-10-17T00:00:00Z",
       "first_name": "Multi-Registrar",
       "last_name": "Organization-User",
       "root_folder": 43
@@ -246,7 +246,7 @@
       "last_login": "2016-10-17T18:38:27Z",
       "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
       "email": "test_yet_another_library_org_user@example.com",
-      "date_joined": "2016-10-17",
+      "date_joined": "2016-10-17T00:00:00Z",
       "first_name": "Yet-Another-Library",
       "last_name": "Organization-User",
       "root_folder": 44
@@ -263,7 +263,7 @@
       "last_login": "2016-10-18T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "deactivated_registrar_user@example.com",
-      "date_joined": "2016-10-18",
+      "date_joined": "2016-10-18T00:00:00Z",
       "first_name": "DeactivatedRegistrar",
       "last_name": "User",
       "root_folder": 45
@@ -279,7 +279,7 @@
       "last_login": "2016-10-18T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "unactivated_registrar_user@example.com",
-      "date_joined": "2016-10-18",
+      "date_joined": "2016-10-18T00:00:00Z",
       "first_name": "UnactivatedRegistrar",
       "last_name": "User",
       "root_folder": 46
@@ -295,7 +295,7 @@
       "last_login": "2016-10-18T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "unactivated_court_user@example.com",
-      "date_joined": "2016-10-18",
+      "date_joined": "2016-10-18T00:00:00Z",
       "first_name": "UnactivatedCourt",
       "last_name": "User",
       "root_folder": 47
@@ -311,7 +311,7 @@
       "last_login": "2016-10-18T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "unactivated_journal_user@example.com",
-      "date_joined": "2016-10-18",
+      "date_joined": "2016-10-18T00:00:00Z",
       "first_name": "UnactivatedJournal",
       "last_name": "User",
       "root_folder": 48
@@ -327,7 +327,7 @@
       "last_login": "2016-10-18T18:56:14Z",
       "password": "pbkdf2_sha256$10000$56cl09Msiau4$IoOlZ+P/I3MJJG+ZxYtH9mb6c+B+VQELqwWyb3ubdWE=",
       "email": "unactivated_faculty_user@example.com",
-      "date_joined": "2016-10-18",
+      "date_joined": "2016-10-18T00:00:00Z",
       "first_name": "UnactivatedFaculty",
       "last_name": "User",
       "root_folder": 49


### PR DESCRIPTION
Just a small tweak — this avoids the warning messages about timezones that we always get when starting to run the tests.