### PR TITLE
Explictly encode with utf-8 to prevent implicit encoding with ascii.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1252,7 +1252,7 @@ class Capture(models.Model):
             urlencode({
                 'token': self.link.create_access_token(),
                 'guid': self.link_id,
-                'next': self.url_fragment(),
+                'next': self.url_fragment().encode('utf-8'),
             })
         ))
 


### PR DESCRIPTION
Fixes https://github.com/harvard-lil/perma/issues/2183