### PR TITLE
Handle requests to both api and api mirror.

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -1,7 +1,5 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.urls.exceptions import NoReverseMatch
-from rest_framework.reverse import reverse
 from django.core.validators import URLValidator
 from requests import TooManyRedirects
 from rest_framework import serializers
@@ -9,7 +7,7 @@ from rest_framework import serializers
 from perma.models import LinkUser, Folder, CaptureJob, Capture, Link, Organization
 from perma.utils import ip_in_allowed_ip_range
 
-from .utils import get_mime_type, mime_type_lookup, url_is_invalid_unicode
+from .utils import get_mime_type, mime_type_lookup, url_is_invalid_unicode, reverse_api_view
 
 
 class BaseSerializer(serializers.ModelSerializer):
@@ -152,13 +150,7 @@ class LinkSerializer(BaseSerializer):
             return None
 
     def get_warc_download_url(self, link):
-        # Reverse needs to be called with the api namespace when the
-        # request is made to perma.cc/api, and cannot be called with
-        # a namespace when the request is made to api.perma.cc
-        try:
-            return reverse('api:public_archives_download', kwargs={'guid': link.guid}, request=self.context['request'])
-        except NoReverseMatch:
-            return reverse('public_archives_download', kwargs={'guid': link.guid}, request=self.context['request'])
+        return reverse_api_view('public_archives_download', kwargs={'guid': link.guid}, request=self.context['request'])
 
 
 class AuthenticatedLinkSerializer(LinkSerializer):
@@ -173,13 +165,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
         allowed_update_fields = ['submitted_title', 'submitted_description', 'notes', 'is_private', 'private_reason']
 
     def get_warc_download_url(self, link):
-        # Reverse needs to be called with the api namespace when the
-        # request is made to perma.cc/api, and cannot be called with
-        # a namespace when the request is made to api.perma.cc
-        try:
-            return reverse('api:archives_download', kwargs={'guid': link.guid}, request=self.context['request'])
-        except NoReverseMatch:
-            return reverse('archives_download', kwargs={'guid': link.guid}, request=self.context['request'])
+        return reverse_api_view('archives_download', kwargs={'guid': link.guid}, request=self.context['request'])
 
 
     def validate_url(self, url):

--- a/perma_web/api/utils.py
+++ b/perma_web/api/utils.py
@@ -4,10 +4,12 @@ from collections import OrderedDict
 from functools import wraps
 
 from django.http import Http404
+from django.urls.exceptions import NoReverseMatch
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 
 from perma.models import Folder
@@ -140,3 +142,12 @@ def url_is_invalid_unicode(url_string):
         if unicodedata.category(x)[0] == "C":
             return True
     return False
+
+def reverse_api_view(viewname, *args, **kwargs):
+    # Reverse needs to be called with the api namespace when the
+    # request is made to perma.cc/api, and cannot be called with
+    # a namespace when the request is made to api.perma.cc
+    try:
+        return reverse('api:' + viewname, *args, **kwargs)
+    except NoReverseMatch:
+        return reverse(viewname, *args, **kwargs)


### PR DESCRIPTION
This fixes a significant bug @abziegler noticed on stage: 500 on requests that need warc_download_url that come in to api.perma.cc rather than perma.cc/api

Our tests all use /api/v1/<route> to work around a similar issue: https://github.com/harvard-lil/perma/blob/develop/perma_web/api/tests/utils.py#L110

We should address that TODO soon: optimally, we should run all tests at both urls, but with the spped of the current tests, that's not feasible.