### PR TITLE
Working on #2021

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from pyquery import PyQuery
 
-from httplib import HTTPResponse
+from httplib import HTTPResponse, CannotSendRequest
 from urllib2 import URLError
 
 import os
@@ -283,7 +283,10 @@ def get_page_source(browser):
         Get page source.
         Use JS rather than browser.page_source so we get the parsed, properly formatted DOM instead of raw user HTML.
     """
-    return browser.execute_script("return document.documentElement.outerHTML")
+    try:
+        return browser.execute_script("return document.documentElement.outerHTML")
+    except (WebDriverException, CannotSendRequest):
+        return browser.page_source
 
 def parse_page_source(source):
     """


### PR DESCRIPTION
First pass workaround for captures where js is disallowed by content security policy.

@jcushman suggests a better approach for the future is to move to Chrome's remote debugger protocol (`--headless --remote-debugging-port=9222`, https://developers.google.com/web/updates/2017/04/headless-chrome))