### PR TITLE
Improve Chrome support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ ghostdriver.log
 
 # node
 node_modules
+npm-debug.log
 # ignore sourcemaps
 *.map
 


### PR DESCRIPTION
This improves our support for setting `CAPTURE_BROWSER = 'Chrome'`, primarily by allowing Chrome to take full-page screenshots.

This pull includes some refactoring but should not substantively affect PhantomJS captures, except for one change -- the page size for screenshots is based on measuring the size of `<html>` instead of `<body>`, since the former can be larger than the latter.

This does not yet take advantage of Chrome's new `--headless` flag. It's just using Selenium's longtime support for controlling desktop browsers along with a virtual display. `--headless` with Selenium/ChromeDriver doesn't seem to work reliably yet. (As of Chrome 59/ChromeDriver 2.29 -- next stable release of both might be good.) But I think that's just a two-line switch once `--headless` is ready, and the only impact of that change would be to make everything more efficient by not routing through a virtual display.

The big change here and motivation for most of the refactoring is to let Chrome take full-page screenshots by resizing the browser window to the size of the page before taking the screenshot. This is the recommended technique in https://developers.google.com/web/updates/2017/04/headless-chrome , so although it feels janky it's apparently what's endorsed by the Chrome team.

That makes it more important to accurately measure the size of the page before taking the screenshot -- if the measurement is too small the screenshot cuts off part of the page. For example when we were measuring the size of `<body>` instead of `<html>`, that broke even for example.com. Right now the size is close but still cuts off the footer on nytimes.com. 

To install dependencies and try out in Vagrant:

```
# install Chrome:
sudo apt-get install libxss1 libappindicator1 libindicator7
wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb # change this from stable to beta if you want to try out Chrome 59, which the Chrome team blog post is about -- also requires changing a line in tasks.py to use google-chrome-beta binary
sudo dpkg -i google-chrome*.deb
sudo apt-get install -f # fixes the missing-dependency errors from previous line

# install ChromeDriver:
sudo apt-get install unzip
wget -N http://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
unzip chromedriver_linux64.zip
chmod +x chromedriver
sudo mv -f chromedriver /usr/local/share/chromedriver
sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
```