### PR TITLE
Warcprox exception handling (workaround one problem with forbes.com)

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -389,7 +389,15 @@ def proxy_capture(capture_job):
                     proxied_pair = [self.url, None]
                     proxied_requests.append(proxied_pair[0])
                     proxied_pairs.append(proxied_pair)
-                response = WarcProxyHandler._proxy_request(self)
+                try:
+                    response = WarcProxyHandler._proxy_request(self)
+                except:
+                    # If warcprox can't handle a request/response for some reason,
+                    # remove the proxied pair so that it doesn't keep trying and
+                    # the capture process can proceed
+                    proxied_requests.remove(proxied_pair[0])
+                    proxied_pairs.remove(proxied_pair)
+                    raise
                 with count_lock:
                     proxied_responses.append(response)
                     proxied_pair[1] = response


### PR DESCRIPTION
The behavior of attempted captures of Forbes.com recently changed, and multiple users have contacted us about it. Captures fail very early in the capture process, and as a result, users aren't presented with the normal "capture failed" screen, nor given a chance to upload their own PDF.

This pull request addresses one component of this bad experience: if warcprox throws an exception while trying to proxy a request, we should remove the corresponding request and response from our list of proxied requests and proxied request/response pairs. As is, if the very first request/response fails in this way, the capture gets stuck forever here, regardless of the success of any other requests:

```
        while not have_response:
            if proxied_responses:
                for request, response in proxied_pairs:
                    if response is None:
                        # Response hasn't finished yet -- we might get here because subsequent
                        # responses have finished, but we have to go in order to find the correct content_type,
                        # so let's wait for this one.
                        break
``` 

This change allows us to, by mere circumstance, sometimes capture articles on forbes.com.

But it isn't a great solution. And, I'm not sure precisely what it means if warcprox throws an exception here. It appears that phantomjs still receives the bad response, in this case a bad redirect, because otherwise, since this is the first request, how would phantomjs know to request any other resources?

This also seems to mean that warcprox can't record everything that our browsers can handle (even phantomjs), which is certainly suboptimal.

Offered up to the team: not sure about this pull request. Improves the project? Potentially crummy warcs better than no warcs at all?