### PR TITLE
Don't convert reserved chars to html entities in our plaintext emails

### DIFF
--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 ###
 
 def send_user_email(to_address, template, context):
-    email_text = render_to_string(template, context)
+    email_text = render_to_string(template, context=context, using="AUTOESCAPE_OFF")
     title, email_text = email_text.split("\n\n", 1)
     title = title.split("TITLE: ")[-1]
     success_count = send_mail(
@@ -56,7 +56,7 @@ def send_admin_email(title, from_address, request, template="email/default.txt",
     """
     EmailMessage(
         title,
-        render_to_string(template, context=context, request=request),
+        render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
         settings.DEFAULT_FROM_EMAIL,
         [settings.DEFAULT_FROM_EMAIL],
         headers={'Reply-To': from_address}
@@ -70,7 +70,7 @@ def send_user_email_copy_admins(title, from_address, to_addresses, request, temp
     """
     EmailMessage(
         title,
-        render_to_string(template, context=context, request=request),
+        render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
         settings.DEFAULT_FROM_EMAIL,
         to_addresses,
         cc=[settings.DEFAULT_FROM_EMAIL, from_address],

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -128,6 +128,13 @@ TEMPLATES = [
         },
     },
 ]
+# Add a second, identical template engine except with autoescape off,
+# for use when rendering non-HTML templates.
+# Use by passing 'using='AUTOESCAPE_OFF' to render or render_to_string.
+off = TEMPLATES[0].copy()
+off['NAME'] = 'AUTOESCAPE_OFF'
+off['OPTIONS']['autoescape'] = False
+TEMPLATES.append(off)
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
https://github.com/harvard-lil/perma/issues/2289

This primarily affects the contact form and the js uncaught error emails. (None of the other emails we send contain HTML reserved chars, it so happens.)