### PR TITLE
Accessible Tables of Contents

### DIFF
--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -22,12 +22,14 @@ Perma.cc prevents link rot.
 <div class="container cont-reading cont-fixed" id="what-is-perma">
   <div class="row">
     <div class="col-sm-4 reading-toc" >
-      <ul>
-        <li class="reading-toc-chapter _active"><a href="#developer-overview">What is Perma.cc?</a></li>
-        <li class="reading-toc-chapter"><a href="#why-use-perma">Why use Perma.cc</a></li>
-        <li class="reading-toc-chapter"><a href="#how-perma-works">How Perma.cc works</a></li>
-        <li class="reading-toc-chapter"><a href="#perma-partners">Perma.cc’s Partners</a></li>
-      </ul>
+       <nav aria-label="Table of Contents">
+        <ul>
+          <li class="reading-toc-chapter _active"><a href="#developer-overview">What is Perma.cc?</a></li>
+          <li class="reading-toc-chapter"><a href="#why-use-perma">Why use Perma.cc</a></li>
+          <li class="reading-toc-chapter"><a href="#how-perma-works">How Perma.cc works</a></li>
+          <li class="reading-toc-chapter"><a href="#perma-partners">Perma.cc’s Partners</a></li>
+        </ul>
+      </nav>
     </div>
 
     <div class="col-sm-8 docs reading-body">

--- a/perma_web/perma/templates/docs/developer/toc.html
+++ b/perma_web/perma/templates/docs/developer/toc.html
@@ -1,45 +1,68 @@
 <div class="col-sm-4 reading-toc" >
-  <ul>
-    <li class="reading-toc-chapter{% if section == 'overview' %} _active{% endif %}"><a href="#developer-overview">Overview</a></li>
-    {% if section == 'overview' %}
-      <li class="reading-toc-section"><a href="#api-key">API Key</a></li>
-      <li class="reading-toc-section"><a href="#pagination">Pagination</a></li>
-      <li class="reading-toc-section"><a href="#jsonp">JSONP</a></li>
-      <li class="reading-toc-section"><a href="#examples-in-curl">Examples in cURL</a></li>
-    {% endif %}
-    <li class="reading-toc-chapter{% if section == 'public-archives' %} _active{% endif %}"><a href="#developer-public-archives">Public Archives</a></li>
-    {% if section == 'public-archives' %}
-      <li class="reading-toc-section"><a href="#get-all-public-archives">Get all public archives</a></li>
-      <li class="reading-toc-section"><a href="#get-one-archive">Get a single archive's details</a></li>
-      <li class="reading-toc-section"><a href="#download-one-archive">Download a single archive</a></li>
-    {% endif %}
-    <li class="reading-toc-chapter{% if section == 'users' %} _active{% endif %}"><a href="#developer-users">Users</a></li>
-    {% if section == 'users' %}
-      <li class="reading-toc-section"><a href="#get-user-account-details">Get a user's account details</a></li>
-      <li class="reading-toc-section"><a href="#get-user-archives">Get a user's archives</a></li>
-      <li class="reading-toc-section"><a href="#get-user-folders">Get a user's folders</a></li>
-      <li class="reading-toc-section"><a href="#get-user-orgs">Get a user's organizations</a></li>
-      <li class="reading-toc-section"><a href="#get-user-shared-folders">Get a user's shared folders inside an organization</a></li>
-      <li class="reading-toc-section"><a href="#get-user-capture-jobs">Get a user's ongoing capture jobs</a></li>
-    {% endif %}
-    <li class="reading-toc-chapter{% if section == 'archives' %} _active{% endif %}"><a href="#developer-archives">Archives</a></li>
-    {% if section == 'archives' %}
-      <li class="reading-toc-section"><a href="#create-an-archive">Create an archive</a></li>
-      <li class="reading-toc-section"><a href="#view-details-of-one-archive">View the details of one archive</a></li>
-      <li class="reading-toc-section"><a href="#download-one-archive-auth">Download a single archive</a></li>
-      <li class="reading-toc-section"><a href="#view-all-archives-of-one-user">View all archives associated with one user</a></li>
-      <li class="reading-toc-section"><a href="#move-to-dark-archive">Place an archive in the dark archive</a></li>
-      <li class="reading-toc-section"><a href="#edit-title-and-notes">Edit the title and notes fields of an archive</a></li>
-      <li class="reading-toc-section"><a href="#move-archive">Move an archive</a></li>
-      <li class="reading-toc-section"><a href="#delete-archive">Delete an archive</a></li>
-    {% endif %}
-    <li class="reading-toc-chapter{% if section == 'folders' %} _active{% endif %}"><a href="#developer-folders">Folders</a></li>
-    {% if section == 'folders' %}
-      <li class="reading-toc-section"><a href="#create-folder">Create a folder</a></li>
-      <li class="reading-toc-section"><a href="#view-folder-details">View a folder's details</a></li>
-      <li class="reading-toc-section"><a href="#rename-folder">Rename a folder</a></li>
-      <li class="reading-toc-section"><a href="#move-folder">Move a folder</a></li>
-      <li class="reading-toc-section"><a href="#delete-folder">Delete a folder</a></li>
-    {% endif %}
-  </ul>
+  <nav aria-labelledby="{{ section }}-heading">
+    <h2 id="{{ section }}-heading" class="sr-only">{{ section | title }} Section Table of Contents</h2>
+    <ul>
+      <li>
+        <h3 class="reading-toc-chapter{% if section == 'overview' %} _active" aria-current="location" aria-expanded="true"{% else %}" aria-expanded="false"{% endif %}><a href="#developer-overview">Overview</a></h3>
+        {% if section == 'overview' %}
+            <ul>
+            <li class="reading-toc-section"><a href="#api-key">API Key</a></li>
+            <li class="reading-toc-section"><a href="#pagination">Pagination</a></li>
+            <li class="reading-toc-section"><a href="#jsonp">JSONP</a></li>
+            <li class="reading-toc-section"><a href="#examples-in-curl">Examples in cURL</a></li>
+          </ul>
+        {% endif %}
+      </li>
+      <li>
+        <h3 class="reading-toc-chapter{% if section == 'public-archives' %} _active" aria-current="location" aria-expanded="true"{% else %}" aria-expanded="false"{% endif %}><a href="#developer-public-archives">Public Archives</a></h3>
+        {% if section == 'public-archives' %}
+        <ul>
+          <li class="reading-toc-section"><a href="#get-all-public-archives">Get all public archives</a></li>
+          <li class="reading-toc-section"><a href="#get-one-archive">Get a single archive's details</a></li>
+          <li class="reading-toc-section"><a href="#download-one-archive">Download a single archive</a></li>
+        </ul>
+        {% endif %}
+      </li>
+      <li>
+        <h3 class="reading-toc-chapter{% if section == 'users' %} _active" aria-current="location" aria-expanded="true"{% else %}" aria-expanded="false"{% endif %}><a href="#developer-users">Users</a></h3>
+        {% if section == 'users' %}
+          <ul>
+            <li class="reading-toc-section"><a href="#get-user-account-details">Get a user's account details</a></li>
+            <li class="reading-toc-section"><a href="#get-user-archives">Get a user's archives</a></li>
+            <li class="reading-toc-section"><a href="#get-user-folders">Get a user's folders</a></li>
+            <li class="reading-toc-section"><a href="#get-user-orgs">Get a user's organizations</a></li>
+            <li class="reading-toc-section"><a href="#get-user-shared-folders">Get a user's shared folders inside an organization</a></li>
+            <li class="reading-toc-section"><a href="#get-user-capture-jobs">Get a user's ongoing capture jobs</a></li>
+          </ul>
+        {% endif %}
+      </li>
+      <li>
+        <h3 class="reading-toc-chapter{% if section == 'archives' %} _active" aria-current="location" aria-expanded="true"{% else %}" aria-expanded="false"{% endif %}><a href="#developer-archives">Archives</a></h3>
+        {% if section == 'archives' %}
+          <ul>
+            <li class="reading-toc-section"><a href="#create-an-archive">Create an archive</a></li>
+            <li class="reading-toc-section"><a href="#view-details-of-one-archive">View the details of one archive</a></li>
+            <li class="reading-toc-section"><a href="#download-one-archive-auth">Download a single archive</a></li>
+            <li class="reading-toc-section"><a href="#view-all-archives-of-one-user">View all archives associated with one user</a></li>
+            <li class="reading-toc-section"><a href="#move-to-dark-archive">Place an archive in the dark archive</a></li>
+            <li class="reading-toc-section"><a href="#edit-title-and-notes">Edit the title and notes fields of an archive</a></li>
+            <li class="reading-toc-section"><a href="#move-archive">Move an archive</a></li>
+            <li class="reading-toc-section"><a href="#delete-archive">Delete an archive</a></li>
+          </ul>
+        {% endif %}
+      </li>
+      <li>
+        <h3 class="reading-toc-chapter{% if section == 'folders' %} _active" aria-current="location" aria-expanded="true"{% else %}" aria-expanded="false"{% endif %}><a href="#developer-folders">Folders</a></h3>
+        {% if section == 'folders' %}
+          <ul>
+            <li class="reading-toc-section"><a href="#create-folder">Create a folder</a></li>
+            <li class="reading-toc-section"><a href="#view-folder-details">View a folder's details</a></li>
+            <li class="reading-toc-section"><a href="#rename-folder">Rename a folder</a></li>
+            <li class="reading-toc-section"><a href="#move-folder">Move a folder</a></li>
+            <li class="reading-toc-section"><a href="#delete-folder">Delete a folder</a></li>
+          </ul>
+        {% endif %}
+      </li>
+    </ul>
+  </nav>
 </div>

--- a/perma_web/perma/templates/manage-layout.html
+++ b/perma_web/perma/templates/manage-layout.html
@@ -7,9 +7,9 @@
     <div class="row">
       <div class="col-sm-12">
         {% if request.user.is_staff or request.user.is_registrar_user %}
-          <h1 class="page-title">Manage users and organizations</h1>
+          <h1 id="page-title" class="page-title">Manage users and organizations</h1>
         {% elif request.user.is_organization_user %}
-          <h1 class="page-title">Manage users</h1>
+          <h1 id="page-title" class="page-title">Manage users</h1>
         {% endif %}
       </div>
     </div> <!-- end row -->
@@ -18,27 +18,29 @@
         <div class="col-sm-3">
 
           <!-- Dashboard tabs -->
-          <ul class="nav nav-pills nav-stacked">
+          <nav aria-labelledby="page-title">
+            <ul class="nav nav-pills nav-stacked">
 
-            <!-- Manage users -->
-            {% if request.user.is_staff %}
-              <li {% if this_page == "users_admin_users" %}class="active" {% endif %}><a href="{% url 'user_management_manage_admin_user' %}"><span>Admin users</span></a></li>
-              <li {% if this_page == "users_registrars" %}class="active" {% endif %}><a href="{% url 'user_management_manage_registrar' %}"><span>Registrars</span></a></li>
-            {% endif %}
+              <!-- Manage users -->
+              {% if request.user.is_staff %}
+                <li {% if this_page == "users_admin_users" %}class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_manage_admin_user' %}"><span>Admin users</span></a></li>
+                <li {% if this_page == "users_registrars" %}class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_manage_registrar' %}"><span>Registrars</span></a></li>
+              {% endif %}
 
-            {% if request.user.is_staff or request.user.is_registrar_user %}
-              <li {% if this_page == "users_registrar_users" %}class="active" {% endif %}><a href="{% url 'user_management_manage_registrar_user' %}"><span>Registrar users</span></a></li>
-            {% endif %}
-            <li {% if this_page == "users_orgs" %}class="active" {% endif %}><a href="{% url 'user_management_manage_organization' %}"><span>Organizations</span></a></li>
+              {% if request.user.is_staff or request.user.is_registrar_user %}
+                <li {% if this_page == "users_registrar_users" %}class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_manage_registrar_user' %}"><span>Registrar users</span></a></li>
+              {% endif %}
+              <li {% if this_page == "users_orgs" %}class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_manage_organization' %}"><span>Organizations</span></a></li>
 
-            <!-- Org users -->
-            <li {% if this_page == "users_organization_users" %}class="active" {% endif %}><a href="{% url 'user_management_manage_organization_user' %}"><span>Org users</span></a></li>
+              <!-- Org users -->
+              <li {% if this_page == "users_organization_users" %}class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_manage_organization_user' %}"><span>Org users</span></a></li>
 
-            <!-- Regular users -->
-            {% if request.user.is_staff %}
-              <li {% if this_page == "users_users" %}class="active" {% endif %}><a href="{% url 'user_management_manage_user' %}"><span>Users</span></a></li>
-            {% endif %}
-          </ul><!--/#dashboard-tabs-->
+              <!-- Regular users -->
+              {% if request.user.is_staff %}
+                <li {% if this_page == "users_users" %}class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_manage_user' %}"><span>Users</span></a></li>
+              {% endif %}
+            </ul><!--/#dashboard-tabs-->
+          </nav>
         </div><!--/col-sm-3-->
       {% endif %}
 

--- a/perma_web/perma/templates/privacy_policy.html
+++ b/perma_web/perma/templates/privacy_policy.html
@@ -17,19 +17,21 @@ The Perma.cc Privacy Policy.
   <div class="container cont-reading cont-fixed">
     <div class="row">
       <div class="col-sm-4 reading-toc" >
-        <ul>
-          <li class="reading-toc-section"><a href="#introduction">Introduction</a></li>
-          <li class="reading-toc-section"><a href="#terms">Important Terms Used Throughout This Privacy Policy</a></li>
-          <li class="reading-toc-section"><a href="#information">Information We Collect and How We Use It</a></li>
-          <li class="reading-toc-section"><a href="#do-not-disclose">If You Do Not Wish to Disclose User Information</a></li>
-          <li class="reading-toc-section"><a href="#local-storage">Local Storage</a></li>
-          <li class="reading-toc-section"><a href="#cookies">Cookies</a></li>
-          <li class="reading-toc-section"><a href="#password">Control of Your Password</a></li>
-          <li class="reading-toc-section"><a href="#underage-users">Underage Users</a></li>
-          <li class="reading-toc-section"><a href="#third-parties">Third Parties</a></li>
-          <li class="reading-toc-section"><a href="#changes">Changes to this Policy</a></li>
-          <li class="reading-toc-section"><a href="#contact">How do I contact Perma?</a></li>
-        </ul>
+        <nav aria-label="Table of Contents">
+          <ul>
+            <li class="reading-toc-section"><a href="#introduction">Introduction</a></li>
+            <li class="reading-toc-section"><a href="#terms">Important Terms Used Throughout This Privacy Policy</a></li>
+            <li class="reading-toc-section"><a href="#information">Information We Collect and How We Use It</a></li>
+            <li class="reading-toc-section"><a href="#do-not-disclose">If You Do Not Wish to Disclose User Information</a></li>
+            <li class="reading-toc-section"><a href="#local-storage">Local Storage</a></li>
+            <li class="reading-toc-section"><a href="#cookies">Cookies</a></li>
+            <li class="reading-toc-section"><a href="#password">Control of Your Password</a></li>
+            <li class="reading-toc-section"><a href="#underage-users">Underage Users</a></li>
+            <li class="reading-toc-section"><a href="#third-parties">Third Parties</a></li>
+            <li class="reading-toc-section"><a href="#changes">Changes to this Policy</a></li>
+            <li class="reading-toc-section"><a href="#contact">How do I contact Perma?</a></li>
+          </ul>
+        </nav>
       </div>
 
       <div class="col-sm-8 docs reading-body">

--- a/perma_web/perma/templates/settings-layout.html
+++ b/perma_web/perma/templates/settings-layout.html
@@ -15,23 +15,25 @@
         <div class="col-sm-3">
 
           <!-- Dashboard tabs -->
-          <ul class="nav nav-pills nav-stacked">
+          <nav aria-label="Settings">
+            <ul class="nav nav-pills nav-stacked">
 
-            <li{% if this_page == 'settings_profile' %} class="active"{% endif %}><a href="{% url 'user_management_settings_profile' %}"><span>Profile</span></a></li>
+              <li{% if this_page == 'settings_profile' %} class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_settings_profile' %}"><span>Profile</span></a></li>
 
-            <li{% if this_page == 'settings_password' %} class="active"{% endif %}><a href="{% url 'user_management_settings_password' %}"><span>Password</span></a></li>
+              <li{% if this_page == 'settings_password' %} class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_settings_password' %}"><span>Password</span></a></li>
 
-            {% if request.user.can_view_subscription %}
-            <li{% if this_page == 'settings_subscription' %} class="active"{% endif %}><a href="{% url 'user_management_settings_subscription' %}" id="dashboard-settings"><span>Subscription</span></a></li>
-            {% endif %}
+              {% if request.user.can_view_subscription %}
+              <li{% if this_page == 'settings_subscription' %} class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_settings_subscription' %}" id="dashboard-settings"><span>Subscription</span></a></li>
+              {% endif %}
 
-            <li{% if this_page == 'settings_tools' %} class="active"{% endif %}><a href="{% url 'user_management_settings_tools' %}"><span>Tools</span></a></li>
+              <li{% if this_page == 'settings_tools' %} class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_settings_tools' %}"><span>Tools</span></a></li>
 
-            {% if request.user.is_organization_user or request.user.is_registrar_user or request.user.has_registrar_pending %}
-            <li{% if this_page == 'settings_affiliations' %} class="active"{% endif %}><a href="{% url 'user_management_settings_affiliations' %}" id="dashboard-settings"><span>Your Affiliations</span></a></li>
-            {% endif %}
+              {% if request.user.is_organization_user or request.user.is_registrar_user or request.user.has_registrar_pending %}
+              <li{% if this_page == 'settings_affiliations' %} class="active" aria-current="page"{% endif %}><a href="{% url 'user_management_settings_affiliations' %}" id="dashboard-settings"><span>Your Affiliations</span></a></li>
+              {% endif %}
 
-          </ul><!--/#dashboard-tabs-->
+            </ul><!--/#dashboard-tabs-->
+          </nav>
         </div><!--/col-sm-3-->
 
         <!-- Dashboard tab content -->

--- a/perma_web/perma/templates/terms_of_service.html
+++ b/perma_web/perma/templates/terms_of_service.html
@@ -18,20 +18,22 @@ The Perma.cc Terms of Service.
 <div class="container cont-reading cont-fixed">
   <div class="row">
     <div class="col-sm-4 reading-toc" >
-      <ul>
-        <li class="reading-toc-section"><a href="#tos-1">Changes to Terms of Service Are Binding; Other Policies</a></li>
-        <li class="reading-toc-section"><a href="#tos-2">Use of Site and Service</a></li>
-        <li class="reading-toc-section"><a href="#tos-3">Account Creation, Maintenance, and Termination</a></li>
-        <li class="reading-toc-section"><a href="#tos-4">Links to Third-Party Sites</a></li>
-        <li class="reading-toc-section"><a href="#tos-5">User Submitted Content and Licensing</a></li>
-        <li class="reading-toc-section"><a href="#tos-6">Rules of Usage</a></li>
-        <li class="reading-toc-section"><a href="#tos-7">Intellectual Property</a></li>
-        <li class="reading-toc-section"><a href="#tos-8">Indemnity</a></li>
-        <li class="reading-toc-section"><a href="#tos-9">Termination of Service</a></li>
-        <li class="reading-toc-section"><a href="#tos-10">Disclaimer of Warranties; Limitations of Liability and Remedies</a></li>
-        <li class="reading-toc-section"><a href="#tos-11">Governing Law and Jurisdiction; Access from Outside Massachusetts</a></li>
-        <li class="reading-toc-section"><a href="#tos-12">General; Entire Agreement</a></li>
-      </ul>
+      <nav aria-label="Table of Contents">
+        <ul>
+          <li class="reading-toc-section"><a href="#tos-1">Changes to Terms of Service Are Binding; Other Policies</a></li>
+          <li class="reading-toc-section"><a href="#tos-2">Use of Site and Service</a></li>
+          <li class="reading-toc-section"><a href="#tos-3">Account Creation, Maintenance, and Termination</a></li>
+          <li class="reading-toc-section"><a href="#tos-4">Links to Third-Party Sites</a></li>
+          <li class="reading-toc-section"><a href="#tos-5">User Submitted Content and Licensing</a></li>
+          <li class="reading-toc-section"><a href="#tos-6">Rules of Usage</a></li>
+          <li class="reading-toc-section"><a href="#tos-7">Intellectual Property</a></li>
+          <li class="reading-toc-section"><a href="#tos-8">Indemnity</a></li>
+          <li class="reading-toc-section"><a href="#tos-9">Termination of Service</a></li>
+          <li class="reading-toc-section"><a href="#tos-10">Disclaimer of Warranties; Limitations of Liability and Remedies</a></li>
+          <li class="reading-toc-section"><a href="#tos-11">Governing Law and Jurisdiction; Access from Outside Massachusetts</a></li>
+          <li class="reading-toc-section"><a href="#tos-12">General; Entire Agreement</a></li>
+        </ul>
+      </nav>
     </div>
 
     <div class="col-sm-8 docs reading-body">


### PR DESCRIPTION
Addresses remainder of https://github.com/harvard-lil/perma/issues/2247 and https://github.com/harvard-lil/perma/issues/2249

The solution for the API docs might be overly verbose, but I can't think of anything more succinct. This is a rather uncommon design, in my admittedly limited experience: I'm not sure there's a great solution. If we felt like it, we could consider breaking this into multiple pages, or making a single, accordion-style menu that positions itself via css.... but that sounds like much too much work. This verbose technique is probably better bang for our buck.