### PR TITLE
mysql connection update and db reset fabric helper

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -132,7 +132,8 @@ def reset_hard_db():
     if not confirm("WARNING! You're about to drop the Perma.cc DBs. Continue anyway?"):
         abort("No DBs dropped. Aborted.")
 
-    local("python manage.py sqlflush | python manage.py dbshell")
+    local("python manage.py sqlflush --database default | python manage.py dbshell")
+    local("python manage.py sqlflush --database perma-cdxline | python manage.py dbshell")
     init_db();
 
 @task

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -134,7 +134,7 @@ def reset_hard_db():
 
     local("python manage.py sqlflush --database default | python manage.py dbshell")
     local("python manage.py sqlflush --database perma-cdxline | python manage.py dbshell")
-    init_db();
+    init_db()
 
 @task
 def screenshots(base_url='http://perma.dev:8000'):

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -7,6 +7,9 @@ from django.conf import settings
 from fabric.context_managers import shell_env
 from fabric.decorators import task
 from fabric.operations import local
+from fabric.contrib.console import confirm
+from fabric.api import abort
+
 
 from perma.tests.utils import reset_failed_test_files_folder
 
@@ -120,6 +123,17 @@ def init_db():
     local("python manage.py migrate --database=perma-cdxline")
     local("python manage.py loaddata fixtures/sites.json fixtures/users.json fixtures/folders.json")
 
+@task
+def reset_hard_db():
+    """
+        Drops the perma and perma_cdxline databases and creates and inits them again
+    """
+
+    if not confirm("WARNING! You're about to drop the Perma.cc DBs. Continue anyway?"):
+        abort("No DBs dropped. Aborted.")
+
+    local("python manage.py sqlflush | python manage.py dbshell")
+    init_db();
 
 @task
 def screenshots(base_url='http://perma.dev:8000'):

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -12,7 +12,7 @@ SERVICES_DIR = os.path.abspath(os.path.join(PROJECT_ROOT, '../services'))
 
 # make sure mysql uses innodb and utf8
 _mysql_connection_options = {
-    "init_command": "SET storage_engine=INNODB; SET NAMES 'utf8';",
+    "init_command": "SET default_storage_engine=INNODB; SET NAMES 'utf8';",
     # for mysql 5.7+, use:
     # "init_command": "SET default_storage_engine=INNODB; SET NAMES 'utf8';",
     "charset": "utf8",


### PR DESCRIPTION
MySQL 5.7 (recent upgrade for me. lookout!) appears to require a new name for the storage engine in the config.

Also added a helper for a common task for me -- fabric helper to drop and create the two perma dbs