### PR TITLE
Link straight to folders on manage/create page. 

### DIFF
--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -358,7 +358,9 @@ class FunctionalTest(BaseTestCase):
             url_to_capture = 'example.com'
             type_to_element(get_id('rawUrl'), url_to_capture)  # type url
             # choose folder from dropdown
-            get_css_selector('#folder-tree > .jstree-container-ul > li:last-child > a').click()
+            folder = get_css_selector('#folder-tree > .jstree-container-ul > li:last-child')
+            folder_id = folder.get_attribute('data-folder_id')
+            folder.click()
 
             # wait until API call enables create archive button
             repeat_while_false(lambda: get_id('addlink').is_enabled(), 5)
@@ -393,10 +395,13 @@ class FunctionalTest(BaseTestCase):
             # type_to_element(get_css_selector('input.link-notes'), 'test')
             # repeat_while_exception(get_xpath("//span[contains(@class,'notes-save-status') and contains(text(),'saved.')]"), NoSuchElementException)
 
-            # Redirect from org-specific url to general /create url
-            self.driver.get(self.server_url + '/manage/create/27')
+            # Verify that the folder used in the last capture was saved.
+            self.driver.get(self.server_url + '/manage/create/')
             current_url = self.driver.current_url
-            self.assertEquals(self.server_url + '/manage/create/', current_url)
+            self.assertEquals(self.server_url + '/manage/create/?folder=' + folder_id, current_url)
+            folder_from_storage = self.driver.execute_script("var ls = JSON.parse(localStorage.perma_selection); return ls[Object.keys(ls)[0]].folderIds[0]")
+            self.assertEquals(folder_id, unicode(folder_from_storage))
+
 
             # Timemap
 

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -1985,7 +1985,9 @@ webpackJsonp([1],[
 	    var selectedFolders = ls.getAll();
 	    selectedFolders[current_user.id] = { 'folderIds': folderIds, 'orgId': orgId };
 	
-	    history.pushState(null, null, "?folder=" + folderIds.join('-'));
+	    if (folderIds && folderIds.length) {
+	      history.pushState(null, null, "?folder=" + folderIds.join('-'));
+	    }
 	
 	    Helpers.jsonLocalStorage.setItem(localStorageKey, selectedFolders);
 	    Helpers.triggerOnWindow("CreateLinkModule.updateLinker");

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -1951,6 +1951,7 @@ webpackJsonp([1],[
 	
 	var APIModule = __webpack_require__(78);
 	var Helpers = __webpack_require__(92);
+	var ErrorHandler = __webpack_require__(79);
 	
 	var localStorageKey = Helpers.variables.localStorageKey;
 	var allowedEventsCount = 0;
@@ -2007,7 +2008,7 @@ webpackJsonp([1],[
 	      });
 	      return folder_list;
 	    } catch (err) {
-	      console.error(err);
+	      ErrorHandler.airbrake.notify(err);
 	    }
 	    return [];
 	  }

--- a/perma_web/static/bundles/global.js
+++ b/perma_web/static/bundles/global.js
@@ -11715,6 +11715,7 @@
 	exports.getCookie = getCookie;
 	exports.csrfSafeMethod = csrfSafeMethod;
 	exports.isHighDensity = isHighDensity;
+	exports.getQueryStringDict = getQueryStringDict;
 	exports.getWindowLocationSearch = getWindowLocationSearch;
 	exports.triggerOnWindow = triggerOnWindow;
 	
@@ -11798,6 +11799,21 @@
 	// via http://stackoverflow.com/a/20413768
 	function isHighDensity() {
 	  return window.matchMedia && (window.matchMedia('only screen and (min-resolution: 124dpi), only screen and (min-resolution: 1.3dppx), only screen and (min-resolution: 48.8dpcm)').matches || window.matchMedia('only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 2.6/2), only screen and (min--moz-device-pixel-ratio: 1.3), only screen and (min-device-pixel-ratio: 1.3)').matches) || window.devicePixelRatio && window.devicePixelRatio > 1.3;
+	}
+	
+	function getQueryStringDict() {
+	  var queryString = window.location.search.substring(1);
+	  if (queryString) {
+	    var queries = queryString.split("&");
+	    var queryDict = {};
+	    for (var i = 0; i < queries.length; i++) {
+	      var split = queries[i].split('=');
+	      queryDict[split[0]] = split[1];
+	    }
+	    return queryDict;
+	  } else {
+	    return {};
+	  }
 	}
 	
 	function getWindowLocationSearch() {

--- a/perma_web/static/js/folder-tree.module.js
+++ b/perma_web/static/js/folder-tree.module.js
@@ -38,7 +38,9 @@ export var ls = {
     var selectedFolders = ls.getAll();
     selectedFolders[current_user.id] = {'folderIds': folderIds, 'orgId': orgId};
 
-    history.pushState(null, null, "?folder=" + folderIds.join('-'));
+    if (folderIds && folderIds.length){
+      history.pushState(null, null, "?folder=" + folderIds.join('-'));
+    }
 
     Helpers.jsonLocalStorage.setItem(localStorageKey, selectedFolders);
     Helpers.triggerOnWindow("CreateLinkModule.updateLinker");

--- a/perma_web/static/js/folder-tree.module.js
+++ b/perma_web/static/js/folder-tree.module.js
@@ -37,16 +37,42 @@ export var ls = {
   setCurrent: function (orgId, folderIds) {
     var selectedFolders = ls.getAll();
     selectedFolders[current_user.id] = {'folderIds': folderIds, 'orgId': orgId};
+
+    history.pushState(null, null, "?folder=" + folderIds.join('-'));
+
     Helpers.jsonLocalStorage.setItem(localStorageKey, selectedFolders);
     Helpers.triggerOnWindow("CreateLinkModule.updateLinker");
   }
 };
 
+export function folderListFromUrl() {
+  var queryDict = Helpers.getQueryStringDict();
+  if (queryDict['folder']){
+    try {
+      var folder_list = queryDict['folder'].split('-');
+      folder_list = folder_list.map(s => parseInt(s));
+      folder_list.forEach(i => {if(isNaN(i)) throw "Invalid folder list"});
+      return folder_list
+    } catch (err) {
+      console.error(err);
+    }
+    return [];
+  }
+}
+
+export function getSavedFolders(){
+  // Look up the ID of the previously selected folder (if any)
+  // looking first at the url, and then at localStorage.
+  return folderListFromUrl() || ls.getCurrent().folderIds
+}
+
+
 export function getSavedFolder(){
-  // Look up the ID of the previously selected folder (if any) from localStorage.
-  var folderIds = ls.getCurrent().folderIds;
-  if(folderIds && folderIds.length)
+  // Look up the ID of the previously selected folder (if any)
+  var folderIds = getSavedFolders()
+  if(folderIds && folderIds.length){
     return folderIds[folderIds.length - 1];
+  }
   return null;
 }
 
@@ -83,12 +109,10 @@ function handleSelectionChange () {
 
 function selectSavedFolder(){
   var folderToSelect = getSavedFolder();
-
   //select default for users with no orgs and no saved selections
   if(!folderToSelect && current_user.top_level_folders.length == 1){
     folderToSelect = current_user.top_level_folders[0].id;
   }
-
   folderTree.select_node(getNodeByFolderID(folderToSelect));
 }
 
@@ -123,7 +147,7 @@ function handleShowFoldersEvent(currentFolder, callback){
   } else {
     loadInitialFolders(
       apiFoldersToJsTreeFolders(current_user.top_level_folders),
-      ls.getCurrent().folderIds,
+      getSavedFolders(),
       simpleCallback);
   }
 }
@@ -165,7 +189,6 @@ function loadInitialFolders(preloadedData, subfoldersToPreload, callback){
     callback(preloadedData);
     return;
   }
-
   // User does have folders selected. First, have jquery fetch contents of all folders in the selected path.
   // Set requestArgs["error"] to null to prevent a 404 from propagating up to the user.)
   $.when.apply($, subfoldersToPreload.map(folderId => APIModule.request("GET", "/folders/" + folderId + "/folders/", null, {"error": null})))

--- a/perma_web/static/js/folder-tree.module.js
+++ b/perma_web/static/js/folder-tree.module.js
@@ -4,6 +4,7 @@ require('jstree-css/default/style.min.css');
 
 var APIModule = require('./helpers/api.module.js');
 var Helpers = require('./helpers/general.helpers.js');
+var ErrorHandler = require('./error-handler.js');
 
 var localStorageKey = Helpers.variables.localStorageKey;
 var allowedEventsCount = 0;
@@ -56,7 +57,7 @@ export function folderListFromUrl() {
       folder_list.forEach(i => {if(isNaN(i)) throw "Invalid folder list"});
       return folder_list
     } catch (err) {
-      console.error(err);
+      ErrorHandler.airbrake.notify(err);
     }
     return [];
   }

--- a/perma_web/static/js/helpers/general.helpers.js
+++ b/perma_web/static/js/helpers/general.helpers.js
@@ -64,6 +64,21 @@ export function isHighDensity() {
     )) || (window.devicePixelRatio && window.devicePixelRatio > 1.3));
 }
 
+export function getQueryStringDict(){
+  var queryString = window.location.search.substring(1);
+  if (queryString){
+      var queries = queryString.split("&");
+      var queryDict = {};
+      for( var i = 0; i < queries.length; i++ ) {
+          var split = queries[i].split('=');
+          queryDict[split[0]] = split[1];
+      }
+      return queryDict;
+  } else {
+      return {};
+  }
+}
+
 export function getWindowLocationSearch() {
   return window.location.search;
 }


### PR DESCRIPTION
Addresses https://github.com/harvard-lil/perma/issues/681.

Folder specified in the URL takes precedence over that in local storage and causes local storage to update.

I decided not to use the fragment, because I think that might have unexpected effects: browsers will attempt to scroll to and set focus to an element with id equal to the fragment. If no such element exists, keyboard focus is usually dropped and set to the top-level html element, and the screen scrolls back to the top. Altering the query string should avoid those problems.