### PR TITLE
Upgrade packages in preparation for Django 1.10

### DIFF
--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -61,6 +61,7 @@ class DefaultResource(ExtendedModelResource):
         serializer = DefaultSerializer()
         validation = DefaultValidation()
         allowed_update_fields = []
+        object_class = None  # will be overridden by subclasses that set queryset
 
     @classmethod
     # Hack to prevent ModelResource from auto-including additional fields

--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -1,7 +1,7 @@
 # handy packages to have in a dev environment
 ipdb
 django-debug-toolbar==1.5     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
-django-extensions==1.6.1        # if installed, `fab run` will use `python manage.py runserver_plus`
+django-extensions==1.7.8        # if installed, `fab run` will use `python manage.py runserver_plus`
 django-nose==1.4.3              # an alternative test runner; enable in settings_testing.py
 pysqlite==2.6.3                 # for use with in memory testing set in settings_testing.py
 pipdeptree                      # show full pip dependency tree with the 'pipdeptree' command line tool

--- a/perma_web/perma/tests/test_admin.py
+++ b/perma_web/perma/tests/test_admin.py
@@ -1,10 +1,13 @@
 # Tests for the django admin:
 
-import django_admin_smoke_tests.tests
+from django_admin_smoke_tests.tests import AdminSiteSmokeTestMixin
 from perma.models import LinkUserManager, LinkUser
 from .utils import PermaTestCase
 
-class AdminTestCase(django_admin_smoke_tests.tests.AdminSiteSmokeTest, PermaTestCase):
+class AdminTestCase(AdminSiteSmokeTestMixin, PermaTestCase):
+    fixtures = PermaTestCase.fixtures
+    exclude_apps = ['tastypie', ]
+
     def setUp(self):
         # monkey-patch create_superuser, which is relied on by the django_admin_smoke_tests package
         LinkUserManager.create_superuser = lambda *args, **kwargs: LinkUser.objects.get(pk=1)

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -16,7 +16,7 @@ django-ratelimit==1.0.0
 smhasher==0.150.1
 jasmine==2.4.0
 pytz==2013b
-django-mptt==0.8.5
+django-mptt==0.8.7
 Werkzeug==0.11.1
 Fabric==1.11.1
 pexpect==3.1
@@ -35,9 +35,9 @@ sorl-thumbnail==12.3			# Used to create our thumbnails
 redis==2.10.5					# Needed to bind with Redis. Supports our sorl thumbnails in production
 django-redis==4.4.3             # use redis as django's cache backend
 django-sslserver==0.14          # For testing SSL locally.
-django-model-utils==2.2         # for tracking dirty models
+django-model-utils==2.6.1         # for tracking dirty models
 django-settings-context-processor==0.2 # make settings available in templates
-django-admin-smoke-tests==0.1.11    # basic tests for the Django admin
+django-admin-smoke-tests==0.3.0    # basic tests for the Django admin
 Pillow==3.3.2                   # Used by the Django admin for ImageField display
 whitenoise==3.2.2               # serve static assets
 django-simple-history==1.8.1    # track changes to certain models

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -14,22 +14,23 @@ appdirs==1.4.3            # via setuptools
 argh==0.26.2              # via watchdog
 argparse==1.4.0           # via jasmine
 args==0.1.0               # via clint
+asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.5.1
 billiard==3.3.0.23        # via celery
 boto==2.42.0
 brotlipy==0.6.0           # via pywb
 celery==3.1.20
 certauth==1.1.3
-cffi==1.9.1               # via brotlipy, cryptography
+cffi==1.10.0              # via brotlipy, cryptography
 chardet==2.3              # via jasmine, pywb
 CherryPy==3.8.2           # via jasmine
-click==6.6                # via flask, pip-tools
+click==6.7                # via flask, pip-tools
 clint==0.5.1              # via internetarchive
 coverage==3.7.1
-cryptography==1.5.3       # via pyopenssl
-django-admin-smoke-tests==0.1.11
-django-model-utils==2.2
-django-mptt==0.8.5
+cryptography==1.8.1       # via pyopenssl
+django-admin-smoke-tests==0.3.0
+django-model-utils==2.6.1
+django-mptt==0.8.7
 django-ratelimit==1.0.0
 django-redis==4.4.3
 django-settings-context-processor==0.2
@@ -49,24 +50,24 @@ Fabric==1.11.1
 fakeredis==0.7.0
 first==2.0.1              # via pip-tools
 flake8==2.5.4
-Flask==0.11.1             # via jasmine
+Flask==0.12.1             # via jasmine
 funcsigs==1.0.2           # via mock
 gevent==1.0.2
 glob2==0.5                # via jasmine-core
-greenlet==0.4.10          # via gevent
+greenlet==0.4.12          # via gevent
 gunicorn==19.3.0
-idna==2.1                 # via cryptography, tldextract
+idna==2.5                 # via cryptography, tldextract
 internetarchive==1.0.10
-ipaddress==1.0.17         # via cryptography
+ipaddress==1.0.18         # via cryptography
 itsdangerous==0.24        # via flask
 jasmine-core==2.5.2       # via jasmine
 jasmine==2.4.0
-Jinja2==2.8               # via flask, jasmine, pywb
+jinja2==2.9.6             # via flask, jasmine, pywb
 jsmin==2.0.9
 jsonpatch==0.4            # via internetarchive
 kombu==3.0.37             # via celery
 LinkHeader==0.4.3
-MarkupSafe==0.23          # via jinja2
+MarkupSafe==1.0           # via jinja2
 mccabe==0.4.0             # via flake8
 mock==2.0.0
 MySQL-python==1.2.5
@@ -75,17 +76,17 @@ netaddr==0.7.12
 newrelic==2.66.0.49
 opbeat==3.3.3
 ordereddict==1.1          # via jasmine-core
-packaging==16.8           # via setuptools
-paramiko==1.17.2          # via fabric
+packaging==16.8           # via cryptography, setuptools
+paramiko==1.18.2          # via fabric
 pathlib==1.0.1            # via pyscss
 pathtools==0.1.2          # via watchdog
-pbr==1.10.0               # via mock
+pbr==2.0.0                # via mock
 pep8==1.7.0               # via flake8
 pexpect==3.1
 Pillow==3.3.2
 pip-tools==1.7
-py==1.4.31                # via pytest
-pyasn1==0.1.9             # via cryptography, requests
+py==1.4.33                # via pytest
+pyasn1==0.2.3             # via requests
 pycparser==2.17           # via cffi
 pycrypto==2.6.1           # via paramiko
 pyflakes==1.0.0           # via flake8
@@ -93,13 +94,13 @@ PyOpenSSL==16.2.0         # via certauth, ndg-httpsclient, requests
 pyparsing==2.2.0          # via packaging
 pyScss==1.3.4
 pytest-xdist==1.10
-pytest==3.0.4             # via pytest-xdist
+pytest==3.0.7             # via pytest-xdist
 python-dateutil==2.2
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2013b0
 PyVirtualDisplay==0.1.5
 pywb==0.33
-PyYAML==3.10              # via jasmine, pywb, watchdog
+pyyaml==3.10              # via jasmine, pywb, watchdog
 redis==2.10.5
 requests-file==1.4.1      # via tldextract
 requests[security]==2.11.1
@@ -124,4 +125,4 @@ wsgiref==0.1.2
 
 # The following packages are commented out because they are
 # considered to be unsafe in a requirements file:
-# setuptools                # via cryptography, django-sslserver, tldextract
+# setuptools                # via cryptography, django-sslserver, pytest, tldextract


### PR DESCRIPTION
Upgrade django-admin-smoke-tests, django-model-utils, and django-mptt to versions compatible with Django 1.10.

Also tweaks the Tastypie API code to be compatible with the next version if we ever move to it.