### PR TITLE
Build from our phantomjs to avoid bitbucket flakiness

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /perma/perma_web
 
 
 # PhantomJS
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+RUN wget https://s3.amazonaws.com/perma/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
     && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
     && mv phantomjs-2.1.1-linux-x86_64 /usr/local/share \
     && ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin \


### PR DESCRIPTION
As with travis build.

Expect a slow build, the next time you build the docker image: this unfortunately invalidates all our build layers lol.