### PR TITLE
Install boto in order for Kombu to use SQS

### DIFF
--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -69,6 +69,7 @@ pywb
 # alternate storages
 django-storages
 boto3                               # required for django-storages to use s3 backend
+boto                                # required for kombu when using SQS
 
 # testing
 hypothesis==3.31.2               # run tests with lots of generated input

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -16,6 +16,7 @@ attrs==17.2.0             # via hypothesis
 beautifulsoup4==4.5.1
 billiard==3.3.0.23        # via celery
 boto3==1.4.4
+boto==2.48.0
 botocore==1.5.49          # via boto3, s3transfer
 brotlipy==0.6.0           # via pywb
 celery==3.1.25


### PR DESCRIPTION
This fixes a problem obscured in one case on Heroku by the uninvited presence of boto 2.42.0. (Probably see https://github.com/heroku/heroku-buildpack-python/issues/379.) Kombu requires boto, not boto3, to talk to SQS.