### PR TITLE
Remove unused function

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -905,13 +905,6 @@ class Link(DeletableModel):
         data = source_file_handle_or_data.read() if hasattr(source_file_handle_or_data, 'read') else source_file_handle_or_data
         return self.write_warc_record(warctools.WarcRecord.RESOURCE, url, data, content_type, warc_date, out_file)
 
-    def write_warc_metadata_record(self, metadata, url, concurrent_to, warc_date=None, out_file=None):
-        data = json.dumps(metadata)
-        extra_headers = [
-            (warctools.WarcRecord.CONCURRENT_TO, concurrent_to)
-        ]
-        return self.write_warc_record(warctools.WarcRecord.RESOURCE, url, data, "application/json", warc_date, out_file, extra_headers)
-
     def write_warc_record(self, record_type, url, data, content_type, warc_date=None, out_file=None, extra_headers=None):
         # set default date and convert to string if necessary
         warc_date = warc_date or timezone.now()

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1,6 +1,5 @@
 import hashlib
 import io
-import json
 import os
 import logging
 import random


### PR DESCRIPTION
I don't think `write_warc_metadata_record` is used anywhere. If it's worth keeping for historical interest, maybe we can comment it out like `get_thumbnail` about 100 lines earlier.