### PR TITLE
Docker services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '2'
 
 services:
+  # rabbitmq:
+  #   image: rabbitmq:3.7.2
   db:
     image: mysql:5.6
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,5 +55,5 @@ services:
 volumes:
   node_modules:
   db_data:
-  rabbitmq_home:
-  redis_data:
+  # rabbitmq_home:
+  # redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
   #   image: rabbitmq:3.7.2
   #   volumes:
   #     - rabbitmq_home:/var/lib/rabbitmq:delegated
+  # redis:
+  #   image: redis:4.0.6
+  #   volumes:
+  #     - redis_data:/data:delegated
   db:
     image: mysql:5.6
     environment:
@@ -52,3 +56,4 @@ volumes:
   node_modules:
   db_data:
   rabbitmq_home:
+  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2'
 services:
   # rabbitmq:
   #   image: rabbitmq:3.7.2
+  #   volumes:
+  #     - rabbitmq_home:/var/lib/rabbitmq:delegated
   db:
     image: mysql:5.6
     environment:
@@ -49,3 +51,4 @@ services:
 volumes:
   node_modules:
   db_data:
+  rabbitmq_home:

--- a/perma_web/.dockerignore
+++ b/perma_web/.dockerignore
@@ -2,3 +2,4 @@
 !Dockerfile
 !requirements.txt
 !package.json
+!npm-shrinkwrap.json

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -28,8 +28,10 @@ RUN apt-get update \
 
 # npm
 COPY package.json /perma/perma_web
+COPY npm-shrinkwrap.json /perma/perma_web
 RUN npm install \
-    && rm package.json
+    && rm package.json \
+    && rm npm-shrinkwrap.json
 
 
 # pip

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -369,7 +369,10 @@ CLOUDFLARE_DIR = os.path.join(SERVICES_DIR, 'cloudflare')
 CLIENT_IP_HEADER = 'REMOTE_ADDR'
 
 # Celery settings
-BROKER_URL = 'amqp://guest:guest@localhost:5672/'
+if os.environ.get('DOCKERIZED'):
+    BROKER_URL = 'amqp://guest:guest@rabbitmq:5672/'
+else:
+    BROKER_URL = 'amqp://guest:guest@localhost:5672/'
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'


### PR DESCRIPTION
Add RabbitMQ so celery tasks can be run by workers.
Add Redis, so you can experiment with prod-like caching, and as prep for future integration with pywb/WebRecorder.

To use, comment in the desired services in docker-compose.yml, and comment in the necessary named volumes.

RabbitMQ requires no additional configuration, though it will not be used unless Django settings have RUN_TASKS_ASYNC = True. (=True by default, but usually toggled to False by devs in settings.py)

To configure Redis, add the below to settings.py (same as settings_prod, except the location is at host 'redis' instead of 'localhost')
```
CACHES = {
    "default": {
        "BACKEND": "django_redis.cache.RedisCache",
        "LOCATION": "redis://redis:6379/0",
        "OPTIONS": {
            "CLIENT_CLASS": "django_redis.client.DefaultClient",
            "IGNORE_EXCEPTIONS": True,  # since this is just a cache, we don't want to show errors if redis is offline for some reason
        }
    }
}
```