### PR TITLE
Remove read only mode

### DIFF
--- a/perma_web/api/resources.py
+++ b/perma_web/api/resources.py
@@ -132,10 +132,6 @@ class DefaultResource(ExtendedModelResource):
         raise ImmediateHttpResponse(response=self.error_response(bundle.request, errors))
 
     def _handle_500(self, request, exception):
-        if settings.READ_ONLY_MODE:
-            return self.error_response(request, {
-                'error_message':"Perma is in read only mode for scheduled maintenance. Please try again shortly."
-            })
         return super(DefaultResource, self)._handle_500(request, exception)
 
     def update_in_place(self, request, original_bundle, new_data):
@@ -548,11 +544,6 @@ class LinkResource(AuthenticatedLinkResource):
         # We create a new entry in our datastore and pass the work off to our indexing
         # workers. They do their thing, updating the model as they go. When we get some minimum
         # set of results we can present the user (a guid for the link), we respond back.
-        if settings.READ_ONLY_MODE:
-            raise ImmediateHttpResponse(response=self.error_response(bundle.request, {
-                'archives': {'__all__': "Perma has paused archive creation for scheduled maintenance. Please try again shortly."},
-                'reason': "Perma has paused archive creation for scheduled maintenance. Please try again shortly.",
-            }))
 
         # Runs validation (exception thrown if invalid), sets properties and saves the object
         if not bundle.data.get('replace'):

--- a/perma_web/perma/middleware.py
+++ b/perma_web/perma/middleware.py
@@ -1,6 +1,4 @@
-from django.conf import settings
 from django.http import Http404
-from django.shortcuts import render
 
 
 class AdminAuthMiddleware(object):
@@ -11,10 +9,3 @@ class AdminAuthMiddleware(object):
         if request.path.startswith('/admin/') and not getattr(request.user, 'is_staff', False):
             raise Http404
 
-
-### read only mode ###
-
-class ReadOnlyMiddleware(object):
-    def process_exception(self, request, exception):
-        if settings.READ_ONLY_MODE:
-            return render(request, 'read_only_mode.html')

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -130,7 +130,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'perma.middleware.AdminAuthMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
-    'perma.middleware.ReadOnlyMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',  # record request.user for model history
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -401,10 +400,6 @@ TASTYPIE_FULL_DEBUG = True  # Better Tastypie error handling for debugging. Only
 # Schedule celerybeat jobs.
 # These will be added to CELERYBEAT_SCHEDULE in settings.utils.post_processing
 CELERYBEAT_JOB_NAMES = []
-
-
-# Set to true to disable database/file writes for maintenance.
-READ_ONLY_MODE = False
 
 
 # tests

--- a/perma_web/perma/signals.py
+++ b/perma_web/perma/signals.py
@@ -1,29 +1,8 @@
-from django.conf import settings
 from django.dispatch import receiver
-from django.contrib.sessions.models import Session
 from django.db.models.signals import pre_save
 
-from .models import LinkUser, Link
-from .utils import ReadOnlyException
+from .models import Link
 
-
-### read only mode ###
-
-# install signals to prevent database writes if settings.READ_ONLY_MODE is set
-write_whitelist = (
-    (Session, None),
-    (LinkUser, {'password'}),
-    (LinkUser, {'last_login'}),
-)
-
-def read_only_mode(sender, instance, **kwargs):
-    for whitelist_sender, whitelist_fields in write_whitelist:
-        if whitelist_sender==sender and (whitelist_fields is None or whitelist_fields==kwargs['update_fields']):
-            return
-    raise ReadOnlyException("Read only mode enabled.")
-
-if settings.READ_ONLY_MODE:
-    pre_save.connect(read_only_mode)
 
 @receiver(pre_save, sender=Link)
 def update_link_count(sender, instance, **kwargs):

--- a/perma_web/perma/storage_backends.py
+++ b/perma_web/perma/storage_backends.py
@@ -12,7 +12,6 @@ from storages.backends.s3boto import S3BotoStorage
 from storages.backends.sftpstorage import SFTPStorage
 from whitenoise.storage import CompressedManifestStaticFilesStorage
 
-from perma.utils import ReadOnlyException
 
 file_saved = django.dispatch.Signal(providing_args=["instance", "path", "overwrite"])
 
@@ -39,8 +38,6 @@ class BaseMediaStorage(object):
             File name will only change if file_path conflicts with an existing file.
             If overwrite=True, existing file will instead be deleted and overwritten.
         """
-        if settings.READ_ONLY_MODE:
-            raise ReadOnlyException("Read only mode enabled.")
 
         if overwrite:
             if self.exists(file_path):

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -112,11 +112,6 @@ def show_debug_toolbar(request):
     """ Used by django-debug-toolbar in settings_dev.py to decide whether to show debug toolbar. """
     return settings.DEBUG
 
-### read only mode ###
-
-class ReadOnlyException(Exception):
-    pass
-
 ### image manipulation ###
 
 @contextmanager


### PR DESCRIPTION
I added this “read only mode” idea a couple of years ago, and we never used it. The general notion was to be able to set the server to stop writing to the database but otherwise keep running, which would in theory let us handle many updates without going into full maintenance mode, without worrying about data integrity. Given that it hasn’t been looked at or thought about in a couple years and I’m not confident it works correctly or does anything useful, let’s pull it out.