### PR TITLE
Percent encode URLs using requests

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -23,7 +23,6 @@ from wsgiref.handlers import format_date_time
 from mptt.managers import TreeManager
 from simple_history.models import HistoricalRecords
 from werkzeug.test import Client
-from werkzeug.urls import iri_to_uri
 from werkzeug.wrappers import BaseResponse
 
 from django.core.signing import TimestampSigner, BadSignature
@@ -854,7 +853,7 @@ class Link(DeletableModel):
     @cached_property
     def ascii_safe_url(self):
         """ Encoded URL as string rather than unicode. """
-        return iri_to_uri(self.submitted_url)
+        return requests.utils.requote_uri(self.submitted_url.encode('utf-8'))
 
     @cached_property
     def url_details(self):


### PR DESCRIPTION
See issue 2162.

With this change, we can capture http://www.berkshireeagle.com/stories/cyberattack-spreads-in-asia,507471 using PhantomJS (still a playback problem, related to cookies, but that's a project for another day). 

Follows up on https://github.com/harvard-lil/perma/commit/1e1b188675313b8c35c233b13b8889a205e723cc, which adds support for capturing urls like http://www.jamalouki.net/Details/40893/نقشة-الورود-ستكسو-إطلالتك-بالكامل-في-الخريف-المقبل using PhantomJS and Warcprox.