### PR TITLE
Tag links with capture timeouts

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -330,6 +330,8 @@ CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_SEND_TASK_ERROR_EMAILS = True
+CELERYD_TASK_TIME_LIMIT = 300     # If a task is running longer than five minutes, kill it
+CELERYD_TASK_SOFT_TIME_LIMIT=290  # provide 10 seconds to catch SoftTimeLimitExceeded
 
 # Control whether Celery tasks should be run in the background or during a request.
 # This should normally be True, but it's handy to not require rabbitmq and celery sometimes.

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -17,9 +17,6 @@ CELERYBEAT_JOB_NAMES = [
     'send-links-to-internet-archives',
     ]
 
-# If a task is running longer than five minutes, kill it
-CELERYD_TASK_TIME_LIMIT = 300
-
 # logging
 LOGGING['handlers']['default']['filename'] = '/var/log/perma/perma.log'
 PHANTOMJS_LOG = '/var/log/perma/phantom.log'

--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -53,6 +53,11 @@
         <div class="col-sm-9">{{ links_w_meta_failure_tag }} ({{ tagged_meta_failure_percentage_of_total }}% of total)</div>
       </div>
 
+      <div class="row">
+        <div class="col-sm-3">Links tagged "timeout-failure":</div>
+        <div class="col-sm-9">{{ links_w_timeout_failure_tag }} ({{ tagged_timeout_failure_percentage_of_total }}% of total)</div>
+      </div>
+
       <hr>
 
       <div class="row">

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -140,6 +140,7 @@ def stats(request, stat_type=None):
             'private_takedown': Link.objects.filter(is_private=True, private_reason='takedown').count(),
             'private_meta_failure': Link.objects.filter(is_private=True, private_reason='failure').count(),
             'links_w_meta_failure_tag': Link.objects.filter(tags__name__in=['meta-tag-retrieval-failure']).count(),
+            'links_w_timeout_failure_tag': Link.objects.filter(tags__name__in=['timeout-failure']).count(),
             'total_user_count': LinkUser.objects.count(),
             'unconfirmed_user_count': LinkUser.objects.filter(is_confirmed=False).count()
         }
@@ -153,6 +154,7 @@ def stats(request, stat_type=None):
         out['private_meta_failure_percentage_of_total'] = round(100.0*out['private_meta_failure']/out['total_link_count'], 1) if out['total_link_count'] else 0
         out['private_meta_failure_percentage_of_private'] = round(100.0*out['private_meta_failure']/out['private_link_count'], 1) if out['private_link_count'] else 0
         out['tagged_meta_failure_percentage_of_total'] = round(100.0*out['links_w_meta_failure_tag']/out['total_link_count'], 1) if out['total_link_count'] else 0
+        out['tagged_timeout_failure_percentage_of_total'] = round(100.0*out['links_w_timeout_failure_tag']/out['total_link_count'], 1) if out['total_link_count'] else 0
 
         out['unconfirmed_user_percentage'] = round(100.0*out['unconfirmed_user_count']/out['total_user_count'], 1) if out['total_user_count'] else 0
 


### PR DESCRIPTION
Currently when link capture times out after 5 minutes (resulting in a `kill -9` of the celery worker), we get an error email and the link stays pending/in_progress forever.

If we set a slightly shorter soft timeout, celery lets us catch the SoftTimeLimitExceeded error, tag the link as timed out, and set link status to failed.

This pull also shows the count of timed-out links on the admin stats page.

In theory we could add tests for all this as well, by running a capture task with a very short soft_timeout. I think that test wants to live in api2/tests, which is currently under construction, so I didn’t write it …