### PR TITLE
Extract page contents by parsing DOM.

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -273,8 +273,15 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
             "test1.jpg", "test2.png", "test_fallback.jpg",
             "wide1.png", "wide2.png", "narrow.png"
         )
+        failures = []
         for expected_capture in expected_captures:
-            self.assertEqual('200', CDXLine.objects.get(urlkey=surt(self.server_url + "/" + expected_capture), link_id=obj['guid']).parsed['status'])
+            try:
+                cdxline = CDXLine.objects.get(urlkey=surt(self.server_url + "/" + expected_capture), link_id=obj['guid'])
+                if cdxline.parsed['status'] != '200':
+                    failures.append("%s returned HTTP status %s." % (expected_capture, cdxline.parsed['status']))
+            except CDXLine.DoesNotExist:
+                failures.append("%s not captured." % expected_capture)
+        self.assertFalse(bool(failures), "Failures in fetching media from iframes: %s" % failures)
 
     #########################
     # File Archive Creation #

--- a/perma_web/perma/site_scripts.py
+++ b/perma_web/perma/site_scripts.py
@@ -1,0 +1,15 @@
+from selenium.common.exceptions import NoSuchElementException
+
+
+def forbes_post_load(browser):
+    # Wait for splash page to auto redirect
+    from perma.tasks import repeat_until_truthy  # avoid circular import
+    current_url = browser.current_url
+    if '/welcome' in current_url:
+        # attempt to click "Continue"
+        try:
+            browser.find_element_by_css_selector('.continue-button').click()
+        except NoSuchElementException:
+            pass
+        # wait until URL changes
+        repeat_until_truthy(lambda: browser.current_url != current_url)

--- a/perma_web/perma/tests/assets/target_capture_files/test.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test.html
@@ -6,5 +6,6 @@
   </head>
   <body>
     Test body.
+    <svg><title>not the page title</title></svg>
   </body>
 </html>

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -46,6 +46,7 @@ ua-parser==0.7.1                # user agent parsing to detect Safari browser fo
 django_webpack_loader==0.3.3    # frontend assets building
 -e git://github.com/rebeccacremona/createsend-python.git@7cd8be21f89fa7bb61dafb31da9ad4a64058bf5b#egg=createsend-python
 tqdm==4.11.2                    # progress bar in dev fab tasks
+pyquery==1.2.17                 # extract data from HTML in capture task
 
 # api
 djangorestframework==3.6.2

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -28,6 +28,7 @@ click==6.7                # via flask, pip-tools
 clint==0.5.1              # via internetarchive
 coverage==4.3.4
 cryptography==1.8.1       # via pyopenssl
+cssselect==1.0.1          # via pyquery
 django-admin-smoke-tests==0.3.0
 django-crispy-forms==1.6.1
 django-filter==1.0.2
@@ -72,6 +73,7 @@ jsmin==2.0.9
 jsonpatch==0.4            # via internetarchive
 kombu==3.0.37             # via celery
 LinkHeader==0.4.3
+lxml==3.7.3               # via pyquery
 MarkupSafe==1.0           # via jinja2
 mccabe==0.4.0             # via flake8
 mock==2.0.0
@@ -97,6 +99,7 @@ pycrypto==2.6.1           # via paramiko
 pyflakes==1.0.0           # via flake8
 pyopenssl==16.2.0         # via certauth, ndg-httpsclient, requests
 pyparsing==2.2.0          # via packaging
+pyquery==1.2.17
 pyScss==1.3.4
 pytest-django==3.1.2
 pytest-xdist==1.15.0


### PR DESCRIPTION
The primary change here is to extract page contents by fetching the whole DOM and inspecting with PyQuery, rather than using multiple calls to Selenium to inspect individual elements.

The general approach now becomes:

- `dom_tree = get_dom_tree(browser)`, which is a slow function that calls out to `browser.execute_script` and returns a parsed PyQuery object.
- Inspect `dom_tree`, which is basically free.

This doesn't seem to be much faster (or slower) in practice, but it simplifies things in a few different ways:

- Use python instead of javascript to extract data, without loss of speed.
- Lots fewer calls to `browser` makes it easier to reason about performance -- slow steps are isolated to `get_dom_tree`.
- Lots fewer calls to `browser` will make it easier to migrate to raw Chrome connection if we want to do that later.

There are two other bits of refactoring in this pull:

- Instead of adding `link.tags.add('browser-crashed')` in `browser_running`, add it at the end in `teardown`. This avoids passing `link` around to a bunch of places, and catches possible case where the browser crashes after the last time `browser_running` is run.
- Rename `proxied_urls` to `requested_urls`, and have it include urls requested through `ProxiedRequestThread` as well as through warcprox. Avoids some possibility of redundant requests.