### PR TITLE
Don't implicitly cast values to ascii

### DIFF
--- a/perma_web/perma/templatetags/current_query_string.py
+++ b/perma_web/perma/templatetags/current_query_string.py
@@ -9,5 +9,17 @@ def current_query_string(context, **kwargs):
         Given {% current_query_string page=1 q='' %}, return the current query string but with page and q values changed.
     """
     query_params = dict(context['request'].GET, **kwargs)
-    query_params = dict((k,v) for k, v in query_params.items() if v is not None and v != '')
-    return urllib.urlencode(query_params, doseq=True)
+    query_params_bytes = {}
+    for k, v in query_params.items():
+        if v is not None and v != '':
+            # This is complex because we need to handle unicode and lists of unicode
+            # in addition to ints, longs, and possibly other data types.
+            # This should improve in python 3.
+            try:
+                query_params_bytes[k] = v.encode('utf-8')
+            except AttributeError:
+                try:
+                    query_params_bytes[k] = [i.encode('utf-8') for i in v]
+                except TypeError:
+                    query_params_bytes[k] = v
+    return urllib.urlencode(query_params_bytes, doseq=True)


### PR DESCRIPTION
This allows us to search for users/registrars/orgs with umlauts, etc. in their names on the /manage pages.