### PR TITLE
Tweak: show upload button on capture failure

### DIFF
--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -10838,15 +10838,17 @@ webpackJsonp([1],{
 	  // archive is still be generated)
 	  // Clear any error messages out
 	  DOMHelpers.removeElement('.error-row');
-	
 	  newGUID = data.guid;
-	
 	  refreshIntervalIds.push(setInterval(check_status, 2000));
 	}
 	
 	function linkNot(jqXHR) {
-	  // The API told us something went wrong.
-	  var message = APIModule.getErrorMessage(jqXHR);
+	  if (typeof jqXHR == 'undefined') {
+	    var message = "Capture Failed";
+	  } else {
+	    // The API told us something went wrong.
+	    var message = APIModule.getErrorMessage(jqXHR);
+	  }
 	
 	  var upload_allowed = true;
 	  if (message.indexOf("limit") > -1) {
@@ -10864,6 +10866,7 @@ webpackJsonp([1],{
 	
 	  $('.create-errors').addClass('_active');
 	  $('#error-container').hide().fadeIn(0);
+	  $('#error-container').removeClass('_hide');
 	
 	  toggleCreateAvailable();
 	}
@@ -10989,16 +10992,9 @@ webpackJsonp([1],{
 	      // If we succeeded, forward to the new archive
 	      if (data.status == "completed") {
 	        window.location.href = "/" + newGUID;
-	
-	        // Else show failure message and reset form.
 	      } else {
-	        var templateArgs = { message: "Error: URL capture failed." };
-	        changeTemplate('#error-template', templateArgs, '#error-container');
-	
-	        $('#error-container').removeClass('_hide _success _wait').addClass('_error');
-	
-	        // Toggle our create button
-	        toggleCreateAvailable();
+	        // Else show failure message and reset form.
+	        linkNot();
 	      }
 	    }
 	  });

--- a/perma_web/static/js/create-link.module.js
+++ b/perma_web/static/js/create-link.module.js
@@ -28,15 +28,17 @@ function linkIt (data) {
   // archive is still be generated)
   // Clear any error messages out
   DOMHelpers.removeElement('.error-row');
-
   newGUID = data.guid;
-
   refreshIntervalIds.push(setInterval(check_status, 2000));
 }
 
 function linkNot (jqXHR) {
-  // The API told us something went wrong.
-  var message = APIModule.getErrorMessage(jqXHR);
+  if (typeof jqXHR == 'undefined') {
+    var message = "Capture Failed";
+  } else {
+    // The API told us something went wrong.
+    var message = APIModule.getErrorMessage(jqXHR);
+  }
 
   var upload_allowed = true;
   if (message.indexOf("limit") > -1) {
@@ -54,6 +56,7 @@ function linkNot (jqXHR) {
 
   $('.create-errors').addClass('_active');
   $('#error-container').hide().fadeIn(0);
+  $('#error-container').removeClass('_hide');
 
   toggleCreateAvailable();
 }
@@ -187,16 +190,9 @@ function check_status () {
       // If we succeeded, forward to the new archive
       if (data.status == "completed") {
         window.location.href = "/" + newGUID;
-
-        // Else show failure message and reset form.
       } else {
-        var templateArgs = {message: "Error: URL capture failed."};
-        changeTemplate('#error-template', templateArgs, '#error-container');
-
-        $('#error-container').removeClass('_hide _success _wait').addClass('_error');
-
-        // Toggle our create button
-        toggleCreateAvailable();
+        // Else show failure message and reset form.
+        linkNot();
       }
     }
   });


### PR DESCRIPTION
See https://github.com/harvard-lil/perma/issues/1994

We show something like this when a capture fails before being handed to tasks.py:
<img width="160" alt="error-allow-upload" src="https://cloud.githubusercontent.com/assets/11020492/25959918/5e455af4-3643-11e7-9b54-f22a3f8ac1fc.png">

If it fails during the task, though, we show this:
<img width="160" alt="error-generic" src="https://cloud.githubusercontent.com/assets/11020492/25959943/746ba554-3643-11e7-9217-7e0b24c8fb44.png">

Swap out the latter for:
<img width="160" alt="default" src="https://cloud.githubusercontent.com/assets/11020492/25960040/bc1925ca-3643-11e7-8a28-b0e0f30af9ff.png">

