### PR TITLE
Use a tmp dir for MEDIA_ROOT when running tests; clean up afterwards.

### DIFF
--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -135,19 +135,12 @@ class ApiResourceTestCaseMixin(SimpleTestCase):
         super(ApiResourceTestCaseMixin, self).setUp()
 
         self.api_client = LoggingAPIClient()
-
-        self._media_org = settings.MEDIA_ROOT
-        self._media_tmp = settings.MEDIA_ROOT = tempfile.mkdtemp()
-
         try:
             self.list_url = "{0}{1}".format(self.url_base, self.resource_url)
         except:
             pass
 
     def tearDown(self):
-        settings.MEDIA_ROOT = self._media_org
-        shutil.rmtree(self._media_tmp)
-
         # wipe cache -- see https://niwinz.github.io/django-redis/latest/#_testing_with_django_redis
         from django_redis import get_redis_connection
         get_redis_connection("default").flushall()

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -78,14 +78,16 @@ def test_python(apps=_default_tests):
 
     # temporarily set MEDIA_ROOT to a tmp directory, in a way that lets us clean up after ourselves
     tmp = tempfile.mkdtemp()
-    shell_envs = {
-        'DJANGO__MEDIA_ROOT': tmp
-    }
-    with shell_env(**shell_envs):
-        local("coverage run manage.py test --settings perma.settings.deployments.settings_testing %s" % (apps))
+    try:
+        shell_envs = {
+            'DJANGO__MEDIA_ROOT': tmp
+        }
+        with shell_env(**shell_envs):
+            local("coverage run manage.py test --settings perma.settings.deployments.settings_testing %s" % (apps))
+    finally:
+        # clean up after ourselves
+        shutil.rmtree(tmp)
 
-    # clean up after ourselves
-    shutil.rmtree(tmp)
 
 @task
 def test_js():

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -78,7 +78,6 @@ def test_python(apps=_default_tests):
 
     # temporarily set MEDIA_ROOT to a tmp directory, in a way that lets us clean up after ourselves
     tmp = tempfile.mkdtemp()
-    print(tmp)
     shell_envs = {
         'DJANGO__MEDIA_ROOT': tmp
     }


### PR DESCRIPTION
Doing this in fabric for 2 reasons:
1) it covers the whole test suite, including code that is imported/invoked outside of any particular test
2) you can see the tmp file created, used, and deleted all in one spot, instead of across multiple files (for instance, if the tmp dir was created in settings_testing

But, I'm totally open to other potential solutions. This was just the only thing I could think of.

See https://github.com/harvard-lil/perma/issues/2139