### PR TITLE
FIX: link count filter name changed in 384bc9

### DIFF
--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -87,8 +87,8 @@
               <a {% if sort == '-last_login' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_login" %}"><i class="icon-ok"></i> Recently active</a>
               <a {% if sort == 'last_login' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="last_login" %}"><i class="icon-ok"></i> Least recently active</a>
               {% if group_name == 'organization_user' %}
-                <a {% if sort == '-created_links_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-created_links_count" %}"><i class="icon-ok"></i> Most links</a>
-                <a {% if sort == 'created_links_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="created_links_count" %}"><i class="icon-ok"></i> Least links</a>
+                <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
+                <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i class="icon-ok"></i> Least links</a>
               {% endif %}
             </li>
           </ul>


### PR DESCRIPTION
Fix for https://github.com/harvard-lil/perma/issues/2018

(Though note: we previously decided to remove this functionality entirely, since user link counts include every link created by that user, not the links the've created for that org. Work on that, and removal/alteration of similar features, is still in progress)