### PR TITLE
Link straight to docs about private perma links

### DIFF
--- a/perma_web/perma/templates/archive/dark-archive.html
+++ b/perma_web/perma/templates/archive/dark-archive.html
@@ -1,6 +1,6 @@
 {% with request.META.HTTP_REFERER as referer %}
   <div class="record-message">
     <p class="record-message-primary">This record is private and cannot be displayed.</p>
-    <p class="record-message-secondary">For more information on private records, see Perma.cc’s <a href="{% url 'docs' %}">documentation</a>. If you feel you’ve reached this page in error, please <a href="{% url 'contact' %}/?subject=Why%20Is%20{{request.path}}%20Private%3F{% if referer %}%20(linked%20at%20{{referer}}){% endif %}">contact Perma.cc</a>.</p>
+    <p class="record-message-secondary">For more information on private records, see Perma.cc’s <a href="{% url 'docs_perma_link_creation' %}#private-records">documentation</a>. If you feel you’ve reached this page in error, please <a href="{% url 'contact' %}/?subject=Why%20Is%20{{request.path}}%20Private%3F{% if referer %}%20(linked%20at%20{{referer}}){% endif %}">contact Perma.cc</a>.</p>
   <div>
 {% endwith %}

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -220,7 +220,7 @@
 
     {% if can_view and link.is_private %}
       <div class="banner banner-status row _isDarchive">
-        <strong>This record is private{% if link.private_reason == 'policy' %} by Perma.cc policy{% elif link.private_reason == 'takedown' %} at the content owner's request, and it cannot be made public on Perma.cc{% endif %}.</strong>
+        <strong><a href="{% url 'docs_perma_link_creation' %}#private-records">This record is private{% if link.private_reason == 'policy' %} by Perma.cc policy{% elif link.private_reason == 'takedown' %} at the content owner's request, and it cannot be made public on Perma.cc{% endif %}.</a></strong>
           It’s only visible to {% if link.organization %}members of {{ link.organization }} and the {{ link.organization.registrar }} registrar{% else %}you{% endif %}.
           {% if link.private_reason == 'user' %}You can make this link public under 'Show record details.'{% endif %}
       </div>

--- a/perma_web/static/bundles/single-link-styles.css
+++ b/perma_web/static/bundles/single-link-styles.css
@@ -4516,6 +4516,15 @@ header._isPrivate ._isDarchive {
   border-bottom: 1px solid #222;
 }
 
+header._isPrivate ._isDarchive a {
+  text-decoration: underline;
+}
+
+header._isPrivate ._isDarchive:hover,
+header._isPrivate ._isDarchive:focus {
+  color: #2D76EE;
+}
+
 header._isPrivate .title:before {
   content: '';
   display: inline-block;

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -105,6 +105,14 @@ header {
     ._isDarchive {
       color: $color-orange-a;
       border-bottom: 1px solid $color-black;
+
+      a {
+        text-decoration: underline;
+      }
+
+      &:hover, &:focus {
+          color: $color-blue;
+      }
     }
     .title:before {
       content: '';


### PR DESCRIPTION
Addresses https://github.com/harvard-lil/perma/issues/2264; also adds more specific link for users who view the link when not logged in.