### PR TITLE
Docker dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '2'
+
+services:
+  db:
+    image: mysql:5.6
+    environment:
+        MYSQL_ROOT_PASSWORD: password
+    volumes:
+      # NAMED VOLUMES
+      # If the volume contains a database (a subdirectory named mysql)
+      # when you start the container, it will be left untouched and unaffected
+      # by config environment variables like $MYSQL_ROOT_PASSWORD.
+      - db_data:/var/lib/mysql:delegated
+      # BIND MOUNTS
+      - ./services/mysql/conf.d:/etc/mysql/conf.d
+  web:
+    build: ./perma_web
+    image: perma:0.2
+    tty: true
+    command: bash
+    volumes:
+      # NAMED VOLUMES
+      # Use a named, persistent volume so that the node_modules directory,
+      # which is created during the image's build process, and which our
+      # code presently expects to be nested inside the perma_web directory,
+      # isn't wiped out when mounting our code in ./perma_web code to
+      # the container. We can consider restructuring the project instead.
+      - node_modules:/perma/perma_web/node_modules
+      # BIND MOUNTS
+      - ./perma_web:/perma/perma_web
+      - ./services/celery:/perma/services/celery
+      - ./services/cloudflare:/perma/services/cloudflare
+      - ./services/django:/perma/services/django:delegated
+      - ./services/logs:/perma/services/logs:delegated
+    environment:
+      # Temporary: let Django load Docker-specific settings conditionally
+      - DOCKERIZED=True
+    extra_hosts:
+      - "perma.test:127.0.0.1"
+      - "api.perma.test:127.0.0.1"
+      - "perma-archives.test:127.0.0.1"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+volumes:
+  node_modules:
+  db_data:

--- a/perma_web/.dockerignore
+++ b/perma_web/.dockerignore
@@ -1,0 +1,4 @@
+**
+!Dockerfile
+!requirements.txt
+!package.json

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:2-stretch
+ENV PYTHONUNBUFFERED 1
+RUN mkdir -p /perma/perma_web
+WORKDIR /perma/perma_web
+
+
+# PhantomJS
+RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+    && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+    && mv phantomjs-2.1.1-linux-x86_64 /usr/local/share \
+    && ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin \
+    && rm phantomjs-2.1.1-linux-x86_64.tar.bz2
+
+
+# Get Node 6 instead of version in APT repository.
+# Downloads an installation script, which ends by running
+# apt-get update: no need to re-run at this layer
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && apt-get install -y nodejs
+
+
+# Get other dependencies.
+RUN apt-get update \
+    && apt-get install -y xvfb \
+    && apt-get install -y mysql-client \
+    && apt-get install -y nano
+
+
+# npm
+COPY package.json /perma/perma_web
+RUN npm install \
+    && rm package.json
+
+
+# pip
+COPY requirements.txt /perma/perma_web
+RUN pip install -U pip \
+    &&  pip install -r requirements.txt --src /usr/local/src \
+    && rm requirements.txt

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import socket
 import os
-import subprocess
+# import subprocess
 import unittest
 import re
 import datetime
@@ -56,7 +56,7 @@ if REMOTE_SERVER_URL:
 else:
     BaseTestCase = StaticLiveServerTestCase
     assert socket.gethostbyname(LOCAL_SERVER_DOMAIN) in ('0.0.0.0', '127.0.0.1'), "Please add `127.0.0.1 " + LOCAL_SERVER_DOMAIN + "` to your hosts file before running this test."
-    build_name += subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()  # pretty label for local jobs: datetime-git_branch
+    # build_name += subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()  # pretty label for local jobs: datetime-git_branch
 
 
 # (2) Configure Sauce vs. local PhantomJS browsers:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -18,27 +18,50 @@ _mysql_connection_options = {
     "charset": "utf8",
 }
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'perma',                      # Or path to database file if using sqlite3.
-        'USER': 'perma',
-        'PASSWORD': 'perma',
-        'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '3306',                      # Set to empty string for default.
-        'OPTIONS': _mysql_connection_options
+if os.environ.get('DOCKERIZED'):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'perma',
+            'USER': 'root',
+            'PASSWORD': 'password',
+            'HOST': 'db',
+            'PORT': '3306',
+            'OPTIONS': _mysql_connection_options
 
-    },
-    'perma-cdxline': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'perma_cdxline',
-        'USER': 'perma',
-        'PASSWORD': 'perma',
-        'HOST': '',
-        'PORT': '3306',
-        'OPTIONS': _mysql_connection_options
-    },
-}
+        },
+        'perma-cdxline': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'perma_cdxline',
+            'USER': 'root',
+            'PASSWORD': 'password',
+            'HOST': 'db',
+            'PORT': '3306',
+            'OPTIONS': _mysql_connection_options
+        },
+    }
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+            'NAME': 'perma',                      # Or path to database file if using sqlite3.
+            'USER': 'perma',
+            'PASSWORD': 'perma',
+            'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+            'PORT': '3306',                      # Set to empty string for default.
+            'OPTIONS': _mysql_connection_options
+
+        },
+        'perma-cdxline': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'perma_cdxline',
+            'USER': 'perma',
+            'PASSWORD': 'perma',
+            'HOST': '',
+            'PORT': '3306',
+            'OPTIONS': _mysql_connection_options
+        },
+    }
 
 # https://docs.djangoproject.com/en/1.9/topics/db/multi-db/#using-routers
 DATABASE_ROUTERS = ['perma.cdx_router.CDXRouter']

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -18,50 +18,34 @@ _mysql_connection_options = {
     "charset": "utf8",
 }
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': 'perma',                      # Or path to database file if using sqlite3.
+        'USER': 'perma',
+        'PASSWORD': 'perma',
+        'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        'PORT': '3306',                      # Set to empty string for default.
+        'OPTIONS': _mysql_connection_options
+
+    },
+    'perma-cdxline': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'perma_cdxline',
+        'USER': 'perma',
+        'PASSWORD': 'perma',
+        'HOST': '',
+        'PORT': '3306',
+        'OPTIONS': _mysql_connection_options
+    },
+}
 if os.environ.get('DOCKERIZED'):
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'perma',
-            'USER': 'root',
-            'PASSWORD': 'password',
-            'HOST': 'db',
-            'PORT': '3306',
-            'OPTIONS': _mysql_connection_options
-
-        },
-        'perma-cdxline': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'perma_cdxline',
-            'USER': 'root',
-            'PASSWORD': 'password',
-            'HOST': 'db',
-            'PORT': '3306',
-            'OPTIONS': _mysql_connection_options
-        },
-    }
-else:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-            'NAME': 'perma',                      # Or path to database file if using sqlite3.
-            'USER': 'perma',
-            'PASSWORD': 'perma',
-            'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-            'PORT': '3306',                      # Set to empty string for default.
-            'OPTIONS': _mysql_connection_options
-
-        },
-        'perma-cdxline': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'perma_cdxline',
-            'USER': 'perma',
-            'PASSWORD': 'perma',
-            'HOST': '',
-            'PORT': '3306',
-            'OPTIONS': _mysql_connection_options
-        },
-    }
+    DATABASES['default']['USER'] = 'root'
+    DATABASES['default']['PASSWORD'] = 'password'
+    DATABASES['default']['HOST'] = 'db'
+    DATABASES['perma-cdxline']['USER'] = 'root'
+    DATABASES['perma-cdxline']['PASSWORD'] = 'password'
+    DATABASES['perma-cdxline']['HOST'] = 'db'
 
 # https://docs.djangoproject.com/en/1.9/topics/db/multi-db/#using-routers
 DATABASE_ROUTERS = ['perma.cdx_router.CDXRouter']


### PR DESCRIPTION
(I rebased https://github.com/harvard-lil/perma/pull/2203, so can't reopen. This adds a commit with Jack's suggested tweak.)

Original PR notes follow.
___

This PR adds the tools for an optional Docker-based development environment. 

It can exist side-by-side with the current Vagrant development environment. The `node_modules` directory utilized by Vagrant will be unaffected, and different databases will be used by Vagrant and by Docker. But, for developer convenience during the transition, both Vagrant and Docker will write warcs and static files to your local `services/django/` directory, and both will log to  your local `services/logs` directory.

## Suggested helpers

Add these aliases to your .bash_profile to seriously cut down on keystrokes:

```
alias dfab="docker-compose exec web fab"
alias dmanage.py="docker-compose exec web python manage.py"
alias dbash="docker-compose exec web"
alias dshell="docker-compose exec web bash"
```

## Up and running

1. Install [Docker](https://docs.docker.com/installation/) or [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and fire it up.

2. `docker-compose up -d`

3. `dfab dev.create_db:db` (password = "password")

4. `dfab run`


## Performance considerations

This should work with any Docker setup, including:
1) native Docker for Mac (hyperkit)
2) Docker Toolbox (virtualbox)
3) native Docker for Mac running a virtualbox Docker Machine (https://blog.datasyndrome.com/docker-on-os-x-hyperkit-not-ready-21c3ca74562a)

Due to persistent I/O efficiency issues with hyperkit, vanilla Docker for Mac is the least performant, but during the course of normal development, it shouldn't matter. Expect heavy load on hyperkit off-and-on when running the tests. I did a lot of experimenting with config, both of Docker and of the MySQL server. Making I/O-heavy volumes [sync in delegated mode](https://docs.docker.com/docker-for-mac/osxfs-caching/) improves things substantially; everything else I tried had little or no effect. Tests take about 9 minutes.

Running in a virtualbox somewhat reduces the strain of the tests, and was a bit zippier. I've lost the timing information (doh!) and I'm too lazy to make another virtualbox and try again. It's up to you (and your computer) whether the small performance gains are worth the hassle of working with Docker Machine.

Baseline: tests in my Vagrant box (Using 4096MB RAM and 2 CPUs) got my fan running once for a second or so, but overall used around half as much CPU as Docker+Virtualbox or Docker+Hyperkit, and completed in 6 minutes.

This is probably worth taking another look at. 
  