### PR TITLE
Upgrade requests and other packages, tweak teardown for functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ addons:
     paths:
       - perma_web/failed_test_files
 
+  # a modern firefox
+  firefox: latest-esr
+
 cache:
   pip: true
   directories:

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -189,7 +189,10 @@ class FunctionalTest(BaseTestCase):
     def quitDriver(self):
         # to get past transient error (selenium OSError: [Errno 9] Bad file descriptor),
         # send signal according to https://stackoverflow.com/a/45786385/4074877
-        self.driver.service.process.send_signal(signal.SIGTERM)
+        try:
+            self.driver.service.process.send_signal(signal.SIGTERM)
+        except AttributeError:
+            pass
         self.driver.quit()
 
     def tearDownLocal(self):

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -180,6 +180,7 @@ class FunctionalTest(BaseTestCase):
             self.virtual_display = Display(visible=0, size=(1024, 800))
             self.virtual_display.start()
             self.driver = webdriver.Firefox(capabilities=self.base_desired_capabilities)
+            self.driver.implicitly_wait(20)
         except RuntimeError:
             self.driver = webdriver.PhantomJS(desired_capabilities=self.base_desired_capabilities)
         print("Using %s for integration tests." % (type(self.driver)))

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -180,7 +180,6 @@ class FunctionalTest(BaseTestCase):
             self.virtual_display = Display(visible=0, size=(1024, 800))
             self.virtual_display.start()
             self.driver = webdriver.Firefox(capabilities=self.base_desired_capabilities)
-            self.driver.implicitly_wait(20)
         except RuntimeError:
             self.driver = webdriver.PhantomJS(desired_capabilities=self.base_desired_capabilities)
         print("Using %s for integration tests." % (type(self.driver)))

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -13,6 +13,7 @@ from pyvirtualdisplay import Display
 from selenium import webdriver
 from selenium.common.exceptions import ElementNotVisibleException, NoSuchElementException
 import time
+import signal
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.urlresolvers import reverse
@@ -185,8 +186,14 @@ class FunctionalTest(BaseTestCase):
         socket.setdefaulttimeout(30)
         self.driver.set_window_size(1024, 800)
 
-    def tearDownLocal(self):
+    def quitDriver(self):
+        # to get past transient error (selenium OSError: [Errno 9] Bad file descriptor),
+        # send signal according to https://stackoverflow.com/a/45786385/4074877
+        self.driver.service.process.send_signal(signal.SIGTERM)
         self.driver.quit()
+
+    def tearDownLocal(self):
+        self.quitDriver()
         if self.virtual_display:
             self.virtual_display.stop()
 
@@ -198,7 +205,7 @@ class FunctionalTest(BaseTestCase):
             else:
                 sauce.jobs.update_job(self.driver.session_id, passed=False)
         finally:
-            self.driver.quit()
+            self.quitDriver()
 
     def test_all(self):
 

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -10,17 +10,17 @@
 Django==1.10.8
 MySQL-python==1.2.5
 celery==3.1.25
-requests[security]==2.11.1
+requests[security]==2.18.4
 wsgiref==0.1.2
 django-ratelimit==1.0.0
 smhasher==0.150.1
-jasmine==2.4.0
+jasmine==2.8.0
 pytz==2013b
 django-mptt==0.8.7
 Werkzeug==0.11.1
 Fabric==1.11.1
 pexpect==3.1
-selenium==2.47.3
+selenium==3.6.0
 jsmin==2.0.9
 pyScss==1.3.4  					# dependency of d-p-compass. included here to avoid wonkiness found in older versions
 tempdir==0.6                    # create temp dirs to be deleted at end of function -- handy for archive creation
@@ -48,6 +48,7 @@ django_webpack_loader==0.3.3    # frontend assets building
 tqdm==4.11.2                    # progress bar in dev fab tasks
 pyquery==1.2.17                 # extract data from HTML in capture task
 warcio==1.3.3                   # helps us write metadata and inspect our WARCs
+cryptography==2.1               # pyopenssl and requests only require 1.8.1; we need 1.9+ to install on stretch
 
 # api
 djangorestframework==3.6.2
@@ -61,7 +62,7 @@ newrelic==2.66.0.49
 opbeat==3.3.3
 
 # PyWB-related stuff
-pywb==0.33
+pywb==0.33.2
 #surt==0.2                       # to canonicalize URLs for the cdxline index -- use whatever version pywb wants
 -e git://github.com/internetarchive/warcprox.git@f79e74482339f8c06880b28e889be694b30d4575#egg=warcprox  # unreleased 1/4/16 version of warcprox
 

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -20,13 +20,15 @@ botocore==1.5.49          # via boto3, s3transfer
 brotlipy==0.6.0           # via pywb
 celery==3.1.25
 certauth==1.1.3
+certifi==2017.7.27.1      # via requests
 cffi==1.10.0              # via brotlipy, cryptography
-chardet==2.3              # via jasmine, pywb
-CherryPy==3.8.2           # via jasmine
-click==6.7                # via flask, pip-tools
+chardet==3.0.4            # via pywb, requests
+cheroot==5.8.3            # via cherrypy
+CherryPy==11.0.0          # via jasmine
+click==6.7                # via pip-tools
 clint==0.5.1              # via internetarchive
 coverage==4.3.4
-cryptography==1.8.1       # via pyopenssl
+cryptography==2.1
 cssselect==1.0.1          # via pyquery
 django-admin-smoke-tests==0.3.0
 django-crispy-forms==1.6.1
@@ -53,20 +55,18 @@ Fabric==1.11.1
 fakeredis==0.7.0
 first==2.0.1              # via pip-tools
 flake8==2.5.4
-Flask==0.12.1             # via jasmine
 funcsigs==1.0.2           # via mock
 futures==3.1.1            # via s3transfer
 gevent==1.0.2
 glob2==0.5                # via jasmine-core
 greenlet==0.4.12          # via gevent
 gunicorn==19.3.0
-idna==2.5                 # via cryptography, tldextract
+idna==2.5                 # via cryptography, requests, tldextract
 internetarchive==1.0.10
 ipaddress==1.0.18         # via cryptography
-itsdangerous==0.24        # via flask
-jasmine-core==2.5.2       # via jasmine
-jasmine==2.4.0
-Jinja2==2.9.6             # via flask, jasmine, pywb
+jasmine-core==2.8.0       # via jasmine
+jasmine==2.8.0
+Jinja2==2.8.1             # via jasmine, pywb
 jmespath==0.9.2           # via boto3, botocore
 jsmin==2.0.9
 jsonpatch==0.4            # via internetarchive
@@ -77,12 +77,10 @@ MarkupSafe==1.0           # via jinja2
 mccabe==0.4.0             # via flake8
 mock==2.0.0
 MySQL-python==1.2.5
-ndg-httpsclient==0.4.2    # via requests
 netaddr==0.7.12
 newrelic==2.66.0.49
 opbeat==3.3.3
 ordereddict==1.1          # via jasmine-core
-packaging==16.8           # via cryptography
 paramiko==1.18.2          # via fabric
 pathlib==1.0.1            # via pyscss
 pathtools==0.1.2          # via watchdog
@@ -91,13 +89,12 @@ pep8==1.7.0               # via flake8
 pexpect==3.1
 Pillow==3.3.2
 pip-tools==1.7
+portend==2.2              # via cherrypy
 py==1.4.33                # via pytest, pytest-xdist
-pyasn1==0.2.3             # via requests
 pycparser==2.17           # via cffi
 pycrypto==2.6.1           # via paramiko
 pyflakes==1.0.0           # via flake8
-pyopenssl==16.2.0         # via certauth, ndg-httpsclient, requests
-pyparsing==2.2.0          # via packaging
+pyopenssl==16.2.0         # via certauth, requests
 pyquery==1.2.17
 pyScss==1.3.4
 pytest-django==3.1.2
@@ -106,32 +103,34 @@ pytest==3.0.7
 python-dateutil==2.2
 pytz==2013b0
 PyVirtualDisplay==0.1.5
-pywb==0.33
+pywb==0.33.2
 PyYAML==3.10              # via jasmine, pywb, watchdog
 redis==2.10.5
 requests-file==1.4.1      # via tldextract
-requests[security]==2.11.1
+requests[security]==2.18.4
 s3transfer==0.1.10        # via boto3
 sauceclient==0.1.0
 schema==0.5.0             # via internetarchive
-selenium==2.47.3
-six==1.10.0               # via cryptography, django-admin-smoke-tests, internetarchive, jasmine, mock, packaging, pip-tools, pyopenssl, pyscss, python-dateutil, pywb, requests-file, surt, warcio
+selenium==3.6.0
+six==1.10.0               # via cheroot, cherrypy, cryptography, django-admin-smoke-tests, internetarchive, jasmine, mock, pip-tools, pyopenssl, pyscss, python-dateutil, pywb, requests-file, surt, tempora, warcio
 smhasher==0.150.1
 sorl-thumbnail==12.3
 surt==0.3.0               # via pywb
 tempdir==0.6
+tempora==1.9              # via portend
 tldextract==2.0.2         # via surt
 tqdm==4.11.2
 ua-parser==0.7.1
+urllib3==1.22             # via requests
 Wand==0.4.4
 warcio==1.3.3
 warctools==4.10.0
 watchdog==0.8.3           # via pywb
 webencodings==0.5.1       # via pywb
-Werkzeug==0.11.1          # via flask, jasmine
+Werkzeug==0.11.1
 whitenoise==3.2.2
 wsgiref==0.1.2
 
 # The following packages are commented out because they are
 # considered to be unsafe in a requirements file:
-# setuptools                # via cryptography, django-sslserver, pytest, tldextract
+# setuptools                # via django-sslserver, pytest, tldextract


### PR DESCRIPTION
In order to upgrade `cryptography`, I started by upgrading `requests`, and then had a small chain of additional package upgrades in order to get pip-compile to complete. In the end, cryptography was still set at 1.8.1, so I specified the version by hand in `requirements.in`, and left the other upgrades in place. Then, on testing, I saw an occasional error (`selenium OSError: [Errno 9] Bad file descriptor`) on teardown of phantomjs, so I adjusted the teardown functions according to https://stackoverflow.com/a/45786385/4074877.

Fixes #2130.