### PR TITLE
Fix django-extensions runserver_plus reloading

### DIFF
--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -1,7 +1,11 @@
 # handy packages to have in a dev environment
 ipdb
-django-debug-toolbar==1.5     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
-django-extensions==1.7.8        # if installed, `fab run` will use `python manage.py runserver_plus`
 django-nose==1.4.3              # an alternative test runner; enable in settings_testing.py
 pysqlite==2.6.3                 # for use with in memory testing set in settings_testing.py
 pipdeptree                      # show full pip dependency tree with the 'pipdeptree' command line tool
+
+# WARNING: The following can break things in weird ways.
+# If you install, be on the lookout for oddities soon after and consider uninstalling.
+django-debug-toolbar==1.5     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
+#django-extensions==1.7.8        # if installed, `fab run` will use `python manage.py runserver_plus`
+-e git://github.com/django-extensions/django-extensions.git@26665e26#egg=django-extensions  # switch back post 1.7.8

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -34,7 +34,11 @@ def run_django(port="0.0.0.0:8000"):
         try:
             # use runserver_plus if installed
             import django_extensions  # noqa
-            local("python manage.py runserver_plus %s --threaded" % port)
+            # use --reloader-type stat because:
+            #  (1) we have to have watchdog installed for pywb, which causes runserver_plus to attempt to use it as the reloader, which depends on inotify, but
+            #  (2) we are using a Vagrant NFS mount, which does not support inotify
+            # see https://github.com/django-extensions/django-extensions/pull/1041
+            local("python manage.py runserver_plus %s --threaded --reloader-type stat" % port)
         except ImportError:
             local("python manage.py runserver %s" % port)
     finally:


### PR DESCRIPTION
Use master branch of django-extensions for now, with support for `--reloader-type stat`, to fix hot reloading for Django test server.