### PR TITLE
Avoid middleware errors when API error handler invoked

### DIFF
--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -84,9 +84,9 @@ urlpatterns = [
 ### error handlers ###
 
 def handler404(request):
-    HttpResponse(status=404)
+    return HttpResponse('Page Not Found', status=404)
 def handler500(request):
-    HttpResponse(status=500)
+    return HttpResponse('Internal Server Error', status=500)
 
 ### django debug toolbar ###
 


### PR DESCRIPTION
With DEBUG=False, try
```
curl -H 'Content-Type: application/json' -X POST -d '{"url": "asdf:[/p]zxcv.com"}' http://api.perma.dev:8000/v1/archives/?api_key=8e1c8dfd8d7f776715ed9074ed0186b6c27bf63d
```
You'll see the expected error (invalid IPv6), plus some middleware-related errors.

The middleware errors are because the api 500 handler needed a return :-)

Added very short text too, for dev happiness using curl.