### PR TITLE
Guide navigation accessibility

### DIFF
--- a/perma_web/perma/templates/docs/accounts.html
+++ b/perma_web/perma/templates/docs/accounts.html
@@ -20,17 +20,28 @@ This section of the user guide describes how Perma accounts work.
 <div class="container cont-reading cont-fixed" id="overview">
   <div class="row">
     <div class="col-sm-4 reading-toc" >
-      <ul>
-        <li class="reading-toc-chapter"><a href="#accounts">Accounts</a></li>
-        <li class="reading-toc-section"><a href="#who-needs-account">Who Needs an Account?</a></li>
-        <li class="reading-toc-section"><a href="#usage-limits">Usage Limits</a></li>
-        <li class="reading-toc-chapter"><a href="#organizations">Organizations</a></li>
-        <li class="reading-toc-section"><a href="#free-service-academic">Free Service for Academic Organizations</a></li>
-        <li class="reading-toc-section"><a href="#free-service-courts">Free Service for Courts</a></li>
-        <li class="reading-toc-section"><a href="#paid-service">Paid Service for Other Organizations</a></li>
-        <li class="reading-toc-section"><a href="#authority">Authority and Responsibilities</a></li>
-        <li class="reading-toc-section"><a href="#adding-org-users">Adding and Removing Organization Users</a></li>
-      </ul>
+      <nav aria-label="Accounts Page Table of Contents">
+        <h2 class="sr-only">Table of Contents</h2>
+        <ul>
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#accounts">Accounts</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#who-needs-account">Who Needs an Account?</a></li>
+              <li class="reading-toc-section"><a href="#usage-limits">Usage Limits</a></li>
+            </ul>
+          </li>
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#organizations">Organizations</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#free-service-academic">Free Service for Academic Organizations</a></li>
+              <li class="reading-toc-section"><a href="#free-service-courts">Free Service for Courts</a></li>
+              <li class="reading-toc-section"><a href="#paid-service">Paid Service for Other Organizations</a></li>
+              <li class="reading-toc-section"><a href="#authority">Authority and Responsibilities</a></li>
+              <li class="reading-toc-section"><a href="#adding-org-users">Adding and Removing Organization Users</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
     </div>
 
     <div class="col-sm-8 reading-body">

--- a/perma_web/perma/templates/docs/docs_menu.html
+++ b/perma_web/perma/templates/docs/docs_menu.html
@@ -1,60 +1,62 @@
 <div class="container cont-full-bleed overview">
   <div class="container cont-full-bleed cont-sm-fixed">
     <div class="row row-no-bleed">
-      <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs" %} _active{% endif %}">
-        {% if request.path == "/docs" %}
-        <div class="overview-module-content">
-        {% else %}
-        <a class="overview-module-content" href="{% url 'docs' %}">
-        {% endif %}
-          <strong class="overview-module-title">Getting Started</strong>
-          <p class="overview-module-description">An introduction to Perma.cc, why it exists, and how to <span class="_noWrap">use it.</span></p>
-        {% if request.path == "/docs" %}</div>{% else %}</a>{% endif %}
-      </div>
+      <nav aria-label="User Guide Table of Contents">
+        <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs" %} _active{% endif %}">
+          {% if request.path == "/docs" %}
+          <div class="overview-module-content" aria-current="page">
+          {% else %}
+          <a class="overview-module-content" href="{% url 'docs' %}">
+          {% endif %}
+            <strong class="overview-module-title">Getting Started</strong>
+            <p class="overview-module-description">An introduction to Perma.cc, why it exists, and how to <span class="_noWrap">use it.</span></p>
+          {% if request.path == "/docs" %}</div>{% else %}</a>{% endif %}
+        </div>
 
-      <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/accounts" %} _active{% endif %}">
-        {% if request.path == "/docs/accounts" %}
-        <div class="overview-module-content">
-        {% else %}
-        <a class="overview-module-content" href="{% url 'docs_accounts' %}">
-        {% endif %}
-          <strong class="overview-module-title">Accounts</strong>
-          <p class="overview-module-description">Learn about individual and organizational accounts.</p>
-        {% if request.path == "/docs/accounts" %}</div>{% else %}</a>{% endif %}
-      </div>
+        <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/accounts" %} _active{% endif %}">
+          {% if request.path == "/docs/accounts" %}
+          <div class="overview-module-content" aria-current="page">
+          {% else %}
+          <a class="overview-module-content" href="{% url 'docs_accounts' %}">
+          {% endif %}
+            <strong class="overview-module-title">Accounts</strong>
+            <p class="overview-module-description">Learn about individual and organizational accounts.</p>
+          {% if request.path == "/docs/accounts" %}</div>{% else %}</a>{% endif %}
+        </div>
 
-      <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/perma-link-creation" %} _active{% endif %}">
-        {% if request.path == "/docs/perma-link-creation" %}
-        <div class="overview-module-content">
-        {% else %}
-        <a class="overview-module-content" href="{% url 'docs_perma_link_creation' %}">
-        {% endif %}
-          <strong class="overview-module-title">Links and Records</strong>
-          <p class="overview-module-description">Learn about the links and records you can create with Perma.cc.</p>
-        {% if request.path == "/docs/perma-link-creation" %}</div>{% else %}</a>{% endif %}
-      </div>
+        <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/perma-link-creation" %} _active{% endif %}">
+          {% if request.path == "/docs/perma-link-creation" %}
+          <div class="overview-module-content" aria-current="page">
+          {% else %}
+          <a class="overview-module-content" href="{% url 'docs_perma_link_creation' %}">
+          {% endif %}
+            <strong class="overview-module-title">Links and Records</strong>
+            <p class="overview-module-description">Learn about the links and records you can create with Perma.cc.</p>
+          {% if request.path == "/docs/perma-link-creation" %}</div>{% else %}</a>{% endif %}
+        </div>
 
-      <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/libraries" %} _active{% endif %}">
-        {% if request.path == "/docs/libraries" %}
-        <div class="overview-module-content">
-        {% else %}
-        <a class="overview-module-content" href="{% url 'docs_libraries' %}">
-        {% endif %}
-          <strong class="overview-module-title">For Libraries</strong>
-          <p class="overview-module-description">Learn about the special role of libraries in supporting Perma.cc.</p>
-        {% if request.path == "/docs/libraries" %}</div>{% else %}</a>{% endif %}
-      </div>
+        <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/libraries" %} _active{% endif %}">
+          {% if request.path == "/docs/libraries" %}
+          <div class="overview-module-content" aria-current="page">
+          {% else %}
+          <a class="overview-module-content" href="{% url 'docs_libraries' %}">
+          {% endif %}
+            <strong class="overview-module-title">For Libraries</strong>
+            <p class="overview-module-description">Learn about the special role of libraries in supporting Perma.cc.</p>
+          {% if request.path == "/docs/libraries" %}</div>{% else %}</a>{% endif %}
+        </div>
 
-      <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/faq" %} _active{% endif %}">
-        {% if request.path == "/docs/faq" %}
-        <div class="overview-module-content">
-        {% else %}
-        <a class="overview-module-content" href="{% url 'docs_faq' %}">
-        {% endif %}
-          <strong class="overview-module-title">FAQ</strong>
-          <p class="overview-module-description">Answers to your common questions about Perma.cc.</p>
-        {% if request.path == "/docs/faq" %}</div>{% else %}</a>{% endif %}
-      </div>
+        <div class="col col-sm-by5 overview-module col-no-gutter{% if request.path == "/docs/faq" %} _active{% endif %}">
+          {% if request.path == "/docs/faq" %}
+          <div class="overview-module-content" aria-current="page">
+          {% else %}
+          <a class="overview-module-content" href="{% url 'docs_faq' %}">
+          {% endif %}
+            <strong class="overview-module-title">FAQ</strong>
+            <p class="overview-module-description">Answers to your common questions about Perma.cc.</p>
+          {% if request.path == "/docs/faq" %}</div>{% else %}</a>{% endif %}
+        </div>
+      </nav>
     </div>
   </div>
 </div>

--- a/perma_web/perma/templates/docs/faq.html
+++ b/perma_web/perma/templates/docs/faq.html
@@ -24,12 +24,14 @@ This section of the user guide provides answers to common questions about Perma.
 <div class="container cont-reading cont-fixed">
   <div class="row">
     <div class="col-sm-4 reading-toc">
-      <ul>
-        <li class="reading-toc-section"><a href="#general">General</a></li>
-        <li class="reading-toc-section"><a href="#librarian">Librarians</a></li>
-        <li class="reading-toc-section"><a href="#journals">Academic journals</a></li>
-        <li class="reading-toc-section"><a href="#technical">Technical questions</a></li>
-      </ul>
+      <nav aria-label="FAQ Page Table of Contents">
+        <ul>
+          <li class="reading-toc-section"><a href="#general">General</a></li>
+          <li class="reading-toc-section"><a href="#librarian">Librarians</a></li>
+          <li class="reading-toc-section"><a href="#journals">Academic journals</a></li>
+          <li class="reading-toc-section"><a href="#technical">Technical questions</a></li>
+        </ul>
+      </nav>
     </div>
     <div class="col-sm-8 reading-body">
       <h2 class="body-ah" id="general">General</h2>

--- a/perma_web/perma/templates/docs/index.html
+++ b/perma_web/perma/templates/docs/index.html
@@ -22,18 +22,28 @@ Welcome to the Perma.cc user guide. The best place to learn about how Perma.cc w
 <div class="container cont-reading cont-fixed">
   <div class="row">
     <div class="col-sm-4 reading-toc" >
-      <ul>
-        <li class="reading-toc-chapter"><a href="#overview">Overview</a></li>
-        <li class="reading-toc-section"><a href="#what-is-perma">What is Perma.cc?</a></li>
-        <li class="reading-toc-section"><a href="#what-is-link-rot">What is link rot?</a></li>
-        <li class="reading-toc-section"><a href="#how-does-perma-work">How does Perma.cc work?</a></li>
-        <li class="reading-toc-section"><a href="#example-perma">Perma.cc example</a></li>
-
-        <li class="reading-toc-chapter"><a href="#perma-basics">Perma.cc Basics</a></li>
-        <li class="reading-toc-section"><a href="#create-account">Accounts</a></li>
-        <li class="reading-toc-section"><a href="#creating-links">Preserving records</a></li>
-        <li class="reading-toc-section"><a href="#viewing-records">Viewing records</a></li>
-      </ul>
+      <nav aria-label="Getting Started Page Table of Contents">
+        <h2 class="sr-only">Table of Contents</h2>
+        <ul>
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#overview">Overview</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#what-is-perma">What is Perma.cc?</a></li>
+              <li class="reading-toc-section"><a href="#what-is-link-rot">What is link rot?</a></li>
+              <li class="reading-toc-section"><a href="#how-does-perma-work">How does Perma.cc work?</a></li>
+              <li class="reading-toc-section"><a href="#example-perma">Perma.cc example</a></li>
+            </ul>
+          </li>
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#perma-basics">Perma.cc Basics</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#create-account">Accounts</a></li>
+              <li class="reading-toc-section"><a href="#creating-links">Preserving records</a></li>
+              <li class="reading-toc-section"><a href="#viewing-records">Viewing records</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
     </div>
 
     <div class="col-sm-8 docs reading-body">

--- a/perma_web/perma/templates/docs/libraries.html
+++ b/perma_web/perma/templates/docs/libraries.html
@@ -23,16 +23,23 @@ This section of the user guide describes the Perma.cc library consortium and the
 <div class="container cont-reading cont-fixed" id="overview">
   <div class="row">
     <div class="col-sm-4 reading-toc" >
-      <ul>
-        <li class="reading-toc-chapter"><a href="#libraries-and-registrars">Libraries as Registrars</a></li>
-        <li class="reading-toc-section"><a href="#becoming-registrar">Becoming a registrar</a></li>
-        <li class="reading-toc-section"><a href="#libraries-authority">Authority and responsibilities</a></li>
-        <li class="reading-toc-section"><a href="#creating-orgs">Creating new archiving orgs</a></li>
-        <li class="reading-toc-section"><a href="#assigning-users-to-orgs">Assigning users to archiving orgs</a></li>
-        <li class="reading-toc-section"><a href="#removing-users-from-orgs">Removing users from archiving orgs</a></li>
-        <li class="reading-toc-section"><a href="#supporting-journals-and-faculty">Supporting your orgs and users</a></li>
-        <li class="reading-toc-section"><a href="#user-resources">Download user resources (PDF)</a></li>
-      </ul>
+      <nav aria-label="For Libraries Page Table of Contents">
+        <h2 class="sr-only">Table of Contents</h2>
+        <ul>
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#libraries-and-registrars">Libraries as Registrars</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#becoming-registrar">Becoming a registrar</a></li>
+              <li class="reading-toc-section"><a href="#libraries-authority">Authority and responsibilities</a></li>
+              <li class="reading-toc-section"><a href="#creating-orgs">Creating new archiving orgs</a></li>
+              <li class="reading-toc-section"><a href="#assigning-users-to-orgs">Assigning users to archiving orgs</a></li>
+              <li class="reading-toc-section"><a href="#removing-users-from-orgs">Removing users from archiving orgs</a></li>
+              <li class="reading-toc-section"><a href="#supporting-journals-and-faculty">Supporting your orgs and users</a></li>
+              <li class="reading-toc-section"><a href="#user-resources">Download user resources (PDF)</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
     </div>
 
     <div class="col-sm-8 reading-body">

--- a/perma_web/perma/templates/docs/perma-link-creation.html
+++ b/perma_web/perma/templates/docs/perma-link-creation.html
@@ -22,21 +22,43 @@ This section of the user guide covers how to create new archives and organize yo
 <div id="organize-links" class="container cont-reading cont-fixed">
   <div class="row">
     <div class="col-sm-4 reading-toc" >
-      <ul>
-        <li class="reading-toc-chapter"><a href="#creating-records">Creating Perma Records and Links</a></li>
-        <li class="reading-toc-section"><a href="#web-page-preservation">Preservation methods</a></li>
-        <li class="reading-toc-section"><a href="#preservation-limits">Preservation limits</a></li>
-        <li class="reading-toc-chapter"><a href="#using-perma-links">Using Perma Links</a></li>
-        <li class="reading-toc-section"><a href="#citing-perma-links">Citing Perma Links</a></li>
-        <li class="reading-toc-section"><a href="#what-readers-see">What readers see</a></li>
-        <li class="reading-toc-chapter"><a href="#managing-links">Managing Perma Links</a></li>
-        <li class="reading-toc-section"><a href="#organizing-links">Organizing Perma Links</a></li>
-        <li class="reading-toc-section"><a href="#annotating-links">Annotating Perma Links</a></li>
-        <li class="reading-toc-chapter"><a href="#about-perma-records">About Perma Records</a></li>
-        <li class="reading-toc-section"><a href="#preservation-formats">Preservation formats</a></li>
-        <li class="reading-toc-section"><a href="#private-records">Private Records</a></li>
-        <li class="reading-toc-section"><a href="#memento">Memento</a></li>
-      </ul>
+      <nav aria-label="Perma Records Page Table of Contents">
+        <h2 class="sr-only">Table of Contents</h2>
+        <ul>
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#creating-records">Creating Perma Records and Links</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#web-page-preservation">Preservation methods</a></li>
+              <li class="reading-toc-section"><a href="#preservation-limits">Preservation limits</a></li>
+            </ul>
+          </li>
+
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#using-perma-links">Using Perma Links</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#citing-perma-links">Citing Perma Links</a></li>
+              <li class="reading-toc-section"><a href="#what-readers-see">What readers see</a></li>
+            </ul>
+          </li>
+
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#managing-links">Managing Perma Links</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#organizing-links">Organizing Perma Links</a></li>
+              <li class="reading-toc-section"><a href="#annotating-links">Annotating Perma Links</a></li>
+            </ul>
+          </li>
+
+          <li>
+            <h3 class="reading-toc-chapter"><a href="#about-perma-records">About Perma Records</a></h3>
+            <ul>
+              <li class="reading-toc-section"><a href="#preservation-formats">Preservation formats</a></li>
+              <li class="reading-toc-section"><a href="#private-records">Private Records</a></li>
+              <li class="reading-toc-section"><a href="#memento">Memento</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
     </div>
 
     <div class="col col-sm-8 docs reading-body">

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -10052,17 +10052,18 @@ div.cont-reading + div.overview div.overview-module-content {
   border-color: #222 !important;
 }
 
-.reading-toc li.reading-toc-chapter._active a {
+.reading-toc li .reading-toc-chapter._active a {
   border-color: #2D76EE;
   color: #2D76EE;
 }
 
-.reading-toc li.reading-toc-section + li.reading-toc-chapter {
-  margin-top: 16px;
+.reading-toc li:last-of-type {
+  margin-bottom: 16px;
 }
 
-.reading-toc li.reading-toc-chapter a {
+.reading-toc .reading-toc-chapter a {
   font-weight: 700;
+  font-size: 14px;
   border-color: #222;
 }
 

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -2013,16 +2013,17 @@ div.cont-reading + div.overview {
         border-color: $color-active !important;
       }
     }
-    &.reading-toc-chapter._active a {
+    & .reading-toc-chapter._active a {
       border-color: $color-blue;
       color: $color-blue;
     }
+    &:last-of-type {
+      margin-bottom: $double;
+    }
   }
-  li.reading-toc-section + li.reading-toc-chapter {
-    margin-top: $double;
-  }
-  li.reading-toc-chapter a {
+  .reading-toc-chapter a {
     font-weight: 700;
+    font-size: 14px;
     border-color: $color-black;
   }
   li.reading-toc-section {


### PR DESCRIPTION
Fixes https://github.com/harvard-lil/perma/issues/2248; partial fix for https://github.com/harvard-lil/perma/issues/2247

There is a bit of redundancy here between aria-labels and headings, but I think that's both okay, and inevitable: I don't want the subheadings in the lists to be `<h2>`.