### PR TITLE
Don't die if we can't write CDX lines here.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -779,8 +779,11 @@ def save_warc(warc_writer, capture_job, link, content_type, screenshot, successf
         warc_size=default_storage.size(link.warc_storage_file())
     )
 
-    print("Writing CDX lines to the DB")
-    CDXLine.objects.create_all_from_link(link)
+    try:
+        print("Writing CDX lines to the DB")
+        CDXLine.objects.create_all_from_link(link)
+    except Exception as e:
+        print("Unable to create CDX lines at this time: {}".format(e))
 
 
 def save_favicons(link, successful_favicon_urls):


### PR DESCRIPTION
Right now, writing CDX lines in production involves calling out to S3 and reading back the warc. This can fail for unimportant reasons. For instance, it appears to at least occasionally be true that, in an entirely successfully capture and save process, we sometimes reach the CDX line creating code before S3 has a warc ready for us to read. (More investigation required: is the save asynchronous, and we should be waiting to join a thread? etc.) 

Since CDXlines are created on playback anyway, creating them here is nonessential (though required presently for tests to pass).

Let's ignore errors for now, and consider removing these lines entirely in the future.