### PR TITLE
Pytest support

### DIFF
--- a/perma_web/.pep8
+++ b/perma_web/.pep8
@@ -1,8 +1,0 @@
-[flake8]
-ignore = E12,
-         E2,W2,
-         E3,W3,
-         E4,
-         E501,
-         F403
-exclude = node_modules,static

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -165,7 +165,14 @@ class ApiResourceTestCaseMixin(ResourceTestCaseMixin, SimpleTestCase):
             copy_file_or_dir(os.path.join(settings.PROJECT_ROOT, TEST_ASSETS_DIR, source_file), target_url)
 
         # start server
-        cls._httpd = TestHTTPServer(('', cls.server_port), TestHTTPRequestHandler)
+        for i in range(100):
+            try:
+                cls._httpd = TestHTTPServer(('', cls.server_port), TestHTTPRequestHandler)
+                break
+            except socket.error:
+                cls.server_port += 1
+        else:
+            raise Exception("Cannot find an open port to host TestHTTPServer.")
         cls._httpd._BaseServer__is_shut_down = multiprocessing.Event()
         cls._server_process = Process(target=cls._httpd.serve_forever)
         cls._server_process.start()

--- a/perma_web/api2/tests/utils.py
+++ b/perma_web/api2/tests/utils.py
@@ -193,7 +193,14 @@ class ApiResourceTestCaseMixin(SimpleTestCase):
             copy_file_or_dir(os.path.join(settings.PROJECT_ROOT, TEST_ASSETS_DIR, source_file), target_url)
 
         # start server
-        cls._httpd = TestHTTPServer(('', cls.server_port), TestHTTPRequestHandler)
+        for i in range(100):
+            try:
+                cls._httpd = TestHTTPServer(('', cls.server_port), TestHTTPRequestHandler)
+                break
+            except socket.error:
+                cls.server_port += 1
+        else:
+            raise Exception("Cannot find an open port to host TestHTTPServer.")
         cls._httpd._BaseServer__is_shut_down = multiprocessing.Event()
         cls._server_process = Process(target=cls._httpd.serve_forever)
         cls._server_process.start()

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -65,21 +65,13 @@ def test(apps=_default_tests):
 @task
 def test_python(apps=_default_tests):
     """ Run Python tests. """
-    excluded_files = [
-        "*/migrations/*",
-        "*/management/*",
-        "*/tests/*",
-        "fabfile/*",
-        "functional_tests/*",
-        "*/settings/*",
-    ]
 
     # In order to run functional_tests, we have to run collectstatic, since functional tests use DEBUG=False
     # For speed we use the default Django STATICFILES_STORAGE setting here, which also has to be set in settings_testing.py
     if "functional_tests" in apps and not os.environ.get('SERVER_URL'):
         local("DJANGO__STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage python manage.py collectstatic --noinput")
 
-    local("coverage run --source='.' --omit='%s' manage.py test %s" % (",".join(excluded_files), apps))
+    local("coverage run manage.py test --settings perma.settings.deployments.settings_testing %s" % (apps))
 
 @task
 def test_js():

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -68,7 +68,3 @@ except ImportError:
 # Our Sorl thumbnail stuff. In prod we use Redis, we'll just use
 # the local uncached DB here in dev.
 THUMBNAIL_KVSTORE = 'sorl.thumbnail.kvstores.cached_db_kvstore.KVStore'
-
-# If running testing, import setting overrides
-if 'test' in sys.argv:
-    from settings_testing import *

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -1,4 +1,4 @@
-from settings_dev import PROJECT_ROOT
+from ..settings import *
 
 #########
 # Setup #

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -20,7 +20,6 @@ django-mptt==0.8.7
 Werkzeug==0.11.1
 Fabric==1.11.1
 pexpect==3.1
-coverage==3.7.1
 selenium==2.47.3
 jsmin==2.0.9
 pyScss==1.3.4  					# dependency of d-p-compass. included here to avoid wonkiness found in older versions
@@ -72,8 +71,11 @@ boto==2.42.0
 
 # testing
 sauceclient==0.1.0
-pytest-xdist==1.10
+pytest==3.0.7
+pytest-django==3.1.2
+pytest-xdist==1.15.0
 fakeredis==0.7.0                # simulate redis backend for tests
 flake8==2.5.4                   # code linting
 beautifulsoup4==4.5.1           # parses html of responses
 mock                            # safe monkey patching
+coverage==4.3.4                 # record code coverage

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -26,7 +26,7 @@ chardet==2.3              # via jasmine, pywb
 CherryPy==3.8.2           # via jasmine
 click==6.7                # via flask, pip-tools
 clint==0.5.1              # via internetarchive
-coverage==3.7.1
+coverage==4.3.4
 cryptography==1.8.1       # via pyopenssl
 django-admin-smoke-tests==0.3.0
 django-crispy-forms==1.6.1
@@ -88,7 +88,7 @@ pep8==1.7.0               # via flake8
 pexpect==3.1
 Pillow==3.3.2
 pip-tools==1.7
-py==1.4.33                # via pytest
+py==1.4.33                # via pytest, pytest-xdist
 pyasn1==0.2.3             # via requests
 pycparser==2.17           # via cffi
 pycrypto==2.6.1           # via paramiko
@@ -96,8 +96,9 @@ pyflakes==1.0.0           # via flake8
 pyopenssl==16.2.0         # via certauth, ndg-httpsclient, requests
 pyparsing==2.2.0          # via packaging
 pyScss==1.3.4
-pytest-xdist==1.10
-pytest==3.0.7             # via pytest-xdist
+pytest-django==3.1.2
+pytest-xdist==1.15.0
+pytest==3.0.7
 python-dateutil==2.2
 python-mimeparse==1.6.0   # via django-tastypie
 pytz==2013b0

--- a/perma_web/setup.cfg
+++ b/perma_web/setup.cfg
@@ -1,0 +1,25 @@
+## http://flake8.pycqa.org/en/latest/user/configuration.html
+[flake8]
+ignore = E12,
+         E2,W2,
+         E3,W3,
+         E4,
+         E501,
+         F403
+exclude = node_modules,static
+
+## http://pytest.org/latest/customize.html#adding-default-options
+[pytest]
+DJANGO_SETTINGS_MODULE = perma.settings.deployments.settings_testing
+norecursedirs = node_modules
+
+## http://coverage.readthedocs.io/en/latest/config.html
+[coverage:run]
+source = .
+omit =
+    */migrations/*
+    */management/*
+    */tests/*
+    fabfile/*
+    functional_tests/*
+    */settings/*


### PR DESCRIPTION
This lets you optionally use `pytest` as your test runner instead of the builtin `manage.py test` which is called by `fab test`. The primary benefit right now is the ability to run tests locally in parallel for speed. Pytest also seems like it has nicer output and offers some cool features we could explore in the future.

Usage:

To allow for parallel tests, go into `mysql -uroot -p` and run `GRANT ALL ON *.* TO 'perma'@'localhost';` so pytest can create multiple test databases (we should do this in the vagrant image if this ends up being useful).

All tests: `pytest`
One test: `pytest -k test_should_provide_different_folder_data_relative_to_user`
Tests for one app: `pytest api/`
Tests in two processes in parallel: `pytest -n 2`
Disable stdout capture if you want to set a breakpoint with pdb: `pytest -s`

If running in parallel, a couple of tests may fail until the interdependent-tests pull req is merged in.

Changes in this pull req:

- Merge config files -- combine .pep8, pytest config, and coverage config into one settings.cfg file
- Have TestHTTPServer try multiple ports so tests can run in parallel
- Make perma.settings.deployments.settings_testing a complete settings file that can be provided to test runners directly, to avoid the sys.argv import hack at the bottom of setting_dev.py

(So, all stuff that's good or neutral regardless of whether we end up wanting to use pytest.)

Speed differences:

I tried running the api tests on my local vagrant with two virtual CPUs in a few different ways:

`fab test:api2`: 200 seconds
`./manage.py test --settings perma.settings.deployments.settings_testing api2` -- same as `fab test` but without recording test coverage: 163 second
`pytest api2/`: 181 seconds
`pytest api2/ -n 2`: 116 seconds

So, ballpark, running in parallel takes about 2/3 as long as running consecutively.

I also tried running in 8 processes outside vagrant and got down to 90 seconds, but with some failures I didn't diagnose ...