### PR TITLE
Only take link title from DOM if not already supplied by the user.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -910,6 +910,9 @@ class Link(DeletableModel):
 
     def save(self, *args, **kwargs):
         # Set a default title if one is missing
+        #
+        # N.B: if you change this default, be sure to update the
+        # title-setting logic in tasks.py to match
         if not self.submitted_title:
             self.submitted_title = self.url_details.netloc
 

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -855,7 +855,7 @@ def run_next_capture():
 
         # A default title is added in models.py, if an api user has not specified a title.
         # Make sure not to override it during the capture process.
-        if link.submitted_title.startswith("http"):
+        if not link.submitted_title.startswith("http"):
             page_metadata = {
                 'title': link.submitted_title
             }

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -524,13 +524,13 @@ def xrobots_blacklists_perma(robots_directives):
 
 # page metadata
 
-def get_metadata(page_metadata, dom_tree):
+def get_metadata(page_metadata, dom_tree, user_submitted_title):
     """
         Retrieve html page metadata.
     """
     page_metadata.update({
         'meta_tags': get_meta_tags(dom_tree),
-        'title': get_title(dom_tree)
+        'title': user_submitted_title or get_title(dom_tree)
     })
 
 def get_meta_tags(dom_tree):
@@ -843,6 +843,7 @@ def run_next_capture():
         start_time = time.time()
         link = capture_job.link
         target_url = link.ascii_safe_url
+        user_submitted_title = link.submitted_title
         browser = warcprox_controller = warcprox_thread = display = screenshot = None
         have_content = have_html = False
         thread_list = []
@@ -998,7 +999,7 @@ def run_next_capture():
             # long time, and might even crash the browser)
             print("Retrieving DOM (pre-onload)")
             dom_tree = get_dom_tree(browser)
-            get_metadata(page_metadata, dom_tree)
+            get_metadata(page_metadata, dom_tree, user_submitted_title)
 
             # get favicon urls (saved as favicon_capture_url later)
             with browser_running(browser):
@@ -1028,7 +1029,7 @@ def run_next_capture():
             # Get a fresh copy of the page's metadata, if possible.
             print("Retrieving DOM (post-onload)")
             dom_tree = get_dom_tree(browser)
-            get_metadata(page_metadata, dom_tree)
+            get_metadata(page_metadata, dom_tree, user_submitted_title)
 
             with browser_running(browser):
                 inc_progress(capture_job, 0.5, "Checking for scroll-loaded assets")

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -524,14 +524,17 @@ def xrobots_blacklists_perma(robots_directives):
 
 # page metadata
 
-def get_metadata(page_metadata, dom_tree, user_submitted_title):
+def get_metadata(page_metadata, dom_tree):
     """
         Retrieve html page metadata.
     """
-    page_metadata.update({
-        'meta_tags': get_meta_tags(dom_tree),
-        'title': user_submitted_title or get_title(dom_tree)
-    })
+    if page_metadata.get('title'):
+        page_metadata['meta_tags'] = get_meta_tags(dom_tree)
+    else:
+        page_metadata.update({
+            'meta_tags': get_meta_tags(dom_tree),
+            'title': get_title(dom_tree)
+        })
 
 def get_meta_tags(dom_tree):
     """
@@ -843,13 +846,19 @@ def run_next_capture():
         start_time = time.time()
         link = capture_job.link
         target_url = link.ascii_safe_url
-        user_submitted_title = link.submitted_title
         browser = warcprox_controller = warcprox_thread = display = screenshot = None
         have_content = have_html = False
         thread_list = []
         page_metadata = {}
         successful_favicon_urls = []
         requested_urls = set()  # all URLs we have requested -- used to avoid duplicate requests
+
+        # A default title is added in models.py, if an api user has not specified a title.
+        # Make sure not to override it during the capture process.
+        if link.submitted_title.startswith("http"):
+            page_metadata = {
+                'title': link.submitted_title
+            }
 
         # Get started, unless the user has deleted the capture in the meantime
         inc_progress(capture_job, 0, "Starting capture")
@@ -999,7 +1008,7 @@ def run_next_capture():
             # long time, and might even crash the browser)
             print("Retrieving DOM (pre-onload)")
             dom_tree = get_dom_tree(browser)
-            get_metadata(page_metadata, dom_tree, user_submitted_title)
+            get_metadata(page_metadata, dom_tree)
 
             # get favicon urls (saved as favicon_capture_url later)
             with browser_running(browser):
@@ -1029,7 +1038,7 @@ def run_next_capture():
             # Get a fresh copy of the page's metadata, if possible.
             print("Retrieving DOM (post-onload)")
             dom_tree = get_dom_tree(browser)
-            get_metadata(page_metadata, dom_tree, user_submitted_title)
+            get_metadata(page_metadata, dom_tree)
 
             with browser_running(browser):
                 inc_progress(capture_job, 0.5, "Checking for scroll-loaded assets")


### PR DESCRIPTION
Makes "Yowza" stick as title:
```
curl -H 'Content-Type: application/json' -X POST -d '{"url": "http://example.com", "title": "Yowza"}' http://api.perma.test:8000/v1/archives/?api_key=<api key>
```