### PR TITLE
Added improved support for Webrecorder Player

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -189,6 +189,7 @@
         {% endcomment %}
       </div>
       <div class="tray-actions col-xs-12">
+          <a href="{% url 'single_linky' guid=link.guid %}?type=warc_download" role="button" class="btn btn-ui-small btn-dashboard" title="download">Download Archive</a>
         {% if not can_edit %}
           <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
         {% endif %}

--- a/perma_web/perma/templates/docs/faq.html
+++ b/perma_web/perma/templates/docs/faq.html
@@ -144,7 +144,7 @@ This section of the user guide provides answers to common questions about Perma.
 
       <h3 class="body-bh" data-href="warc-replay">How do I view a downloaded archive?</h3>
         <div class="faq-answer">
-          <p class="body-text">Perma archives are downloadable and can be viewed using tool that can replay WARC files like <a href="https://github.com/webrecorder/webrecorderplayer-electron/releases/latest">Rhizome's Webrecorder Player</a></p>
+          <p class="body-text">Perma archives are downloadable and can be viewed using tools that can replay WARC files like <a href="https://github.com/webrecorder/webrecorderplayer-electron/releases/latest">Rhizome's Webrecorder Player</a></p>
         </div>
 
       <h3 class="body-bh" data-href="robots-text">Can I prevent Perma.cc from publicly displaying archives of pages from my site?</h3>

--- a/perma_web/perma/templates/docs/faq.html
+++ b/perma_web/perma/templates/docs/faq.html
@@ -142,6 +142,11 @@ This section of the user guide provides answers to common questions about Perma.
         <p class="body-text">No. Perma.cc preserves only the targeted page. It does not drill down to capture pages that are linked on the targeted page. So for example, if you use Perma.cc to preserve a page that has 10 links on it, you would preserve that page but not the pages available at the 10 links.</p>
       </div>
 
+      <h3 class="body-bh" data-href="warc-replay">How do I view a downloaded archive?</h3>
+        <div class="faq-answer">
+          <p class="body-text">Perma archives are downloadable and can be viewed using tool that can replay WARC files like <a href="https://github.com/webrecorder/webrecorderplayer-electron/releases/latest">Rhizome's Webrecorder Player</a></p>
+        </div>
+
       <h3 class="body-bh" data-href="robots-text">Can I prevent Perma.cc from publicly displaying archives of pages from my site?</h3>
       <div class="faq-answer">
         <p class="body-text">

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -1,5 +1,5 @@
 from wsgiref.util import FileWrapper
-import logging, io, gzip, itertools, json
+import logging, itertools, json
 from time import mktime
 from collections import OrderedDict
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -1,14 +1,15 @@
 from wsgiref.util import FileWrapper
-import logging
+import logging, io, gzip, itertools, json
 from time import mktime
+from collections import OrderedDict
 
-from django.contrib.auth.views import redirect_to_login
 from ratelimit.decorators import ratelimit
 from datetime import timedelta
 from wsgiref.handlers import format_date_time
 from ua_parser import user_agent_parser
 from urllib import urlencode
 
+from django.contrib.auth.views import redirect_to_login
 from django.core.files.storage import default_storage
 from django.forms import widgets
 from django.http import HttpResponseForbidden, Http404
@@ -25,6 +26,8 @@ from ..models import Link, Registrar, Organization, LinkUser
 from ..forms import ContactForm
 from ..utils import if_anonymous, ratelimit_ip_key
 from ..email import send_admin_email, send_user_email_copy_admins
+
+from warcio.warcwriter import BufferWARCWriter
 
 logger = logging.getLogger(__name__)
 valid_serve_types = ['image', 'warc_download']
@@ -134,9 +137,54 @@ def single_linky(request, guid):
         if link.user_deleted:
             raise Http404
         elif request.user.can_view(link):
-            response = StreamingHttpResponse(FileWrapper(default_storage.open(link.warc_storage_file()), 1024 * 8),
-                                             content_type="application/gzip")
-            response['Content-Disposition'] = "attachment; filename=%s.warc.gz" % link.guid
+
+            def make_warcinfo(filename, guid, coll_title, coll_desc, rec_title, pages):
+                # #
+                # Thank you! Rhizome/WebRecorder.io/Ilya Kreymer
+                # #
+
+                coll_metadata = {'type': 'collection',
+                                 'title': coll_title,
+                                 'desc': coll_desc
+                                }
+
+                rec_metadata = {'type': 'recording',
+                                'title': rec_title,
+                                'pages': pages}
+
+                # Coll info
+                writer = BufferWARCWriter(gzip=True)
+                params = OrderedDict([('operator', 'Perma.cc download'),
+                                      ('Perma-GUID', guid),
+                                      ('format', 'WARC File Format 1.0'),
+                                      ('json-metadata', json.dumps(coll_metadata))])
+
+                record = writer.create_warcinfo_record(filename, params)
+                writer.write_record(record)
+
+                # Rec Info
+                params['json-metadata'] = json.dumps(rec_metadata)
+
+                record = writer.create_warcinfo_record(filename, params)
+                writer.write_record(record)
+
+                return writer.get_contents()
+
+
+            filename = "%s.warc.gz" % link.guid
+
+            warcinfo = make_warcinfo( filename = filename,
+                         guid = link.guid,
+                         coll_title = 'Perma Archive, %s' % link.submitted_title,
+                         coll_desc = link.submitted_description,
+                         rec_title = 'Perma Archive of %s' % link.submitted_title,
+                         pages= [{'title': link.submitted_title, 'url': link.submitted_url}])
+
+            warc_stream = FileWrapper(default_storage.open(link.warc_storage_file()))
+            warc_stream = itertools.chain([warcinfo], warc_stream)
+            response = StreamingHttpResponse(warc_stream, content_type="application/gzip")
+            response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+
             return response
         else:
             return HttpResponseForbidden('Private archive.')

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -47,6 +47,7 @@ django_webpack_loader==0.3.3    # frontend assets building
 -e git://github.com/rebeccacremona/createsend-python.git@7cd8be21f89fa7bb61dafb31da9ad4a64058bf5b#egg=createsend-python
 tqdm==4.11.2                    # progress bar in dev fab tasks
 pyquery==1.2.17                 # extract data from HTML in capture task
+warcio==1.3.3                   # helps us write metadata and inspect our WARCs
 
 # api
 djangorestframework==3.6.2

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -125,6 +125,7 @@ tldextract==2.0.2         # via surt
 tqdm==4.11.2
 ua-parser==0.7.1
 Wand==0.4
+warcio==1.3.3
 warctools==4.10.0
 watchdog==0.8.3           # via pywb
 webencodings==0.5.1       # via pywb

--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -484,6 +484,8 @@ def new_rewrite(self, status_headers, urlrewriter, cookie_rewriter):
 HeaderRewriter.rewrite = new_rewrite
 
 
+
+
 # =================================================================
 def create_perma_wb_router(config={}):
     """


### PR DESCRIPTION
This pull req suggests a way to prepend our warcs with some metadata that helps wr player display the archive in a more helpful way
    
We only prepend to the warc as we're streaming it to the client, and we only prepend rarely, when the request type is warc_download

Thanks for the help @ikreymer!
    
Also added a download button in the record details tray -- need to refine this button ux/ui in the tray