### PR TITLE
Add return policy page

### DIFF
--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -71,7 +71,7 @@
       <footer>
         <div class="container cont-fixed">
           <div class="row">
-            <div class="col col-md-7">
+            <div class="col col-lg-7">
               <ul id="footer-nav">
                 <li class="footer-nav-item"><a href="{% url 'about' %}">About</a></li>
                 <li class="footer-nav-item"><a href="{% url 'docs' %}">Guide</a></li>
@@ -84,10 +84,11 @@
                 <li class="footer-nav-item"><a href="https://status.perma.cc/">Status</a></li>
               </ul>
             </div>
-            <div class="col col-md-5">
+            <div class="col col-lg-5">
               <ul id="boilerplate">
                 <li class="boilerplate-item"><a href="{% url 'terms_of_service' %}">Terms of Service</a></li>
                 <li class="boilerplate-item"><a href="{% url 'privacy_policy' %}">Privacy Policy</a></li>
+                <li class="boilerplate-item"><a href="{% url 'return_policy' %}">Return Policy</a></li>
                 <li class="boilerplate-item"><a href="{% url 'copyright_policy' %}">Copyright Policy</a></li>
               </ul>
             </div>

--- a/perma_web/perma/templates/return_policy.html
+++ b/perma_web/perma/templates/return_policy.html
@@ -1,0 +1,25 @@
+{% extends "base-responsive.html" %}
+{% block title %} | Return Policy{% endblock %}
+
+{% block meta_description %}
+The Perma.cc Return Policy.
+{% endblock %}
+
+{% block mainContent %}
+  <div class="container cont-fixed">
+    <div class="row">
+      <div class="col-sm-12 ">
+        <h1>Return Policy</h1>
+      </div>
+    </div>
+  </div>
+
+<div class="container cont-reading cont-fixed">
+  <div class="row">
+    <div class="col-sm-8 docs reading-body">
+      <p class="body-text">We do not offer refunds, but you may cancel your subscription to avoid incurring additional charges. If you have questions about this policy, please <a href="/contact?subject=Question%20About%20Return%20Policy">contact us</a>.</p>
+
+    </div><!--span-->
+  </div><!--row-->
+</div><!--container-->
+{% endblock mainContent %}

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url(r'^copyright-policy/?$', DirectTemplateView.as_view(template_name='copyright_policy.html'), name='copyright_policy'),
     url(r'^terms-of-service/?$', DirectTemplateView.as_view(template_name='terms_of_service.html'), name='terms_of_service'),
     url(r'^privacy-policy/?$', DirectTemplateView.as_view(template_name='privacy_policy.html'), name='privacy_policy'),
+    url(r'^return-policy/?$', DirectTemplateView.as_view(template_name='return_policy.html'), name='return_policy'),
     url(r'^contingency-plan/?$', DirectTemplateView.as_view(template_name='contingency_plan.html'), name='contingency_plan'),
     url(r'^contact/?$', common.contact, name='contact'),
     url(r'^contact/thanks/?$', common.contact_thanks, name='contact_thanks'),

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -11796,7 +11796,7 @@ footer {
   font-weight: 700;
 }
 
-@media only screen and (min-width: 990px) {
+@media only screen and (min-width: 1200px) {
   footer {
     position: absolute;
     bottom: 0;
@@ -11875,7 +11875,7 @@ footer #footer-nav {
   padding-left: 0;
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1200px) {
   footer #footer-nav li:last-child a {
     margin-right: 0;
   }
@@ -11890,7 +11890,7 @@ footer #boilerplate a {
   padding-bottom: 0;
 }
 
-@media only screen and (min-width: 990px) {
+@media only screen and (min-width: 1200px) {
   footer {
     padding: 16px 0 40px;
   }

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3362,7 +3362,7 @@ footer {
   font-family: $font-hed-alt;
   color: $color-white;
   font-weight: 700;
-  @include respond-desktop {
+  @include respond-wide {
     @include affix-to-bottom;
     padding-top: 0;
     background: $color-white;
@@ -3418,7 +3418,7 @@ footer {
   #footer-nav {
     padding-left: 0;
     li:last-child a {
-      @include respond-tablet {
+      @include respond-wide {
         margin-right: 0;
       }
     }
@@ -3432,7 +3432,7 @@ footer {
       padding-bottom: 0;
     }
   }
-  @include respond-desktop {
+  @include respond-wide {
     padding: $double 0 $grid * 5;
     a:hover {
       border-color: $color-orange;


### PR DESCRIPTION
Adds a link to the footer.

This makes the footer so wordy that I had to adjust the footer styling: we toggle to the blue mobile-style footer at a larger screen size now. I think it's fine; happy to readdress if anybody hates it.

![image](https://user-images.githubusercontent.com/11020492/33038917-417041ce-ce04-11e7-80e5-e1f0def73a2b.png)

![image](https://user-images.githubusercontent.com/11020492/33038923-461a07d2-ce04-11e7-8b6f-29ab29f7a32a.png)

