### PR TITLE
Trivial tweak to latest tasks.py

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -273,7 +273,7 @@ def scroll_browser(browser):
         pass
 
 def get_page_source(browser):
-    """ 
+    """
         Get page source.
         Use JS rather than browser.page_source so we get the parsed, properly formatted DOM instead of raw user HTML.
     """
@@ -282,8 +282,8 @@ def get_page_source(browser):
 def parse_page_source(source):
     """
         Return page source as a parsed PyQuery object for querying.
-         
-        PyQuery here works the same as `$(source)` in jQuery. So for example you can do `parsed_source(selector)` 
+
+        PyQuery here works the same as `$(source)` in jQuery. So for example you can do `parsed_source(selector)`
         with the returned value to get a list of LXML elements matching the selector.
     """
     return PyQuery(source, parser='html')
@@ -574,7 +574,7 @@ def favicon_thread(successful_favicon_urls, dom_tree, content_url, thread_list, 
 
 def favicon_get_urls(dom_tree, content_url):
     """
-        Retrieve favicon URLs from DOM. 
+        Retrieve favicon URLs from DOM.
     """
     urls = []  # order here matters so that we prefer meta tag favicon over /favicon.ico
     for el in dom_tree('link'):

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -984,10 +984,11 @@ def run_next_capture():
             page_load_thread.join(max(0, ONLOAD_EVENT_TIMEOUT - (time.time() - start_time)))
             if page_load_thread.is_alive():
                 print("Onload timed out")
-            post_load_function = get_post_load_function(browser)
-            if post_load_function:
-                print("Running domain's post-load function")
-                post_load_function(browser)
+            with browser_running(browser):
+                post_load_function = get_post_load_function(browser)
+                if post_load_function:
+                    print("Running domain's post-load function")
+                    post_load_function(browser)
 
             # Get a fresh copy of the page's metadata, if possible.
             print("Retrieving DOM (post-onload)")


### PR DESCRIPTION
Whitespace, and fix for one tiny discovery: the browser often crashes during NYTimes captures while waiting for the onload event. If that happens, we currently still try to find the post-load function and run it, which causes an exception with a lengthy stacktrace that it would be better to keep out of the logs. This throws in yet one more with "browser_running" to hide that.