### PR TITLE
Password validation

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -12,7 +12,6 @@ import socket
 from urllib import urlencode
 from urlparse import urlparse
 import simple_history
-import string
 import requests
 import itertools
 import time
@@ -39,6 +38,7 @@ from django.db import models
 from django.db.models import Q, Max, Count
 from django.db.models.query import QuerySet
 from django.utils import timezone
+from django.utils.crypto import get_random_string
 from django.utils.functional import cached_property
 from mptt.models import MPTTModel, TreeForeignKey
 from model_utils import FieldTracker
@@ -461,9 +461,7 @@ class LinkUser(AbstractBaseUser):
         return self.email
 
     def save_new_confirmation_code(self):
-        r = random.SystemRandom()
-        self.confirmation_code = ''.join(
-            r.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for x in range(30))
+        self.confirmation_code = get_random_string(length=30)
         self.save()
 
     def top_level_folders(self):

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -12,6 +12,7 @@ import socket
 from urllib import urlencode
 from urlparse import urlparse
 import simple_history
+import string
 import requests
 import itertools
 import time
@@ -458,6 +459,12 @@ class LinkUser(AbstractBaseUser):
     # On Python 3: def __str__(self):
     def __unicode__(self):
         return self.email
+
+    def save_new_confirmation_code(self):
+        r = random.SystemRandom()
+        self.confirmation_code = ''.join(
+            r.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for x in range(30))
+        self.save()
 
     def top_level_folders(self):
         """

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -185,7 +185,7 @@ AUTH_USER_MODEL = 'perma.LinkUser'
 
 LOGIN_REDIRECT_URL = '/manage/create/'
 LOGIN_URL = '/login'
-
+VALIDATE_ALL_PASSWORDS = False
 
 MESSAGE_STORAGE = 'django.contrib.messages.storage.fallback.FallbackStorage'
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -186,6 +186,23 @@ AUTH_USER_MODEL = 'perma.LinkUser'
 LOGIN_REDIRECT_URL = '/manage/create/'
 LOGIN_URL = '/login'
 VALIDATE_ALL_PASSWORDS = False
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 9,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'perma.utils.AlphaNumericValidator',
+    },
+]
 
 MESSAGE_STORAGE = 'django.contrib.messages.storage.fallback.FallbackStorage'
 

--- a/perma_web/perma/templates/password_change_embedded_form.html
+++ b/perma_web/perma/templates/password_change_embedded_form.html
@@ -1,21 +1,27 @@
 <form method="post" action="{% url 'password_change' %}" class="embedded-form" role="form">
   <fieldset>
-    {% if auth_form.non_field_errors %}{{ auth_form.non_field_errors }}{% endif %}
-    <div class="form-group{% if auth_form.old_password.errors %} _error{% endif %}">
+    {% if form.non_field_errors %}{{ form.non_field_errors }}{% endif %}
+    <div class="form-group{% if form.old_password.errors %} _error{% endif %}">
       <label for="id_old_password">Old password</label>
       <input type="password" class="form-control" name="old_password" id="id_old_password">
-      {% if auth_form.old_password.errors %}{{ auth_form.old_password.errors }}{% endif %}
+      {% if form.old_password.errors %}{{ form.old_password.errors }}{% endif %}
       <p class="field-note"><a href="{% url 'password_reset' %}">Forgot your password?</a></p>
     </div>
-    <div class="form-group{% if auth_form.new_password1.errors %} _error{% endif %}">
+    <div class="form-group{% if form.new_password1.errors %} _error{% endif %}">
       <label for="id_new_password1">New password</label>
       <input type="password" class="form-control" name="new_password1" id="id_new_password1">
-      {% if auth_form.new_password1.errors %}{{ auth_form.new_password1.errors }}{% endif %}
+      {% if form.new_password1.errors %}
+        {{ form.new_password1.errors }}
+      {% elif form.new_password1.help_text %}
+        <div class="field-error">
+        {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+        </div>
+      {% endif %}
     </div>
-    <div class="form-group{% if auth_form.new_password2.errors %} _error{% endif %}">
+    <div class="form-group{% if form.new_password2.errors %} _error{% endif %}">
       <label for="id_new_password2">Confirm password</label>
       <input type="password" class="form-control" name="new_password2" id="id_new_password2">
-      {% if auth_form.new_password2.errors %}{{ auth_form.new_password2.errors }}{% endif %}
+      {% if form.new_password2.errors %}{{ form.new_password2.errors }}{% endif %}
     </div>
   </fieldset>
   <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">

--- a/perma_web/perma/templates/password_change_embedded_form.html
+++ b/perma_web/perma/templates/password_change_embedded_form.html
@@ -14,7 +14,7 @@
         {{ form.new_password1.errors }}
       {% elif form.new_password1.help_text %}
         <div class="field-error">
-        {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+        {{ form.new_password1.help_text | safe }}
         </div>
       {% endif %}
     </div>

--- a/perma_web/perma/templates/registration/password_change_form.html
+++ b/perma_web/perma/templates/registration/password_change_form.html
@@ -16,7 +16,13 @@
           <div class="form-group{% if form.new_password1.errors %} _error{% endif %}">
             <label for="id_new_password1">New password</label>
             {{ form.new_password1 }}
-            <span class="field-error">{{ form.new_password1.errors }}</span>
+            {% if form.new_password1.errors %}
+              {{ form.new_password1.errors }}
+            {% elif form.new_password1.help_text %}
+              <div class="field-error">
+              {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+              </div>
+            {% endif %}
           </div>
           <div class="form-group{% if form.new_password2.errors %} _error{% endif %}">
             <label for="id_new_password2">Confirm password</label>

--- a/perma_web/perma/templates/registration/password_change_form.html
+++ b/perma_web/perma/templates/registration/password_change_form.html
@@ -20,7 +20,7 @@
               {{ form.new_password1.errors }}
             {% elif form.new_password1.help_text %}
               <div class="field-error">
-              {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+              {{ form.new_password1.help_text | safe }}
               </div>
             {% endif %}
           </div>

--- a/perma_web/perma/templates/registration/password_reset_confirm.html
+++ b/perma_web/perma/templates/registration/password_reset_confirm.html
@@ -17,7 +17,7 @@
                 <span class="field-error">{{ form.new_password1.errors }}</span>
               {% elif form.new_password1.help_text %}
                 <div class="field-error">
-                {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+                {{ form.new_password1.help_text | safe }}
                 </div>
               {% endif %}
             </div>

--- a/perma_web/perma/templates/registration/password_reset_confirm.html
+++ b/perma_web/perma/templates/registration/password_reset_confirm.html
@@ -13,7 +13,13 @@
             <div class="form-group{% if form.new_password1.errors %} _error{% endif %}">
               <label for="id_new_password1">New password:</label>
               {{ form.new_password1 }}
-              <span class="field-error">{{ form.new_password1.errors }}</span>
+              {% if form.new_password1.errors %}
+                <span class="field-error">{{ form.new_password1.errors }}</span>
+              {% elif form.new_password1.help_text %}
+                <div class="field-error">
+                {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+                </div>
+              {% endif %}
             </div>
             <div class="form-group{% if form.new_password2.errors %} _error{% endif %}">
               <label for="id_new_password2">Confirm password:</label>

--- a/perma_web/perma/templates/registration/password_update_form.html
+++ b/perma_web/perma/templates/registration/password_update_form.html
@@ -16,7 +16,7 @@
               {{ form.new_password1.errors }}
             {% elif form.new_password1.help_text %}
               <div class="field-error">
-              {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+              {{ form.new_password1.help_text | safe }}
               </div>
             {% endif %}
           </div>

--- a/perma_web/perma/templates/registration/password_update_form.html
+++ b/perma_web/perma/templates/registration/password_update_form.html
@@ -1,0 +1,34 @@
+{% extends "base-responsive.html" %}
+
+{% block mainContent %}
+<div class="container cont-fixed">
+  <div class="row">
+    <div class="col-sm-12">
+      <h1 class="page-title">Your Password Has Expired</h1>
+      <form action="{{ action }}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="confirmation_code" value="{{ confirmation_code }}">
+        <fieldset class="col-sm-6">
+          <div class="form-group{% if form.new_password1.errors %} _error{% endif %}">
+            <label for="id_new_password1">New password</label>
+            {{ form.new_password1 }}
+            {% if form.new_password1.errors %}
+              {{ form.new_password1.errors }}
+            {% elif form.new_password1.help_text %}
+              <div class="field-error">
+              {% autoescape off %}{{ form.new_password1.help_text }}{% endautoescape %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="form-group{% if form.new_password2.errors %} _error{% endif %}">
+            <label for="id_new_password2">Confirm password</label>
+            {{ form.new_password2 }}
+            <span class="field-error">{{ form.new_password2.errors }}</span>
+          </div>
+        </fieldset>
+        <button type="submit" value="Change Password" class="btn">Change Password</button>
+      </form>
+    </div>
+  </div>
+</div> <!-- end wrapper -->
+{% endblock mainContent %}

--- a/perma_web/perma/templates/registration/set_password.html
+++ b/perma_web/perma/templates/registration/set_password.html
@@ -23,7 +23,7 @@
                   {% for error in field.errors %}<span class="field-error">{{ error }}</span>{% endfor %}
                   {% elif field.help_text %}
                     <div class="field-error">
-                    {% autoescape off %}{{ field.help_text }}{% endautoescape %}
+                    {{ field.help_text | safe }}
                     </div>
                 {% endif %}
               </div>

--- a/perma_web/perma/templates/registration/set_password.html
+++ b/perma_web/perma/templates/registration/set_password.html
@@ -22,7 +22,9 @@
                 {% if field.errors %}
                   {% for error in field.errors %}<span class="field-error">{{ error }}</span>{% endfor %}
                   {% elif field.help_text %}
-                  <span class="field-error">{{ field.help_text }}</span>
+                    <div class="field-error">
+                    {% autoescape off %}{{ field.help_text }}{% endautoescape %}
+                    </div>
                 {% endif %}
               </div>
             {% endfor %}

--- a/perma_web/perma/tests/test_views_auth.py
+++ b/perma_web/perma/tests/test_views_auth.py
@@ -25,8 +25,11 @@ class AuthViewsTestCase(PermaTestCase):
     @override_settings(VALIDATE_ALL_PASSWORDS=True)
     def test_all_passwords_validated_with_setting(self):
         # Login through our form and make sure we get asked to change our password
-        response = self.client.post(reverse('user_management_limited_login'),
-            {'username':'test_user@example.com', 'password':'pass'})
+        response = self.client.post(
+            reverse('user_management_limited_login'),
+            {'username':'test_user@example.com', 'password':'pass'}
+        )
+        self.assertEqual(response.status_code, 200)
         self.assertIn('Your Password Has Expired', response.content)
         self.assertNotIn('_auth_user_id', self.client.session)
 

--- a/perma_web/perma/tests/test_views_auth.py
+++ b/perma_web/perma/tests/test_views_auth.py
@@ -45,15 +45,15 @@ class AuthViewsTestCase(PermaTestCase):
 
     def test_password_change(self):
         """
-        Let's make sure we can login and chagne our password
+        Let's make sure we can login and change our password
         """
 
         self.client.login(username='test_user@example.com', password='pass')
         self.assertIn('_auth_user_id', self.client.session)
 
         self.client.post(reverse('password_change'),
-            {'old_password':'pass', 'new_password1':'changed-password',
-            'new_password2':'changed-password'})
+            {'old_password':'pass', 'new_password1':'changed-password1',
+            'new_password2':'changed-password1'})
 
         self.client.logout()
 
@@ -63,6 +63,6 @@ class AuthViewsTestCase(PermaTestCase):
 
         self.client.logout()
 
-        # Try to login with our old password
-        self.client.login(username='test_user@example.com', password='changed-password')
+        # Try to login with our new password
+        self.client.login(username='test_user@example.com', password='changed-password1')
         self.assertIn('_auth_user_id', self.client.session)

--- a/perma_web/perma/tests/test_views_auth.py
+++ b/perma_web/perma/tests/test_views_auth.py
@@ -1,6 +1,9 @@
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from .utils import PermaTestCase
+
+from perma.models import LinkUser
 
 
 class AuthViewsTestCase(PermaTestCase):
@@ -18,6 +21,15 @@ class AuthViewsTestCase(PermaTestCase):
         self.assertEqual(create_url, True)
         self.assertEqual(response.status_code, 302)
         self.assertIn('_auth_user_id', self.client.session)
+
+    @override_settings(VALIDATE_ALL_PASSWORDS=True)
+    def test_all_passwords_validated_with_setting(self):
+        # Login through our form and make sure we get asked to change our password
+        response = self.client.post(reverse('user_management_limited_login'),
+            {'username':'test_user@example.com', 'password':'pass'})
+        self.assertIn('Your Password Has Expired', response.content)
+        self.assertNotIn('_auth_user_id', self.client.session)
+
 
     def test_deactived_user_login(self):
         self.submit_form('user_management_limited_login',
@@ -62,6 +74,27 @@ class AuthViewsTestCase(PermaTestCase):
         self.assertNotIn('_auth_user_id', self.client.session)
 
         self.client.logout()
+
+        # Try to login with our new password
+        self.client.login(username='test_user@example.com', password='changed-password1')
+        self.assertIn('_auth_user_id', self.client.session)
+
+    @override_settings(VALIDATE_ALL_PASSWORDS=True)
+    def test_password_update(self):
+        user = LinkUser.objects.get(email='test_user@example.com')
+        user.save_new_confirmation_code()
+        response = self.client.post(reverse('password_update'), {
+            'confirmation_code':user.confirmation_code,
+            'new_password1':'changed-password1',
+            'new_password2':'changed-password1'
+        })
+        self.assertNotIn('_auth_user_id', self.client.session)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('login', response['Location'])
+
+        # Try to login with our old password
+        self.client.login(username='test_user@example.com', password='pass')
+        self.assertNotIn('_auth_user_id', self.client.session)
 
         # Try to login with our new password
         self.client.login(username='test_user@example.com', password='changed-password1')

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1835,12 +1835,12 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # reg confirm - non-matching passwords
         self.submit_form('register_password', reverse_kwargs={'args': [confirmation_code]},
-                         data={'new_password1':'a', 'new_password2':'b'},
+                         data={'new_password1':'new-password1', 'new_password2':'new-password2'},
                          error_keys=['new_password2'])
 
         # reg confirm - correct
         self.submit_form('register_password', reverse_kwargs={'args': [confirmation_code]},
-                         data={'new_password1': 'a', 'new_password2': 'a'},
+                         data={'new_password1': 'new-password1', 'new_password2': 'new-password1'},
                          success_url=reverse('user_management_limited_login'))
 
     def test_signup_with_existing_email_rejected(self):

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -72,6 +72,7 @@ urlpatterns = [
     url(r'^password/reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', auth_views.password_reset_confirm, {'template_name': 'registration/password_reset_confirm.html'}, name='password_reset_confirm'),
     url(r'^password/reset/complete/?$', auth_views.password_reset_complete, {'template_name': 'registration/password_reset_complete.html'}, name='password_reset_complete'),
     url(r'^password/reset/done/?$', auth_views.password_reset_done, {'template_name': 'registration/password_reset_done.html'}, name='password_reset_done'),
+    url(r'^password/update/?$', user_management.update_password, name='password_update'),
     url(r'^api_key/create/?$', user_management.api_key_create, name='api_key_create'),
 
     # Settings

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -14,7 +14,7 @@ from django.views.generic import UpdateView
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.forms import AuthenticationForm, SetPasswordForm, PasswordResetForm
+from django.contrib.auth.forms import AuthenticationForm, SetPasswordForm, PasswordResetForm, PasswordChangeForm
 from django.contrib.auth import views as auth_views
 from django.db.models import Count, Max, Sum
 from django.db.models.expressions import RawSQL
@@ -951,7 +951,12 @@ def settings_password(request):
     """
     Settings change password ...
     """
-    context = {'next': request.get_full_path(), 'this_page': 'settings_password'}
+    form = PasswordChangeForm(get_form_data(request))
+    context = {
+        'next': request.get_full_path(),
+        'this_page': 'settings_password',
+        'form': form,
+    }
     return render(request, 'user_management/settings-password.html', context)
 
 

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -11164,6 +11164,10 @@ textarea:focus {
   padding-bottom: 16px;
 }
 
+.field-error ul {
+  padding-left: 0;
+}
+
 .errorlist {
   list-style-type: none;
   margin: 0;

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -2936,6 +2936,10 @@ textarea {
   padding-bottom: $double;
 }
 
+.field-error ul {
+  padding-left: 0;
+}
+
 .errorlist {
   list-style-type: none;
   margin: 0;


### PR DESCRIPTION
For PCI compliance:
```
(a) Are user password parameters configured to
require passwords/passphrases meet the
following?
 A minimum password length of at least
seven characters
 Contain both numeric and alphabetic
characters
Alternatively, the passwords/passphrases must have
complexity and strength at least equivalent to the
parameters specified above.
```
This PR does two things:
1) immediately imposes stricter password policies for new passwords (which covers new users and any current users who reset or change their passwords)
2) adds a configuration variable VALIDATE_ALL_PASSWORDS, False by default, which if True, checks a user's password against the current validation rules when they log in. If it doesn't meet the requirements, they are forced to update it.

To force all users to update their passwords, we can set VALIDATE_ALL_PASSWORDS = True and then expire all sessions (http://blog.sashalaundy.com/blog/2014/08/26/howto-force-all-django-users-to-log-out-with-the-django-orm/)