### PR TITLE
Update pip-tools, remove versions from req.in, explain usage

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -37,12 +37,16 @@ If you are using Vagrant, all of your logs will end up in /vagrant/services/logs
 
 ### Python requirements
 
-Top-level requirements should go in `requirements.in`. If you change that file, you should then regenerate the
-`requirements.txt` file with:
+Top-level requirements should go in `requirements.in`, usually without a version specified.
+If you change that file, you should then regenerate the `requirements.txt` file with:
 
-    pip-compile --output-file requirements.txt requirements.in
+    pip-compile
 
 This ensures that our sub-requirements are always pinned to fixed versions.
+
+To update a requirement to latest, run:
+
+    pip-compile -P package-name
 
 ### Node requirements
 

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -5,78 +5,77 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 
-# Package:                      # Used for:
+# Package:                          # Used for:
 
-Django==1.10.8
-MySQL-python==1.2.5
-celery==3.1.25
-requests[security]==2.18.4
-wsgiref==0.1.2
-django-ratelimit==1.0.0
-smhasher==0.150.1
-jasmine==2.8.0
-pytz==2013b
-django-mptt==0.8.7
-Werkzeug==0.11.1
-Fabric==1.11.1
-pexpect==3.1
-selenium==3.6.0
-jsmin==2.0.9
-pyScss==1.3.4  					# dependency of d-p-compass. included here to avoid wonkiness found in older versions
-tempdir==0.6                    # create temp dirs to be deleted at end of function -- handy for archive creation
-netaddr==0.7.12                 # to check archive IPs against banned ranges
-internetarchive==1.0.10         # upload warcs to internet archive
-python-dateutil==2.2            # calculate link expiration date
-Wand==0.4.4           			# ImageMagick bindings to help with thumbnail creation and PDF -> PNG conversions
-sorl-thumbnail==12.3			# Used to create our thumbnails
-redis==2.10.5					# Needed to bind with Redis. Supports our sorl thumbnails in production
-django-redis==4.4.3             # use redis as django's cache backend
-django-sslserver==0.14          # For testing SSL locally.
-django-model-utils==2.6.1         # for tracking dirty models
-django-settings-context-processor==0.2 # make settings available in templates
-django-admin-smoke-tests==0.3.0    # basic tests for the Django admin
-Pillow==3.3.2                   # Used by the Django admin for ImageField display
-whitenoise==3.2.2               # serve static assets
-django-simple-history==1.8.1    # track changes to certain models
-PyVirtualDisplay==0.1.5         # for capturing with non-headless browsers
-LinkHeader==0.4.3               # memento headers for single-link pages
-pip-tools==1.7                  # generating requirements.txt from requirements.in
-django-taggit==0.20.2           # tagging registrars
-ua-parser==0.7.1                # user agent parsing to detect Safari browser for playbacks
-django_webpack_loader==0.3.3    # frontend assets building
+Django
+MySQL-python
+celery
+requests[security]
+wsgiref
+django-ratelimit
+smhasher
+jasmine
+pytz
+django-mptt
+Werkzeug
+Fabric
+pexpect
+selenium
+jsmin
+pyScss  					        # dependency of d-p-compass. included here to avoid wonkiness found in older versions
+tempdir                             # create temp dirs to be deleted at end of function -- handy for archive creation
+netaddr                             # to check archive IPs against banned ranges
+internetarchive                     # upload warcs to internet archive
+python-dateutil                     # calculate link expiration date
+Wand           			            # ImageMagick bindings to help with thumbnail creation and PDF -> PNG conversions
+sorl-thumbnail			            # Used to create our thumbnails
+redis					            # Needed to bind with Redis. Supports our sorl thumbnails in production
+django-redis                        # use redis as django's cache backend
+django-sslserver                    # For testing SSL locally.
+django-model-utils                  # for tracking dirty models
+django-settings-context-processor   # make settings available in templates
+django-admin-smoke-tests            # basic tests for the Django admin
+Pillow                              # Used by the Django admin for ImageField display
+whitenoise                          # serve static assets
+django-simple-history               # track changes to certain models
+PyVirtualDisplay                    # for capturing with non-headless browsers
+LinkHeader                          # memento headers for single-link pages
+pip-tools                           # generating requirements.txt from requirements.in
+django-taggit                       # tagging registrars
+ua-parser                           # user agent parsing to detect Safari browser for playbacks
+django_webpack_loader               # frontend assets building
 -e git://github.com/rebeccacremona/createsend-python.git@7cd8be21f89fa7bb61dafb31da9ad4a64058bf5b#egg=createsend-python
-tqdm==4.11.2                    # progress bar in dev fab tasks
-pyquery==1.2.17                 # extract data from HTML in capture task
-warcio==1.3.3                   # helps us write metadata and inspect our WARCs
-cryptography==2.1               # pyopenssl and requests only require 1.8.1; we need 1.9+ to install on stretch
+tqdm                                # progress bar in dev fab tasks
+pyquery                             # extract data from HTML in capture task
+warcio                              # helps us write metadata and inspect our WARCs
+cryptography                        # pyopenssl and requests only require 1.8.1; we need 1.9+ to install on stretch
 
 # api
-djangorestframework==3.6.2
-django-crispy-forms==1.6.1  # interactive docs
-django-filter==1.0.2        # searching
+djangorestframework
+django-crispy-forms                 # interactive docs
+django-filter                       # searching
 
 # deployment
-gunicorn==19.3.0
-gevent==1.0.2
-newrelic==2.66.0.49
-opbeat==3.3.3
+gunicorn
+gevent
+newrelic
+opbeat
 
 # PyWB-related stuff
-pywb==0.33.2
-#surt==0.2                       # to canonicalize URLs for the cdxline index -- use whatever version pywb wants
+pywb
 -e git://github.com/internetarchive/warcprox.git@f79e74482339f8c06880b28e889be694b30d4575#egg=warcprox  # unreleased 1/4/16 version of warcprox
 
 # alternate storages
-django-storages==1.5.2
-boto3==1.4.4  # required for django-storages to use s3 backend
+django-storages
+boto3                               # required for django-storages to use s3 backend
 
 # testing
-sauceclient==0.1.0
-pytest==3.0.7
-pytest-django==3.1.2
-pytest-xdist==1.15.0
-fakeredis==0.7.0                # simulate redis backend for tests
-flake8==2.5.4                   # code linting
-beautifulsoup4==4.5.1           # parses html of responses
-mock                            # safe monkey patching
-coverage==4.3.4                 # record code coverage
+sauceclient
+pytest
+pytest-django
+pytest-xdist
+fakeredis                           # simulate redis backend for tests
+flake8                              # code linting
+beautifulsoup4                      # parses html of responses
+mock                                # safe monkey patching
+coverage                            # record code coverage

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -24,7 +24,7 @@ certifi==2017.7.27.1      # via requests
 cffi==1.10.0              # via brotlipy, cryptography
 chardet==3.0.4            # via pywb, requests
 cheroot==5.8.3            # via cherrypy
-CherryPy==11.0.0          # via jasmine
+cherrypy==11.0.0          # via jasmine
 click==6.7                # via pip-tools
 clint==0.5.1              # via internetarchive
 coverage==4.3.4
@@ -42,16 +42,16 @@ django-simple-history==1.8.1
 django-sslserver==0.14
 django-storages==1.5.2
 django-taggit==0.20.2
-Django==1.10.8            # via django-admin-smoke-tests, django-model-utils, django-sslserver
-django_webpack_loader==0.3.3
+django-webpack-loader==0.3.3
+django==1.10.8
 djangorestframework==3.6.2
 docopt==0.6.2             # via internetarchive
 docutils==0.13.1          # via botocore
-EasyProcess==0.2.3        # via pyvirtualdisplay
+easyprocess==0.2.3        # via pyvirtualdisplay
 ecdsa==0.13               # via paramiko
 enum34==1.1.6             # via brotlipy, cryptography, pyscss
 execnet==1.4.1            # via pytest-xdist
-Fabric==1.11.1
+fabric==1.11.1
 fakeredis==0.7.0
 first==2.0.1              # via pip-tools
 flake8==2.5.4
@@ -66,17 +66,17 @@ internetarchive==1.0.10
 ipaddress==1.0.18         # via cryptography
 jasmine-core==2.8.0       # via jasmine
 jasmine==2.8.0
-Jinja2==2.8.1             # via jasmine, pywb
+jinja2==2.8.1             # via jasmine, pywb
 jmespath==0.9.2           # via boto3, botocore
 jsmin==2.0.9
 jsonpatch==0.4            # via internetarchive
 kombu==3.0.37             # via celery
-LinkHeader==0.4.3
+linkheader==0.4.3
 lxml==3.7.3               # via pyquery
-MarkupSafe==1.0           # via jinja2
+markupsafe==1.0           # via jinja2
 mccabe==0.4.0             # via flake8
 mock==2.0.0
-MySQL-python==1.2.5
+mysql-python==1.2.5
 netaddr==0.7.12
 newrelic==2.66.0.49
 opbeat==3.3.3
@@ -87,8 +87,8 @@ pathtools==0.1.2          # via watchdog
 pbr==2.0.0                # via mock
 pep8==1.7.0               # via flake8
 pexpect==3.1
-Pillow==3.3.2
-pip-tools==1.7
+pillow==3.3.2
+pip-tools==1.10.1
 portend==2.2              # via cherrypy
 py==1.4.33                # via pytest, pytest-xdist
 pycparser==2.17           # via cffi
@@ -96,15 +96,15 @@ pycrypto==2.6.1           # via paramiko
 pyflakes==1.0.0           # via flake8
 pyopenssl==16.2.0         # via certauth, requests
 pyquery==1.2.17
-pyScss==1.3.4
+pyscss==1.3.4
 pytest-django==3.1.2
 pytest-xdist==1.15.0
 pytest==3.0.7
 python-dateutil==2.2
-pytz==2013b0
-PyVirtualDisplay==0.1.5
+pytz==2017.2
+pyvirtualdisplay==0.1.5
 pywb==0.33.2
-PyYAML==3.10              # via jasmine, pywb, watchdog
+pyyaml==3.10              # via jasmine, pywb, watchdog
 redis==2.10.5
 requests-file==1.4.1      # via tldextract
 requests[security]==2.18.4
@@ -122,15 +122,11 @@ tldextract==2.0.2         # via surt
 tqdm==4.11.2
 ua-parser==0.7.1
 urllib3==1.22             # via requests
-Wand==0.4.4
+wand==0.4.4
 warcio==1.3.3
 warctools==4.10.0
 watchdog==0.8.3           # via pywb
 webencodings==0.5.1       # via pywb
-Werkzeug==0.11.1
+werkzeug==0.11.1
 whitenoise==3.2.2
 wsgiref==0.1.2
-
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
-# setuptools                # via django-sslserver, pytest, tldextract


### PR DESCRIPTION
So I think we haven't quite been using pip-tools right -- we're supposed to specify versions only in `requirements.txt`, not in `requirements.in`. This still pins versions, but lets us use `pip-compile` to upgrade a package and all dependencies just by running something like `pip-compile -P celery`.

In this pull req:

- update pip-tools to latest
- drop all version numbers from requirements.in
- update pytz (this is the only version that actually changed as a result of dropping version numbers, which I think was because it had a weird `2013b` version number and can safely be ignored)
- remove `cryptography` from `requirements.in` (because it doesn't actually have to specified there once it's updated in `requirements.txt`)
- document usage in `developer.md`