### PR TITLE
Run tests with pytest by default.

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -60,15 +60,15 @@ def run_ssl(port="0.0.0.0:8000"):
 _default_tests = "perma api functional_tests lockss"
 
 @task
-def test(apps=_default_tests):
+def test(apps=_default_tests, pytest=True):
     """ Run perma tests. (For coverage, run `coverage report` after tests pass.) """
     reset_failed_test_files_folder()
-    test_python(apps)
+    test_python(apps, pytest)
     if apps == _default_tests:
         test_js()
 
 @task
-def test_python(apps=_default_tests):
+def test_python(apps=_default_tests, pytest=True):
     """ Run Python tests. """
 
     # In order to run functional_tests, we have to run collectstatic, since functional tests use DEBUG=False
@@ -83,7 +83,11 @@ def test_python(apps=_default_tests):
             'DJANGO__MEDIA_ROOT': tmp
         }
         with shell_env(**shell_envs):
-            local("coverage run manage.py test --settings perma.settings.deployments.settings_testing %s" % (apps))
+            # all arguments to Fabric tasks are interpretted as strings
+            if pytest == 'False':
+                local("coverage run manage.py test --settings perma.settings.deployments.settings_testing %s" % (apps))
+            else:
+                local("pytest %s --ds=perma.settings.deployments.settings_testing --cov --cov-report= " % (apps))
     finally:
         # clean up after ourselves
         shutil.rmtree(tmp)

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -74,6 +74,7 @@ boto3                               # required for django-storages to use s3 bac
 hypothesis==3.31.2               # run tests with lots of generated input
 sauceclient
 pytest
+pytest-cov
 pytest-django
 pytest-xdist
 fakeredis                           # simulate redis backend for tests

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -92,6 +92,7 @@ pynacl==1.1.2
 pyopenssl==16.2.0         # via certauth, requests
 pyquery==1.2.17
 pyscss==1.3.4
+pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-xdist==1.15.0
 pytest==3.0.7

--- a/perma_web/setup.cfg
+++ b/perma_web/setup.cfg
@@ -12,6 +12,7 @@ exclude = node_modules,static
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = perma.settings.deployments.settings_testing
 norecursedirs = node_modules
+python_files = tests.py test_*.py *_tests.py
 
 ## http://coverage.readthedocs.io/en/latest/config.html
 [coverage:run]


### PR DESCRIPTION
There's a memory problem with python unittest in 2.7. Short version of the story: data initialized during self.setUp isn't freed at the end of the test. This behavior is changed in 3.4. See https://chrisbailey.blogs.ilrt.org/2013/05/19/pythons-leaky-testcase-aka-hidden-gotchas-using-self/ and https://bugs.python.org/issue11798

As a result, as our test suite has grown, we've needed more and more memory to run the tests. We've gotten to the point where over 2GB of RAM is required.... more than @anastasia and @rebeccacremona have available in our dev boxes. So, when running the complete suite of tests locally, we start getting failures midway, of the form `OSError: [Errno 12] Cannot allocate memory` or `raise WebDriverException("Unable to start phantomjs with ghostdriver: %s" % e) WebDriverException: Message: Unable to start phantomjs with ghostdriver: [Errno 12] Cannot allocate memory` or similar. 

Using pytest completely avoids the issue.

If anybody wants to run with manage.py (or if we want to continue using that in travis, for example), fab test now takes a second optional argument:
`fab test:pytest=False` or `fab test:apps='api perma',pytest=False` etc. to run with manage.py