### PR TITLE
Api routes for downloading warcs

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -62,6 +62,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
             'creation_timestamp',
             'captures',
             'warc_size',
+            'warc_download_url',
             'queue_time',
             'capture_time',
         ]

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -4,6 +4,8 @@ import os
 import dateutil.parser
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.http import StreamingHttpResponse
+import StringIO
 from surt import surt
 import json
 import urllib
@@ -43,6 +45,7 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
         self.firm_folder = Folder.objects.get(name="Some Case")
 
         self.unrelated_link = Link.objects.get(pk="7CF8-SS4G")
+        self.unrelated_private_link = Link.objects.get(pk="ABCD-0001")
         self.link = Link.objects.get(pk="3SLN-JHX9")
 
         self.unrelated_link_detail_url = "{0}/{1}".format(self.list_url, self.unrelated_link.pk)
@@ -50,9 +53,12 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
 
         self.logged_in_list_url = self.list_url
         self.logged_in_unrelated_link_detail_url = reverse('api:archives', args=[self.unrelated_link.pk])
+        self.logged_in_private_link_download_url = reverse('api:archives_download', args=[self.unrelated_private_link.pk])
 
         self.public_list_url = reverse('api:public_archives')
         self.public_link_detail_url = reverse('api:public_archives', args=[self.link.pk])
+        self.public_link_download_url = reverse('api:public_archives_download', args=[self.link.pk])
+        self.public_link_download_url_for_private_link = reverse('api:public_archives_download', args=[self.unrelated_private_link.pk])
 
         self.logged_out_fields = [
             'title',
@@ -101,6 +107,35 @@ class LinkResourceTestCase(ApiResourceTransactionTestCase):
     def test_get_detail_json(self):
         self.successful_get(self.public_link_detail_url, fields=self.logged_out_fields)
 
+    @patch('api.views.stream_warc', autospec=True)
+    def test_public_download(self, stream):
+        stream.return_value = StreamingHttpResponse(StringIO.StringIO("warc placeholder"))
+        resp = self.api_client.get(self.public_link_download_url)
+        self.assertHttpOK(resp)
+        self.assertEqual(stream.call_count, 1)
+
+    def test_private_download_at_public_url(self):
+        self.rejected_get(self.public_link_download_url_for_private_link, expected_status_code=404)
+
+    def test_private_download_unauthenticated(self):
+        self.rejected_get(self.logged_in_private_link_download_url, expected_status_code=401)
+
+    def test_private_download_unauthorized(self):
+        self.rejected_get(
+            self.logged_in_private_link_download_url,
+            expected_status_code=403,
+            user=self.firm_user
+        )
+
+    @patch('perma.utils.stream_warc', autospec=True)
+    def test_private_download(self, stream):
+        stream.return_value = StreamingHttpResponse(StringIO.StringIO("warc placeholder"))
+        self.api_client.force_authenticate(user=self.regular_user)
+        resp = self.api_client.get(
+            self.logged_in_private_link_download_url,
+        )
+        self.assertHttpOK(resp)
+        self.assertEqual(stream.call_count, 1)
 
     ########################
     # URL Archive Creation #

--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -52,11 +52,14 @@ urlpatterns = [
         url(r'^public/archives/?$', views.PublicLinkListView.as_view(), name='public_archives'),
         # /public/archives/:guid
         url(r'^public/archives/%s/?$' % guid_pattern, views.PublicLinkDetailView.as_view(), name='public_archives'),
-
+        # /public/archives/:guid/download
+        url(r'^public/archives/%s/download/?$' % guid_pattern, views.PublicLinkDownloadView.as_view(), name='public_archives_download'),
         # /archives
         url(legacy_user_prefix + r'archives/?$', views.AuthenticatedLinkListView.as_view(), name='archives'),
         # /archives/:guid
         url(legacy_user_prefix + r'archives/%s/?$' % guid_pattern, views.AuthenticatedLinkDetailView.as_view(), name='archives'),
+        # /archives/:guid/download
+        url(legacy_user_prefix + r'archives/%s/download/?$' % guid_pattern, views.AuthenticatedLinkDownloadView.as_view(), name='archives_download'),
 
         # /capture_jobs
         url(legacy_user_prefix + r'capture_jobs/?$', views.CaptureJobListView.as_view(), name='capture_jobs'),

--- a/perma_web/perma/templates/docs/developer/index.html
+++ b/perma_web/perma/templates/docs/developer/index.html
@@ -107,11 +107,18 @@ Welcome to the Perma.cc developer guide.
     <p class="body-text">Response</p>
     <pre class="prettyprint">{"meta": {"limit": 1, "next": "/v1/public/archives/?limit=1", "offset": 0, "previous": null, "total_count": 2}, "objects": [{"assets": [{"base_storage_path": "2015/1/21/22/39/Y6JJ-TDUJ", "favicon": null, "image_capture": "cap.png", "pdf_capture": null, "warc_capture": "archive.warc.gz"}], "creation_timestamp": "2015-01-21T17:39:44Z", "is_private": true, "expiration_date": "2017-01-21T17:39:44Z", "guid": "Y6JJ-TDUJ", "title": "Example.com. yo.", "url": "http://example.com", "organization": {"id": 1, "name": "Test Journal"}}]}</pre>
 
-    <h3 id="get-one-archive" class="body-bh">Get one archive</h3>
-    <p class="body-text">If we have a the globally unique ID of one archive, we can GET details on it.</p>
+    <h3 id="get-one-archive" class="body-bh">Get a single archive's details</h3>
+    <p class="body-text">If we have the globally unique ID of one archive, we can GET details on it.</p>
     <pre>curl https://api.{{ request.get_host }}/v1/public/archives/Y6JJ-TDUJ/</pre>
     <p class="body-text">Response</p>
     <pre class="prettyprint">{"assets": [{"base_storage_path": "2015/1/21/22/39/Y6JJ-TDUJ", "favicon": null, "image_capture": "cap.png", "pdf_capture": null, "warc_capture": "archive.warc.gz"}], "creation_timestamp": "2015-01-21T17:39:44Z", "is_private": true, "expiration_date": "2017-01-21T17:39:44Z", "guid": "Y6JJ-TDUJ", "title": "Example.com. yo.", "url": "http://example.com", "organization": {"id": 1, "name": "Test Journal"}}</pre>
+
+    <h3 id="download-one-archive" class="body-bh">Download a single archive</h3>
+    <p class="body-text">Perma archives are downloadable and can be viewed using tools that can replay WARC files, like <a href="https://github.com/webrecorder/webrecorderplayer-electron/releases/latest">Rhizome's Webrecorder Player</a>.</p>
+    <pre>wget https://api.{{ request.get_host }}/v1/public/archives/Y6JJ-TDUJ/download</pre>
+    <p>or</p>
+    <pre>curl -o your_favorite_filename.warc.gz https://api.{{ request.get_host }}/v1/public/archives/Y6JJ-TDUJ/download</pre>
+
     </div>
   </div>
 </div>
@@ -183,9 +190,15 @@ Welcome to the Perma.cc developer guide.
       <pre class="prettyprint">{"assets": [{"base_storage_path": "2015/1/21/21/41/8H4S-TNRA", "favicon": null, "image_capture": "pending", "pdf_capture": null, "warc_capture": "pending"}], "created_by": {"first_name": "Regular", "full_name": "Regular User", "id": 4, "last_name": "User", "short_name": "Regular"}, "creation_timestamp": "2015-01-21T16:41:15Z", "is_private": false, "expiration_date": "2017-01-21T16:41:15Z", "folders": ["/v1/folders/25/"], "guid": "8H4S-TNRA", "notes": "", "title": "This is a test page", "url": "http://example.com", "organization": null}</pre>
 
       <h3 id="view-details-of-one-archive" class="body-bh">View the details of one archive</h3>
-      <pre>curl https://api.{{ request.get_host }}/v1/archives/Y6JJ-TDUJ/</pre>
+      <pre>curl https://api.{{ request.get_host }}/v1/archives/Y6JJ-TDUJ/?api_key=your-api-key</pre>
       <p class="body-text">This will show you details of an archive. Pass in the archive's globally unique ID using a GET request.</p>
       <pre class="prettyprint">{"assets": [{"base_storage_path": "2015/1/21/22/39/Y6JJ-TDUJ", "favicon": null, "image_capture": "cap.png", "pdf_capture": null, "warc_capture": "archive.warc.gz"}], "created_by": {"first_name": "Regular", "full_name": "Regular User", "id": 4, "last_name": "User", "short_name": "Regular"}, "creation_timestamp": "2015-01-21T17:39:44Z", "is_private": false, "expiration_date": "2017-01-21T17:39:44Z", "folders": ["/v1/folders/25/"], "guid": "Y6JJ-TDUJ", "notes": "", "title": "Example Domain", "url": "http://example.com", "organization": null}</pre>
+
+      <h3 id="download-one-archive-auth" class="body-bh">Download a single archive</h3>
+      <p class="body-text">Perma archives are downloadable and can be viewed using tools that can replay WARC files, like <a href="https://github.com/webrecorder/webrecorderplayer-electron/releases/latest">Rhizome's Webrecorder Player</a>.</p>
+      <pre>wget https://api.{{ request.get_host }}/v1/archives/Y6JJ-TDUJ/download?api_key=your-api-key</pre>
+      <p>or</p>
+      <pre>curl -o your_favorite_filename.warc.gz https://api.{{ request.get_host }}/v1/archives/Y6JJ-TDUJ/download?api_key=your-api-key</pre>
 
       <h3 id="view-all-archives-of-one-user" class="body-bh">View all archives associated with one user</h3>
       <p class="body-text">If you want to list all the archives associated with one user, route through the User endpoint. (The result set will contain a list of all the user's archives. We're limiting ourseleves to just 1 result to keep this example short.)</p>

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -457,9 +457,8 @@ def decrypt_from_perma_payments(ciphertext, encoder=encoding.Base64Encoder):
 @contextmanager
 def preserve_perma_warc(guid, timestamp, destination):
     """
-        Inside this context manager, the environment variable MAGICK_TEMPORARY_PATH will be set to a
-        temp path that gets deleted when the context closes. This stops Wand's calls to ImageMagick
-        leaving temp files around.
+    Context manager for opening a perma warc, ready to receive warc records.
+    Safely closes and saves the file to storage when context is exited.
     """
     out = tempfile.TemporaryFile()
     write_perma_warc_header(out, guid, timestamp)


### PR DESCRIPTION
https://github.com/harvard-lil/perma/issues/1642

Public archives can be downloaded at `/api/v1/public/archives/:guid/download` without an api_key.

All archives can be downloaded by qualified users (admins, private link owners) at `/v1/archives/:guid/download?api_key=<appropriate api key>` .

The URL used to download warcs via the GUI, `/:guid/?type=warc_download`, still works exactly like it did before: public archives may be downloaded by anyone there, and private archives may be downloaded by qualified users if they have an authenticated session (i.e. are logged in, via the log in form). This URL (still) cannot be authenticated using an API key.