### PR TITLE
Tie waypoint to column to decouple from zoom/viewport/window.

### DIFF
--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -376,11 +376,14 @@ webpackJsonp([1],[
 	      if (links.length === requestCount) {
 	        requestData.offset += requestCount;
 	        linkTable.find('.item-container:last').waypoint(function (direction) {
-	          this.destroy(); // cancel waypoint
-	          linkTable.append('<div class="links-loading-more">Loading more ...</div>');
-	          getNextContents();
+	          if (direction == 'down') {
+	            this.destroy(); // cancel waypoint
+	            linkTable.append('<div class="links-loading-more">Loading more ...</div>');
+	            getNextContents();
+	          }
 	        }, {
-	          offset: '100%' // trigger waypoint when element hits bottom of window
+	          offset: '100%', // trigger waypoint when element hits bottom of window,
+	          context: '.col-links'
 	        });
 	      }
 	    });

--- a/perma_web/static/js/links-list.module.js
+++ b/perma_web/static/js/links-list.module.js
@@ -153,11 +153,14 @@ function showFolderContents (folderID, query) {
         if(links.length === requestCount){
           requestData.offset += requestCount;
           linkTable.find('.item-container:last').waypoint(function(direction) {
-            this.destroy();  // cancel waypoint
-            linkTable.append('<div class="links-loading-more">Loading more ...</div>');
-            getNextContents();
+            if (direction == 'down'){
+              this.destroy();  // cancel waypoint
+              linkTable.append('<div class="links-loading-more">Loading more ...</div>');
+              getNextContents();
+            }
           }, {
-            offset:'100%'  // trigger waypoint when element hits bottom of window
+            offset:'100%',  // trigger waypoint when element hits bottom of window,
+            context: '.col-links'
           });
         }
     });


### PR DESCRIPTION
Ensures infinite scroll is triggered when scrolling to the bottom of the links list, regardless of various interfering variables.