### PR TITLE
Change git:// to git+http:// in dev_requirements.txt to fix Pip Vagrant error

### DIFF
--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -8,4 +8,4 @@ pipdeptree                      # show full pip dependency tree with the 'pipdep
 # If you install, be on the lookout for oddities soon after and consider uninstalling.
 django-debug-toolbar==1.5     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
 #django-extensions==1.7.8        # if installed, `fab run` will use `python manage.py runserver_plus`
--e git://github.com/django-extensions/django-extensions.git@26665e26#egg=django-extensions  # switch back post 1.7.8
+-e git+http://github.com/django-extensions/django-extensions.git@26665e26#egg=django-extensions  # switch back post 1.7.8


### PR DESCRIPTION
pip -r dev_requirements.txt throws an error inside of Vagrant because
of the git:// requirement.  Github does not allow a clone of a git://
URL without credentials.  git+http:// allows a fallback to HTTP for
public repositories (which the Django one of course is).