### PR TITLE
Improve run_in_frames_recursive function

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -252,21 +252,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
         link = Link.objects.get(guid=obj['guid'])
         self.assertValidCapture(link.primary_capture)
 
-    def test_should_capture_all_srcset_images(self):
-        target_folder = self.org_user.root_folder
-        obj = self.successful_post(self.list_url,
-                                   data={
-                                       'url': self.server_url + "/test_media_outer.html",
-                                       'folder': target_folder.pk,
-                                   },
-                                   user=self.org_user)
-
-        # verify that all images in src and srcset were found and captured
-        expected_captures = ("test1.jpg", "test2.png", "test_fallback.jpg", "wide1.png", "wide2.png", "narrow.png")
-        for expected_capture in expected_captures:
-            self.assertEqual('200', CDXLine.objects.get(urlkey=surt(self.server_url + "/" + expected_capture), link_id=obj['guid']).parsed['status'])
-
-    def test_should_capture_nested_audio_file(self):
+    def test_media_capture_in_iframes(self):
         settings.ENABLE_AV_CAPTURE = True
         target_folder = self.org_user.root_folder
         obj = self.successful_post(self.list_url,
@@ -276,8 +262,17 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
                                    },
                                    user=self.org_user)
 
-        # verify that embedded /test.* files in iframe were found and captured
-        expected_captures = ("test.wav", "test2.wav", "test.mp4", "test2.mp4", "test.swf", "test2.swf", "test3.swf")
+        # verify that all images in src and srcset were found and captured
+        expected_captures = (
+            # test_media_a.html
+            "test.wav", "test2.wav",
+            # test_media_b.html
+            "test.mp4", "test2.mp4",
+            # test_media_c.html
+            "test.swf", "test2.swf", "test3.swf",
+            "test1.jpg", "test2.png", "test_fallback.jpg",
+            "wide1.png", "wide2.png", "narrow.png"
+        )
         for expected_capture in expected_captures:
             self.assertEqual('200', CDXLine.objects.get(urlkey=surt(self.server_url + "/" + expected_capture), link_id=obj['guid']).parsed['status'])
 

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -873,13 +873,14 @@ def run_next_capture():
                     proxied_pairs.append(proxied_pair)
                 try:
                     response = WarcProxyHandler._proxy_request(self)
-                except:
+                except Exception as e:
                     # If warcprox can't handle a request/response for some reason,
                     # remove the proxied pair so that it doesn't keep trying and
                     # the capture process can proceed
                     proxied_requests.remove(proxied_pair[0])
                     proxied_pairs.remove(proxied_pair)
-                    raise
+                    print("WarcProx exception: %s parsing response from %s" % (e.__class__.__name__, proxied_pair[0]))
+                    return  # swallow exception
                 with tracker_lock:
                     proxied_responses["any"] = True
                     proxied_responses["size"] += response.response_recorder.len

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -999,7 +999,7 @@ def run_next_capture():
                     proxy_address
                 ))
 
-            print("Waiting for onload event before proceding.")
+            print("Waiting for onload event before proceeding.")
             page_load_thread.join(max(0, ONLOAD_EVENT_TIMEOUT - (time.time() - start_time)))
             if page_load_thread.is_alive():
                 print("Onload timed out")

--- a/perma_web/perma/tests/assets/target_capture_files/test_media_a.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test_media_a.html
@@ -1,22 +1,8 @@
 <html>
   <body>
+    <!-- included by test_media_outer.html -->
     <audio src="test.wav">
       <sOuRcE src="test2.wav">
     </audio>
-    <video src="test.mp4">
-      <sOuRcE src="test2.mp4">
-    </video>
-    <object type="application/x-shockwave-flash" data="test.swf">
-      <param name="movie" value="test2.swf" />
-      <param name="quality" value="high"/>
-      <embed src="test3.swf"></embed>
-    </object>
-    <img srcset="test1.jpg 1x, test2.png 2x" src="test_fallback.jpg">
-    <picture>
-      <source media="(min-width: 600px)"
-              srcset="wide1.png 800w, wide2.png 1200w"
-              sizes="100vw">
-      <img src="narrow.png">
-    </picture>
   </body>
 </html>

--- a/perma_web/perma/tests/assets/target_capture_files/test_media_a.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test_media_a.html
@@ -1,0 +1,22 @@
+<html>
+  <body>
+    <audio src="test.wav">
+      <sOuRcE src="test2.wav">
+    </audio>
+    <video src="test.mp4">
+      <sOuRcE src="test2.mp4">
+    </video>
+    <object type="application/x-shockwave-flash" data="test.swf">
+      <param name="movie" value="test2.swf" />
+      <param name="quality" value="high"/>
+      <embed src="test3.swf"></embed>
+    </object>
+    <img srcset="test1.jpg 1x, test2.png 2x" src="test_fallback.jpg">
+    <picture>
+      <source media="(min-width: 600px)"
+              srcset="wide1.png 800w, wide2.png 1200w"
+              sizes="100vw">
+      <img src="narrow.png">
+    </picture>
+  </body>
+</html>

--- a/perma_web/perma/tests/assets/target_capture_files/test_media_b.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test_media_b.html
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <!-- included by test_media_outer.html -->
+    <!-- includes test_media_c.html -->
+    <video src="test.mp4">
+      <sOuRcE src="test2.mp4">
+    </video>
+    <iframe src="test_media_c.html"></iframe>
+  </body>
+</html>

--- a/perma_web/perma/tests/assets/target_capture_files/test_media_c.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test_media_c.html
@@ -1,11 +1,6 @@
 <html>
   <body>
-    <audio src="test.wav">
-      <sOuRcE src="test2.wav">
-    </audio>
-    <video src="test.mp4">
-      <sOuRcE src="test2.mp4">
-    </video>
+    <!-- included by test_media_b.html -->
     <object type="application/x-shockwave-flash" data="test.swf">
       <param name="movie" value="test2.swf" />
       <param name="quality" value="high"/>

--- a/perma_web/perma/tests/assets/target_capture_files/test_media_outer.html
+++ b/perma_web/perma/tests/assets/target_capture_files/test_media_outer.html
@@ -1,5 +1,13 @@
 <html>
   <body>
-    <iframe src="test_media_inner.html"></iframe>
+    <!--
+        Parent file to test our ability to traverse iframes. Hierarchy:
+            test_media_outer.html
+                test_media_a.html
+                test_media_b.html
+                    test_media_c.html
+     -->
+    <iframe src="test_media_a.html"></iframe>
+    <iframe src="test_media_b.html"></iframe>
   </body>
 </html>


### PR DESCRIPTION
This updates the run_in_frames_recursive function to switch to frames by numeric index rather than fetching and using WebElement references. The primary advantage is we don't get expired WebElement references on pages that keep rewriting their HTML. Also saves a couple of find_element calls per recursion.

Other improvements while refactoring:

- Recursion is now limited to depth of 3, and 20 iframes visited overall.
- Check for non-http iframes and skip.
- Avoid 1 redundant tree traversal in each recursion, by putting traversal at the end of the loop instead of the beginning.

On the testing side, this pull consolidates two tests that were hitting the same nested-frame endpoint, and expands that test to look for media elements across a more complicated iframe hierarchy.

Unrelatedly (except it came up while debugging), this pull req goes ahead and swallows warcprox errors in TrackingRequestHandler, since they mess with the log and don't seem to help anything.