### PR TITLE
Show more link info to admins

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -140,8 +140,8 @@ class LinkUserAdmin(UserAdmin):
 
 
 class LinkAdmin(SimpleHistoryAdmin):
-    list_display = ['guid', 'submitted_url', 'submitted_title', 'submitted_description', 'created_by', 'creation_timestamp','user_deleted']
-    search_fields = ['guid', 'submitted_url', 'submitted_title', 'submitted_description']
+    list_display = ['guid', 'submitted_url', 'created_by', 'creation_timestamp', 'tag_list', 'is_private', 'user_deleted']
+    search_fields = ['guid', 'submitted_url', 'tags__name']
     fieldsets = (
         (None, {'fields': ('guid', 'submitted_url', 'submitted_title', 'submitted_description', 'created_by', 'creation_timestamp', 'warc_size', 'replacement_link', 'tags')}),
         ('Visibility', {'fields': ('is_private', 'private_reason', 'is_unlisted',)}),
@@ -158,9 +158,12 @@ class LinkAdmin(SimpleHistoryAdmin):
     raw_id_fields = ['created_by','replacement_link']
 
     def get_queryset(self, request):
-        qs = super(LinkAdmin, self).get_queryset(request).select_related('created_by',)
+        qs = super(LinkAdmin, self).get_queryset(request).select_related('created_by',).prefetch_related('tags')
         qs.query.where = WhereNode()  # reset filters to include "deleted" objs
         return qs
+
+    def tag_list(self, obj):
+        return u", ".join(o.name for o in obj.tags.all())
 
 
 class FolderAdmin(MPTTModelAdmin):

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -154,11 +154,15 @@ class LinkAdmin(SimpleHistoryAdmin):
         new_class("CaptureInline", admin.TabularInline, model=Capture,
                   fields=['role', 'status', 'url', 'content_type', 'record_type', 'user_upload'],
                   can_delete=False),
+        new_class("CaptureJobInline", admin.StackedInline, model=CaptureJob,
+                   fields=['status', 'step_count', 'step_description', 'human'],
+                   readonly_fields=['step_count', 'step_description', 'human'],
+                   can_delete=False)
     ]
     raw_id_fields = ['created_by','replacement_link']
 
     def get_queryset(self, request):
-        qs = super(LinkAdmin, self).get_queryset(request).select_related('created_by',).prefetch_related('tags')
+        qs = super(LinkAdmin, self).get_queryset(request).select_related('created_by',).prefetch_related('tags', 'capture_job')
         qs.query.where = WhereNode()  # reset filters to include "deleted" objs
         return qs
 

--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -48,14 +48,21 @@
         <div class="col-sm-9">{{ private_link_count }} ({{ private_link_percentage }}%)</div>
       </div>
 
+      <hr>
+
       <div class="row">
         <div class="col-sm-3">Links tagged "meta-tag-retrieval-failure":</div>
-        <div class="col-sm-9">{{ links_w_meta_failure_tag }} ({{ tagged_meta_failure_percentage_of_total }}% of total)</div>
+        <div class="col-sm-9"><a href="/admin/perma/link/?q=meta-tag-retrieval-failure">{{ links_w_meta_failure_tag }} ({{ tagged_meta_failure_percentage_of_total }}% of total</a>)</div>
       </div>
 
       <div class="row">
         <div class="col-sm-3">Links tagged "timeout-failure":</div>
-        <div class="col-sm-9">{{ links_w_timeout_failure_tag }} ({{ tagged_timeout_failure_percentage_of_total }}% of total)</div>
+        <div class="col-sm-9"><a href="/admin/perma/link/?q=timeout-failure">{{ links_w_timeout_failure_tag }} ({{ tagged_timeout_failure_percentage_of_total }}% of total)</a></div>
+      </div>
+
+      <div class="row">
+        <div class="col-sm-3">Links tagged "browser-crashed":</div>
+        <div class="col-sm-9"><a href="/admin/perma/link/?q=browser-crashed">{{ links_w_browser_crashed_tag }} ({{ tagged_browser_crashed_percentage_of_total }}% of total)</a></div>
       </div>
 
       <hr>

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -141,6 +141,7 @@ def stats(request, stat_type=None):
             'private_meta_failure': Link.objects.filter(is_private=True, private_reason='failure').count(),
             'links_w_meta_failure_tag': Link.objects.filter(tags__name__in=['meta-tag-retrieval-failure']).count(),
             'links_w_timeout_failure_tag': Link.objects.filter(tags__name__in=['timeout-failure']).count(),
+            'links_w_browser_crashed_tag': Link.objects.filter(tags__name__in=['browser-crashed']).count(),
             'total_user_count': LinkUser.objects.count(),
             'unconfirmed_user_count': LinkUser.objects.filter(is_confirmed=False).count()
         }
@@ -155,6 +156,7 @@ def stats(request, stat_type=None):
         out['private_meta_failure_percentage_of_private'] = round(100.0*out['private_meta_failure']/out['private_link_count'], 1) if out['private_link_count'] else 0
         out['tagged_meta_failure_percentage_of_total'] = round(100.0*out['links_w_meta_failure_tag']/out['total_link_count'], 1) if out['total_link_count'] else 0
         out['tagged_timeout_failure_percentage_of_total'] = round(100.0*out['links_w_timeout_failure_tag']/out['total_link_count'], 1) if out['total_link_count'] else 0
+        out['tagged_browser_crashed_percentage_of_total'] = round(100.0*out['links_w_browser_crashed_tag']/out['total_link_count'], 1) if out['total_link_count'] else 0
 
         out['unconfirmed_user_percentage'] = round(100.0*out['unconfirmed_user_count']/out['total_user_count'], 1) if out['total_user_count'] else 0
 

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -8371,6 +8371,10 @@ a.cc:active {
   background-color: #222;
 }
 
+.stats-container a {
+  text-decoration: underline;
+}
+
 .style-container-padding,
 .cont-full,
 .cont-fixed {

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -719,6 +719,10 @@ a.cc {
   }
 }
 
+.stats-container a {
+  text-decoration: underline;
+}
+
 /////////////////////////////////////////
 
 // Container, Row, Column


### PR DESCRIPTION
More tags on stats page; link from stats page to filtered view of link admin:
<img width="320" alt="links" src="https://cloud.githubusercontent.com/assets/11020492/25629922/4a3f8e82-2f39-11e7-8348-bd3a815e6f33.png">
<img width="320" alt="filtered" src="https://cloud.githubusercontent.com/assets/11020492/25629931/4fb03592-2f39-11e7-8084-05c7163c1bb7.png">

Include capture job on bottom of link's admin page, read-only except for status:
<img width="259" alt="capture-job-included" src="https://cloud.githubusercontent.com/assets/11020492/25629962/61f160f0-2f39-11e7-999f-c0fe6ab73597.png">


