### PR TITLE
Main site navigation accessibility

### DIFF
--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -38,13 +38,14 @@
   </head>
   <body class="{% block bodyFlags %}{% endblock bodyFlags %}">
     <header class="_default">
-      <div class="navbar navbar-default navbar-static-top">
+      <nav class="navbar navbar-default navbar-static-top" aria-labelledby="upper_right_menu_name">
         <div class="container cont-fixed">
           <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#upper_right_menu" aria-expanded="false">
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar" aria-hidden="true"></span>
+              <span class="icon-bar" aria-hidden="true"></span>
+              <span class="icon-bar" aria-hidden="true"></span>
             </button>
             <div class="navbar-brand logo">
               <a href="{% url 'landing' %}">Perma.cc<img alt="" class="infinity-logo" src="{{ STATIC_URL }}img/perma-logo-orange.svg"></a>
@@ -52,7 +53,7 @@
           </div>
           {% include 'includes/upper_right_menu.html' %}
         </div><!--/container -->
-      </div><!--/navbar -->
+      </nav><!--/navbar -->
     </header>
 
     <section id="main" class="{% block mainFlags %}{% endblock mainFlags %}">

--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -73,25 +73,29 @@
         <div class="container cont-fixed">
           <div class="row">
             <div class="col col-lg-7">
-              <ul id="footer-nav">
-                <li class="footer-nav-item"><a href="{% url 'about' %}">About</a></li>
-                <li class="footer-nav-item"><a href="{% url 'docs' %}">Guide</a></li>
-                <li class="footer-nav-item"><a href="{% url 'dev_docs' %}">Developers</a></li>
-                <li class="footer-nav-item"><a href="{% url 'stats' %}">Stats</a></li>
-                <li class="footer-nav-item"><a href="{% url 'contact' %}">Contact</a></li>
-                <li class="footer-nav-item"><a href="https://blogs.law.harvard.edu/perma/">Blog</a></li>
-                <li class="footer-nav-item"><a href="https://twitter.com/permacc">Twitter</a></li>
-                <li class="footer-nav-item"><a href="https://github.com/harvard-lil/perma">GitHub</a></li>
-                <li class="footer-nav-item"><a href="https://status.perma.cc/">Status</a></li>
-              </ul>
+              <nav aria-label="Learn More">
+                <ul id="footer-nav">
+                  <li class="footer-nav-item"><a href="{% url 'about' %}">About</a></li>
+                  <li class="footer-nav-item"><a href="{% url 'docs' %}">Guide</a></li>
+                  <li class="footer-nav-item"><a href="{% url 'dev_docs' %}">Developers</a></li>
+                  <li class="footer-nav-item"><a href="{% url 'stats' %}">Stats</a></li>
+                  <li class="footer-nav-item"><a href="{% url 'contact' %}">Contact</a></li>
+                  <li class="footer-nav-item"><a href="https://blogs.law.harvard.edu/perma/">Blog</a></li>
+                  <li class="footer-nav-item"><a href="https://twitter.com/permacc">Twitter</a></li>
+                  <li class="footer-nav-item"><a href="https://github.com/harvard-lil/perma">GitHub</a></li>
+                  <li class="footer-nav-item"><a href="https://status.perma.cc/">Status</a></li>
+                </ul>
+              </nav>
             </div>
             <div class="col col-lg-5">
-              <ul id="boilerplate">
-                <li class="boilerplate-item"><a href="{% url 'terms_of_service' %}">Terms of Service</a></li>
-                <li class="boilerplate-item"><a href="{% url 'privacy_policy' %}">Privacy Policy</a></li>
-                <li class="boilerplate-item"><a href="{% url 'return_policy' %}">Return Policy</a></li>
-                <li class="boilerplate-item"><a href="{% url 'copyright_policy' %}">Copyright Policy</a></li>
-              </ul>
+              <nav aria-label="Terms and Conditions">
+                <ul id="boilerplate">
+                  <li class="boilerplate-item"><a href="{% url 'terms_of_service' %}">Terms of Service</a></li>
+                  <li class="boilerplate-item"><a href="{% url 'privacy_policy' %}">Privacy Policy</a></li>
+                  <li class="boilerplate-item"><a href="{% url 'return_policy' %}">Return Policy</a></li>
+                  <li class="boilerplate-item"><a href="{% url 'copyright_policy' %}">Copyright Policy</a></li>
+                </ul>
+              </nav>
             </div>
           </div>
         </div><!--/container-->

--- a/perma_web/perma/templates/includes/upper_right_menu.html
+++ b/perma_web/perma/templates/includes/upper_right_menu.html
@@ -1,56 +1,68 @@
-<div class="navbar-collapse collapse">
+<div class="navbar-collapse collapse" id="upper_right_menu">
+  <h2 class="sr-only" id="upper_right_menu_name">Main Menu</h2>
   <ul class="nav navbar-nav navbar-right">
     {% if request.user.is_authenticated %}
       {% if this_page != 'create_link' and this_page != 'single_link' %}
-        <li class="navbar-create-button"><a href="{% url 'create_link' %}" role="button" class="btn btn-large btn-info navbar-create navbar-btn" data-toggle="tooltip" title="Create new Perma archive">Create and manage Perma Links</a></li>
+        <li class="navbar-create-button"><a href="{% url 'create_link' %}" class="btn btn-large btn-info navbar-create navbar-btn">Create and manage Perma Links</a></li>
       {% endif %}
       <li class="dropdown">
-        <a href="#" class="dropdown-toggle navbar-link needsclick" data-toggle="dropdown" role="button" aria-expanded="false">{{ request.user.get_short_name }}</a>
-        <ul class="dropdown-menu" role="menu">
+        <a href="#" class="dropdown-toggle navbar-link needsclick" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+          <span class="sr-only">Main Dropdown</span>
+          <span class="sr-only">You are logged in as:</span>
+          <span>{{ request.user.get_short_name }}</span>
+        </a>
+        <ul class="dropdown-menu">
           {% if not this_page == 'create_link' %}
             <li><a href="{% url 'create_link' %}">Create and manage Perma Links</a></li>
             <li class="divider"></li>
           {% endif %}
 
-
           {% if request.user.is_staff or request.user.is_registrar_user %}
-            <li role="presentation" class="dropdown-header">Manage users</li>
+            <li><h3 class="dropdown-header">Manage users</h3>
+              <ul class="dropdown-inner-list">
+                {% if request.user.is_staff %}
+                  <li><a href="{% url 'user_management_manage_admin_user' %}">Admin users</a></li>
+                  <li><a href="{% url 'user_management_manage_registrar' %}">Registrars</a></li>
+                {% endif %}
 
-            {% if request.user.is_staff %}
-              <li><a href="{% url 'user_management_manage_admin_user' %}">Admin users</a></li>
-              <li><a href="{% url 'user_management_manage_registrar' %}">Registrars</a></li>
-            {% endif %}
+                <li><a href="{% url 'user_management_manage_registrar_user' %}">Registrar users</a></li>
+                <li><a href="{% url 'user_management_manage_organization' %}">Organizations</a></li>
+                <li><a href="{% url 'user_management_manage_organization_user' %}">Organization users</a></li>
 
-            <li><a href="{% url 'user_management_manage_registrar_user' %}">Registrar users</a></li>
-            <li><a href="{% url 'user_management_manage_organization' %}">Organizations</a></li>
-            <li><a href="{% url 'user_management_manage_organization_user' %}">Organization users</a></li>
+                {% if request.user.is_staff %}
+                  <li><a href="{% url 'user_management_manage_user' %}">Users</a></li>
+                {% endif %}
+              {% endif %}
 
-            {% if request.user.is_staff %}
-              <li><a href="{% url 'user_management_manage_user' %}">Users</a></li>
-            {% endif %}
-            <li class="divider"></li>
-          {% endif %}
-
-          <!-- Org users -->
-          {% if request.user.is_organization_user %}
-            <li><a href="{% url 'user_management_manage_organization_user' %}">Manage users</a></li>
-            <li class="divider"></li>
-          {% endif %}
+              <!-- Org users -->
+              {% if request.user.is_organization_user %}
+                <li><a href="{% url 'user_management_manage_organization_user' %}">Manage users</a></li>
+              {% endif %}
+            </ul>
+          </li>
+          <li class="divider"></li>
           {% if request.user.is_staff %}
-            <li><a href="{% url 'admin:index' %}">Admin console</a></li>
-            <li><a href="{% url 'user_management_stats' %}">Site stats</a></li>
-            <li class="divider"></li>
+          <li><h3 class="dropdown-header">Admin Only</h3>
+            <ul class="dropdown-inner-list">
+              <li><a href="{% url 'admin:index' %}">Admin console</a></li>
+              <li><a href="{% url 'user_management_stats' %}">Site stats</a></li>
+            </ul>
+          </li>
+          <li class="divider"></li>
           {% endif %}
-          <li role="presentation" class="dropdown-header">Settings</li>
-          <li><a href="{% url 'user_management_settings_profile' %}">Profile</a></li>
-          <li><a href="{% url 'user_management_settings_password' %}">Password</a></li>
-          {% if request.user.can_view_subscription %}
-            <li><a href="{% url 'user_management_settings_subscription' %}">Subscription</a></li>
-          {% endif %}
-          <li><a href="{% url 'user_management_settings_tools' %}">Tools</a></li>
-          {% if request.user.is_organization_user or request.user.is_registrar_user or request.user.has_registrar_pending %}
-            <li><a href="{% url 'user_management_settings_affiliations' %}">Your affiliations</a></li>
-          {% endif %}
+          <li><h3 class="dropdown-header">Settings</h3>
+            <ul class="dropdown-inner-list">
+              <li><a href="{% url 'user_management_settings_profile' %}">Profile</a></li>
+              <li><a href="{% url 'user_management_settings_password' %}">Password</a></li>
+              {% if request.user.can_view_subscription %}
+                <li><a href="{% url 'user_management_settings_subscription' %}">Subscription</a></li>
+              {% endif %}
+              <li><a href="{% url 'user_management_settings_tools' %}">Tools</a></li>
+              {% if request.user.is_organization_user or request.user.is_registrar_user or request.user.has_registrar_pending %}
+                <li><a href="{% url 'user_management_settings_affiliations' %}">Your affiliations</a></li>
+              {% endif %}
+            </ul>
+          </li>
           <li class="divider"></li>
 
           {# use a <button> instead of a link for logout to pass CSRF protection #}

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -11619,6 +11619,55 @@ li.dropdown {
   }
 }
 
+.dropdown-inner-list {
+  padding-left: 0;
+}
+
+.dropdown-inner-list > li {
+  list-style: none;
+}
+
+.dropdown-inner-list > li > a,
+.dropdown-inner-list > li button {
+  color: black;
+  font-family: "Roboto", Helvetica, Arial, "Lucida Grande", sans-serif;
+  padding: 4px 12px 4px 24px;
+  font-size: 17px;
+  text-align: right;
+}
+
+.dropdown-inner-list > li > a:hover,
+.dropdown-inner-list > li > a:focus,
+.dropdown-inner-list > li button:hover,
+.dropdown-inner-list > li button:focus {
+  background-color: #0092FF;
+  color: white;
+}
+
+.dropdown-inner-list > li form {
+  margin: 0;
+  text-align: right;
+}
+
+.dropdown-inner-list > li button {
+  font-weight: 400;
+  border: none;
+  background-color: transparent;
+  width: 100%;
+  border-radius: 0;
+}
+
+.dropdown-inner-list a,
+.dropdown-inner-list button {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333333;
+  white-space: nowrap;
+}
+
 .dropdown.open .dropdown-menu {
   display: block;
 }

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3215,6 +3215,21 @@ li.dropdown {
   }
 }
 
+.dropdown-inner-list {
+  @include style-dropdown-items;
+  padding-left: 0;
+
+  & a, & button {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 1.42857143;
+    color: #333333;
+    white-space: nowrap;
+  }
+}
+
 .dropdown.open {
   .dropdown-menu {
     display: block;


### PR DESCRIPTION
Addresses https://github.com/harvard-lil/perma/issues/2242.

![image](https://user-images.githubusercontent.com/11020492/36265549-6f2099d4-123d-11e8-9719-1770648e5caa.png)

I'm not attached to these particular names/labels or this solution at all.

I went with "main nav" and "main dropdown" because I saw that the docs consistently refer to that dropdown as the "main dropdown". I'm hoping that labeling it as such, and nesting it inside something called "main  nav" would make it easier to find and identify, if you didn't already know what it was.

I broke the footer nav into "Learn More" and "Terms and Conditions" primarily because of the existing markup, which makes these two lists, and because there are so many items there, I feel like a little structure is helpful: either two separate labeled navs, or some headings. I went with two labeled navs so that it is potentially easier to jump straight to the legalese, if that's what interests you, or straight to the guides and information pages, if that's what interests you.

Note, there are still a few things in here that could use attention: there are some links that should be buttons, the logo has an open issue, etc. To be addressed separately.