### PR TITLE
remove - unnecessarily passing the entire link object to delete, when…

### DIFF
--- a/perma_web/perma/templates/archive/confirm/link-delete-confirm.html
+++ b/perma_web/perma/templates/archive/confirm/link-delete-confirm.html
@@ -1,5 +1,4 @@
 {% extends "archive/confirm/base-archive-confirm.html" %}
-{% load as_json %}
 {% load render_bundle from webpack_loader %}
 
 {% block confirm %}
@@ -13,7 +12,7 @@
 {% block scripts %}
   <script>
     var url_link_browser = "{% url 'create_link' %}",
-      archive = {% as_json link %},
+      archive = { guid: "{{ link.guid }}" },
       refer_url = "{{ request.META.HTTP_REFERER }}";
   </script>
 


### PR DESCRIPTION
… all we need is the guid property set on the archive object

fixes #1990