### PR TITLE
Fix main dropdown appearance

### DIFF
--- a/perma_web/perma/templates/includes/upper_right_menu.html
+++ b/perma_web/perma/templates/includes/upper_right_menu.html
@@ -32,22 +32,22 @@
                 {% if request.user.is_staff %}
                   <li><a href="{% url 'user_management_manage_user' %}">Users</a></li>
                 {% endif %}
-              {% endif %}
-
-              <!-- Org users -->
-              {% if request.user.is_organization_user %}
-                <li><a href="{% url 'user_management_manage_organization_user' %}">Manage users</a></li>
-              {% endif %}
-            </ul>
-          </li>
-          <li class="divider"></li>
+              </ul>
+            </li>
+            <li class="divider"></li>
+          {% endif %}
+          <!-- Org users -->
+          {% if request.user.is_organization_user %}
+            <li><a href="{% url 'user_management_manage_organization_user' %}">Manage users</a></li>
+            <li class="divider"></li>
+          {% endif %}
           {% if request.user.is_staff %}
-          <li><h3 class="dropdown-header">Admin Only</h3>
-            <ul class="dropdown-inner-list">
-              <li><a href="{% url 'admin:index' %}">Admin console</a></li>
-              <li><a href="{% url 'user_management_stats' %}">Site stats</a></li>
-            </ul>
-          </li>
+            <li><h3 class="dropdown-header">Admin Only</h3>
+              <ul class="dropdown-inner-list">
+                <li><a href="{% url 'admin:index' %}">Admin console</a></li>
+                <li><a href="{% url 'user_management_stats' %}">Site stats</a></li>
+              </ul>
+            </li>
           <li class="divider"></li>
           {% endif %}
           <li><h3 class="dropdown-header">Settings</h3>


### PR DESCRIPTION
In https://github.com/harvard-lil/perma/pull/2271, I had improper nesting for all users except admins and registrar users. 

![image](https://user-images.githubusercontent.com/11020492/36500974-c886900c-1713-11e8-832d-9c785ec4ddcb.png)

This restores the correct appearance.

![image](https://user-images.githubusercontent.com/11020492/36501026-f97e5ce4-1713-11e8-894d-9ed4746b7bcd.png)

![image](https://user-images.githubusercontent.com/11020492/36501032-fed18f7c-1713-11e8-9510-d7a056ac0119.png)

Note to self: always visually test all kinds of users.... not just with screen reader!

