### PR TITLE
Count orgs on the python side to avoid counting deleted orgs.

### DIFF
--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -32,7 +32,7 @@
   <div class="row row-no-bleed admin-data">
     <div class="col col-xs-6 col-no-gutter admin-data-point">
       <p class="count-label">Organizations</p>
-      <p class="count-number">{{ orgs_count.count }}</p>
+      <p class="count-number">{{ orgs_count }}</p>
     </div>
     <div class="col col-xs-6 col-no-gutter admin-data-point">
       <p class="count-label">Registrars</p>
@@ -117,8 +117,8 @@
             </div>
             <div class="col col-xs-12 col-md-4 col-half-gutter">
               <div class="item-count-group">
-                <strong class="list-count-number">{{ registrar.orgs_count }}</strong>
-                <span class="item-count-label">org{{ registrar.orgs_count|pluralize }} <a href="{% url 'user_management_manage_organization' %}?registrar={{registrar.id}}">View</a></span>
+                <strong class="list-count-number">{{ registrar.organizations.count }}</strong>
+                <span class="item-count-label">org{{ registrar.organizations.count | pluralize }} <a href="{% url 'user_management_manage_organization' %}?registrar={{registrar.id}}">View</a></span>
               </div>
             </div>
             <div class="col col-xs-12 col-md-4 col-half-gutter">

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -238,10 +238,9 @@ def manage_registrar(request):
     registrars = registrars.annotate(
         registrar_users=Count('users', distinct=True),
         last_active=Max('users__last_login'),
-        orgs_count=Count('organizations',distinct=True),
     )
 
-    orgs_count = registrars.aggregate(count=Sum('orgs_count'))
+    orgs_count = Organization.objects.filter(registrar__in=registrars).count()
     #users_count = registrars.aggregate(count=Sum('registrar_users'))
 
     # handle pagination


### PR DESCRIPTION
This means we'll hit the the database once per registrar displayed on the page, but since this view is paginated, and since this is an admin-only view, I'm not worried. 

(This well might be more efficient than annotating with the counts in the first place, since that had to be done for ALL registrars, not just the ones on the desired page.)