### PR TITLE
Manage pages markup overhaul

### DIFF
--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -59,7 +59,15 @@
       {% if this_page != 'landing' and this_page != 'manage' %}
         <div id="main-content" class="container cont-full-bleed">
       {% endif %}
-      <p id="main-skip-target" tabindex="-1" class="sr-only">Main Content</p>
+
+      {% block defaultSkipTarget %}
+        {% comment %}
+          Override this block in child templates with an empty block,
+          if you want to provide a template-specific skip target.
+          Then, place exactly the same p tag as below in your desired location.
+        {% endcomment %}
+        <p id="main-skip-target" tabindex="-1" class="sr-only">Main Content</p>
+      {% endblock defaultSkipTarget %}
 
       {% block mainContent %}{% endblock mainContent %}
 

--- a/perma_web/perma/templates/manage-layout.html
+++ b/perma_web/perma/templates/manage-layout.html
@@ -2,6 +2,8 @@
 
 {% block bodyFlags %}_admin{% endblock %}
 
+{% block defaultSkipTarget %}{% comment %}empty on purpose, to override the default and provide a template-specific target below{% endcomment %}{% endblock defaultSkipTarget %}
+
 {% block mainContent %}
   <div id="dashboard-container" class="container cont-fixed">
     <div class="row">
@@ -47,6 +49,7 @@
       <!-- Dashboard tab content -->
       <div class="tab-content col-sm-9">
         <div class="tab-pane active">
+          <p id="main-skip-target" tabindex="-1" class="sr-only">Main Content</p>
           {% block dashboardContent %}{% endblock dashboardContent %}
         </div><!--/.tab-pane-->
       </div><!--/.tab-content-->

--- a/perma_web/perma/templates/user_management/includes/paginator.html
+++ b/perma_web/perma/templates/user_management/includes/paginator.html
@@ -1,20 +1,20 @@
 {% load current_query_string %}
 {% if page.paginator.num_pages > 1 %}
-  <div class="pagination">
+  <nav class="pagination" aria-label="{% if title %}{{ title }}{% endif %} pagination">
     <ul class="pagination">
       {% if page.has_previous %}
-        <li><a href="?{% current_query_string page=page.previous_page_number %}">&lt;</a></li>
+        <li><a href="?{% current_query_string page=page.previous_page_number %}"><span class="sr-only">Previous Page</span><span aria-hidden="true">&lt;</span></a></li>
       {% endif %}
       {% for i in page.paginator.page_range %}
         {% ifequal i page.number %}
-          <li class="active"><a href="">{{ i }}</a></li>
+          <li class="active" aria-current="page"><a href="#"><span class="sr-only">Page</span> {{ i }}</a></li>
         {% else %}
-          <li><a href="?{% current_query_string page=i %}">{{ i }}</a></li>
+          <li><a href="?{% current_query_string page=i %}"><span class="sr-only">Page</span> {{ i }}</a></li>
         {% endifequal %}
       {% endfor %}
       {% if page.has_next  %}
-        <li><a href="?{% current_query_string page=page.next_page_number %}">&gt;</a></li>
+        <li><a href="?{% current_query_string page=page.next_page_number %}"><span class="sr-only">Next Page</span><span aria-hidden="true"> &gt;</span></a></li>
       {% endif %}
     </ul>
-  </div>
+  </nav>
 {% endif %}

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -4,14 +4,10 @@
 {% block title %} | Organizations{% endblock %}
 
 {% block dashboardContent %}
+  <h2 class="body-ah">Organizations</h2>
+  {% if request.user.is_staff or request.user.is_registrar_user %}
 
-  <h2 class="body-ah">Organizations {% if request.user.is_staff or request.user.is_registrar_user %}
-    <span class="action">
-      <button class="btn-transparent" data-toggle="collapse" data-target="#add-member">
-        <i class="icon-plus-sign"></i> add<span class="_verbose"> organization</span>
-      </button>
-    </span>
-  </h2>
+  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> organization</a>
 
   <div id="add-member" class="collapse {% if form.errors %}in{% endif %}">
     <form method="post">
@@ -21,46 +17,45 @@
       <button type="submit" class="btn">Create new organization</button>
     </form>
   </div>
-  {% else %}
-  </h2>
   {% endif %}
 
   <div class="row row-no-bleed admin-data">
+    <h3 class="sr-only">Stats</h3>
     <div class="col col-xs-6 col-no-gutter admin-data-point">
-      <p class="count-label">Users</p>
-      <p class="count-number">{{ users_count }}</p>
+      <div class="count-label">Users</div>
+      <div class="count-number">{{ users_count }}</div>
     </div>
     {% comment %}
     <div class="col col-no-gutter admin-data-point">
-      <p class="count-label">Deactivated Users</p>
-      <p class="count-number">{{ deactivated_users }}</p>
+      <div class="count-label">Deactivated Users</div>
+      <div class="count-number">{{ deactivated_users }}</div>
     </div>
     <div class="col col-no-gutter admin-data-point">
-      <p class="count-label">Unactivated Users</p>
-      <p class="count-number">{{ unactivated_users }}</p>
+      <div class="count-label">Unactivated Users</div>
+      <div class="count-number">{{ unactivated_users }}</div>
     </div>
     {% endcomment %}
     <div class="col col-xs-6 col-no-gutter admin-data-point">
-      <p class="count-label">Organizations</p>
-      <p class="count-number">{{ orgs.paginator.count }}</p>
+      <div class="count-label">Organizations</div>
+      <div class="count-number">{{ orgs.paginator.count }}</div>
     </div>
   </div>
 
   <div class="row">
     <div class="col-sm-12">
+      <h3 class="sr-only">Search Organizations</h3>
       {% include "user_management/includes/search_form.html" with search_placeholder="Search Organizations" %}
     </div>
   </div><!-- search -->
-
 
   {% if search_query or registrar_filter %}
     <div class="row">
       <div class="col-sm-12">
         <div class="remove-search-filters">
-          <span class="filters-title">Filters: </span>
+          <h3 class="filters-title"><span class="sr-only">Current</span> Filters:</h3>
           {% if registrar_filter %}<span class="filter-label">Registrar</span> <strong>{{registrar_filter.name}}</strong> {% endif %}
           {% if search_query %}<span class="filter-label">Search</span> <strong>{{search_query}}</strong>{% endif %}
-          <a class="action remove-filters" href="?sort=name"><i class="icon-remove-sign"></i> Clear all filters</a>
+          <a class="action remove-filters" href="?sort=name"><i class="icon-remove-sign" aria-hidden="true"></i> Clear all filters</a>
         </div>
       </div>
     </div>
@@ -68,96 +63,106 @@
 
   <div class="row row-no-bleed">
     <div class="col admin-found col-no-gutter">
+      <h3 class="sr-only">Organization List</h3>
       <div class="sort-filter-count"><strong>Found:</strong> {{ orgs.paginator.count }} organization{{ orgs.paginator.count|pluralize }}</div>
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>
         <div class="btn-transparent dropdown">
-          <button type="button" data-toggle="dropdown">
-            Sort <span class="caret"></span>
-          </button>
-
-          <ul class="dropdown-menu" role="menu">
+          <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Sort <span class="caret"></span></button>
+          <ul class="dropdown-menu">
             <li>
-              <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string page='' sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
-              <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
-              <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
-              <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
-              <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
-              <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="=last_active" %}"><i class="icon-ok"></i> Least recently active</a>
-              <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
-              <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i class="icon-ok"></i> Least links</a>
-              <a {% if sort == '-org_users' %}class="selected" {% endif %} href="?sort=-org_users{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i class="icon-ok"></i> Most users</a>
-              <a {% if sort == 'org_users' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="org_users" %}"><i class="icon-ok"></i> Least users</a>
+              <a {% if sort == 'name' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' sort="name" %}"><i aria-hidden="true" class="icon-ok"></i> Name A - Z</a>
+            </li>
+            <li>
+              <a {% if sort == '-name' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-name" %}"><i aria-hidden="true" class="icon-ok"></i> Name Z - A</a>
+            </li>
+            <li>
+              <a {% if sort == '-date_created' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-date_created" %}"><i aria-hidden="true" class="icon-ok"></i> Newest</a>
+            </li>
+            <li>
+              <a {% if sort == 'date_created' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="date_created" %}"><i aria-hidden="true" class="icon-ok"></i> Oldest</a>
+            </li>
+            <li>
+              <a {% if sort == '-last_active' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-last_active" %}"><i aria-hidden="true" class="icon-ok"></i> Recently active</a>
+            </li>
+            <li>
+              <a {% if sort == 'last_active' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="=last_active" %}"><i aria-hidden="true" class="icon-ok"></i> Least recently active</a>
+            </li>
+            <li>
+              <a {% if sort == '-link_count' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i aria-hidden="true" class="icon-ok"></i> Most links</a>
+            </li>
+            <li>
+              <a {% if sort == 'link_count' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i aria-hidden="true" class="icon-ok"></i> Least links</a>
+            </li>
+            <li>
+              <a {% if sort == '-org_users' %}class="selected" aria-current="true" {% endif %} href="?sort=-org_users{% if search_query %}&q={{ search_query }}{% endif %}{% if registrar_filter %}&registrar={{ registrar_filter.id }}{% endif %}"><i aria-hidden="true" class="icon-ok"></i> Most users</a>
+            </li>
+            <li>
+              <a {% if sort == 'org_users' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="org_users" %}"><i aria-hidden="true" class="icon-ok"></i> Least users</a>
             </li>
           </ul>
         </div>
         {% if request.user.is_staff %}
           <div class="dropdown">
-            <button type="button" data-toggle="dropdown">
-              Registrar <span class="caret"></span>
-            </button>
-
-            <ul class="dropdown-menu" role="menu">
-              <li>
-                {% if registrars %}
-                  {% for registrar in registrars %}
-                    {% if registrar_filter == registrar %}
-                      <a class="selected" href="?{% current_query_string registrar='' page='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
-                    {% else %}
-                      <a href="?{% current_query_string registrar=registrar.id page='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
-                    {% endif %}
-                  {% endfor %}
-                {% else %}
-                  <a href="">None</a>
-                {% endif %}
-              </li>
+            <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Registrar <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+              {% if registrars %}
+                {% for registrar in registrars %}
+                  {% if registrar_filter == registrar %}
+                    <li>
+                      <a class="selected" aria-current="true" href="?{% current_query_string registrar='' page='' %}"><i aria-hidden="true" class="icon-ok"></i> {{registrar.name}}</a>
+                    </li>
+                  {% else %}
+                    <li>
+                      <a href="?{% current_query_string registrar=registrar.id page='' %}"><i aria-hidden="true" class="icon-ok"></i> {{registrar.name}}</a>
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              {% else %}
+                <li><a href="#">None</a></li>
+              {% endif %}
             </ul>
           </div>
         {% endif %}
       </div>
     </div>
   </div>
-  {% if orgs %}
-    {% for org in orgs %}
-      <div class="item-container">
-        <div class="row row-no-bleed">
-          <div class="col col-sm-8 col-no-gutter">
-            <div class="item-title">
-              <a href="{% url 'user_management_manage_organization_user' %}?org={{org.id}}">{% if org.default_to_private %}
-                <span class="ui-private">[private]</span> {% endif %}{{ org.name }}
-              </a>
-            </div>
-            {% if request.user.is_staff %}
-              <div class="item-affil">
-                <a href="{% url 'user_management_manage_registrar' %}?q={{org.registrar.name.split|join:'+'|lower}}">{{ org.registrar }}</a>
-              </div>
-            {% endif %}
 
-            <div class="row row-half-bleed item-count-groups">
-              <div class="col col-xs-12 col-md-4 col-half-gutter">
-                <div class="item-count-group">
-                  <strong class="list-count-number">{{ org.link_count|intcomma }}</strong>
-                  <span class="item-count-label">links</span>
-                </div>
+  {% if orgs %}
+    <ol class="result-list">
+    {% for org in orgs %}
+      <li class="item-container">
+        <div class="col col-sm-8 col-no-gutter">
+          <h4 class="item-title">
+            {% if org.default_to_private %}<span class="ui-private">[private organization]</span> {% endif %}
+            {{ org.name }}
+            </a>
+          </h4>
+          {% if request.user.is_staff %}
+            <div class="item-affil">
+              <a href="{% url 'user_management_manage_registrar' %}?q={{org.registrar.name.split|join:'+'|lower}}"><span class="sr-only">Associated with</span> {{ org.registrar }}</a>
+            </div>
+          {% endif %}
+
+          <div class="row row-half-bleed item-count-groups">
+            <div class="col col-xs-12 col-md-4 col-half-gutter">
+              <div class="item-count-group">
+                <strong class="list-count-number">{{ org.link_count|intcomma }}</strong>
+                <span class="item-count-label">links</span>
               </div>
-              <div class="col col-xs-12 col-md-4 col-half-gutter">
-                <div class="item-count-group">
-                  <strong class="list-count-number">{{ org.organization_users|default_if_none:"0" }}</strong>
-                  <span class="item-count-label">users <a href="{% url 'user_management_manage_organization_user' %}?org={{org.id}}">View</a></span>
-                </div>
+            </div>
+            <div class="col col-xs-12 col-md-4 col-half-gutter">
+              <div class="item-count-group">
+                <strong class="list-count-number">{{ org.organization_users|default_if_none:"0" }}</strong>
+                <span class="item-count-label">users <a href="{% url 'user_management_manage_organization_user' %}?org={{org.id}}">View <div class="sr-wrapper"><span class="sr-only">users</span></div> </a></span>
               </div>
             </div>
           </div>
+        </div>
 
-          <div class="col col-sm-4 col-no-gutter sm-align-right admin-actions">
-            {% if org.link_count < 1 %}
-              <a class="action" href="{% url 'user_management_manage_single_organization_delete' org.id %}">delete</a>
-            {% endif %}
-            <a class="action" href="{% url 'user_management_manage_single_organization' org.id %}">edit</a>
-            {% if request.user.is_staff %}
-              <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit in admin console</a>
-            {% endif %}
-            <p class="item-activity">
+        <div class="col col-sm-4 col-no-gutter sm-align-right admin-actions">
+          <div>
+            <div class="item-activity">
             created {{ org.date_created|date:'N j, Y' }}
             <br>
             {% if org.organization_users %}
@@ -165,13 +170,25 @@
             {% else %}
             <span class="text-warning">no existing users</span>
             {% endif %}
-            </p>
+            </div>
           </div>
+          <div>
+            <div class="item-status">
+              {% if org.link_count < 1 %}
+                <a class="action" href="{% url 'user_management_manage_single_organization_delete' org.id %}">delete <span class="sr-only">{{ org.name }}</a>
+              {% endif %}
+              <a class="action" href="{% url 'user_management_manage_single_organization' org.id %}">edit <span class="sr-only">{{ org.name }}</a>
+              {% if request.user.is_staff %}
+                <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> in admin console</a>
+              {% endif %}
+            </div>
+          </div>
+
         </div>
-      </div>
+      </li>
     {% endfor %}
   {% else %}
-    <p class="item-notification">No organizations found.</p>
+    <div class="item-notification">No organizations found.</div>
   {% endif %}
 
   {% include "user_management/includes/paginator.html" with page=orgs %}

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -7,7 +7,7 @@
   <h2 class="body-ah">Organizations</h2>
   {% if request.user.is_staff or request.user.is_registrar_user %}
 
-  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> organization</a>
+  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> organization</span></a>
 
   <div id="add-member" class="collapse {% if form.errors %}in{% endif %}">
     <form method="post">
@@ -175,9 +175,9 @@
           <div>
             <div class="item-status">
               {% if org.link_count < 1 %}
-                <a class="action" href="{% url 'user_management_manage_single_organization_delete' org.id %}">delete <span class="sr-only">{{ org.name }}</a>
+                <a class="action" href="{% url 'user_management_manage_single_organization_delete' org.id %}">delete <span class="sr-only">{{ org.name }}</span></a>
               {% endif %}
-              <a class="action" href="{% url 'user_management_manage_single_organization' org.id %}">edit <span class="sr-only">{{ org.name }}</a>
+              <a class="action" href="{% url 'user_management_manage_single_organization' org.id %}">edit <span class="sr-only">{{ org.name }}</span></a>
               {% if request.user.is_staff %}
                 <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> in admin console</a>
               {% endif %}
@@ -187,6 +187,7 @@
         </div>
       </li>
     {% endfor %}
+  </ol>
   {% else %}
     <div class="item-notification">No organizations found.</div>
   {% endif %}

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -192,6 +192,6 @@
     <div class="item-notification">No organizations found.</div>
   {% endif %}
 
-  {% include "user_management/includes/paginator.html" with page=orgs %}
+  {% include "user_management/includes/paginator.html" with page=orgs title='Organization List'%}
 
 {% endblock %}

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -133,14 +133,15 @@
     {% for org in orgs %}
       <li class="item-container">
         <div class="col col-sm-8 col-no-gutter">
-          <h4 class="item-title">
+          <h4 class="item-title" id="org-{{ org.id }}" tabindex="-1">
             {% if org.default_to_private %}<span class="ui-private">[private organization]</span> {% endif %}
             {{ org.name }}
             </a>
           </h4>
           {% if request.user.is_staff %}
             <div class="item-affil">
-              <a href="{% url 'user_management_manage_registrar' %}?q={{org.registrar.name.split|join:'+'|lower}}"><span class="sr-only">Associated with</span> {{ org.registrar }}</a>
+              <span class="sr-only">Associated with: </span>
+              <a href="{% url 'user_management_manage_registrar' %}?q={{org.registrar.name.split|join:'+'|lower}}#registrar-{{ org.registrar.id }}">{{ org.registrar }}</a>
             </div>
           {% endif %}
 

--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -113,7 +113,7 @@
     {% for registrar in registrars %}
       <li class="item-container {% if registrar.status != "approved" %}muted{% endif %}">
         <div class="col col-sm-8 col-no-gutter">
-          <h4 class="item-title">
+          <h4 class="item-title" id="registrar-{{ registrar.id }}" tabindex="-1">
             {{ registrar.name }}
             {% if registrar.status == "pending" %}
               <a class="text-warning" href="{% url 'user_management_approve_pending_registrar' registrar.id %}"> needs approval</a>

--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -3,23 +3,17 @@
 {% load intcomma from humanize %}
 {% block title %} | Registrars{% endblock %}
 
-{% block manage-nav-registrar %}<li class="active"><a href="{% url 'user_management_manage_registrar' %}">Registrars</a></li>{% endblock %}
-
 {% block dashboardContent %}
+  <h2 class="body-ah">Registrars</h2>
 
-  <h2 class="body-ah">Registrars
-    <span class="action">
-      <button class="btn-transparent" data-toggle="collapse" data-target="#add-member">
-        <i class="icon-plus-sign"></i> add<span class="_verbose"> registrar</span>
-      </button>
-    </span>
-  </h2>
+  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> registrar</a>
 
   {% if messages %}
     {% for message in messages %}
       <div class="alert alert-{{ message.level_tag }} alert-block">{% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}</div>
     {% endfor %}
   {% endif %}
+
   <div id="add-member" class="collapse {% if form.errors %}in{% endif %}">
     <form method="post" novalidate>
       {% csrf_token %}
@@ -30,29 +24,32 @@
   </div>
 
   <div class="row row-no-bleed admin-data">
+    <h3 class="sr-only">Stats</h3>
     <div class="col col-xs-6 col-no-gutter admin-data-point">
-      <p class="count-label">Organizations</p>
-      <p class="count-number">{{ orgs_count }}</p>
+      <div class="count-label">Organizations</div>
+      <div class="count-number">{{ orgs_count }}</div>
     </div>
     <div class="col col-xs-6 col-no-gutter admin-data-point">
-      <p class="count-label">Registrars</p>
-      <p class="count-number">{{ registrars.paginator.count }}</p>
+      <div class="count-label">Registrars</div>
+      <div class="count-number">{{ registrars.paginator.count }}</div>
     </div>
   </div>
 
   <div class="row">
     <div class="col-sm-12">
+      <h3 class="sr-only">Search Registrars</h3>
       {% include "user_management/includes/search_form.html" with search_placeholder="Search Registrars" %}
     </div>
   </div><!-- search -->
 
-  {% if search_query %}
+  {% if status or search_query %}
     <div class="row">
       <div class="col-sm-12">
         <div class="remove-search-filters">
-          <span class="filters-title">Filters: </span>
-          <span class="filter-label">Search</span> <strong>{{search_query}}</strong>
-          <a class="action remove-filters" href="?sort=name"><i class="icon-remove-sign"></i> Clear all filters</a>
+          <h3 class="filters-title"><span class="sr-only">Current</span> Filters:</h3>
+          {% if status %}<span class="filter-label">Status</span> <strong>{{status}}</strong> {% endif %}
+          {% if search_query %}<span class="filter-label">Search</span> <strong>{{search_query}}</strong>{% endif %}
+          <a class="action remove-filters" href="?sort=name"><i class="icon-remove-sign" aria-hidden="true"></i> Clear all filters</a>
         </div>
       </div>
     </div>
@@ -60,52 +57,68 @@
 
   <div class="row row-no-bleed">
     <div class="col admin-found col-no-gutter">
+      <h3 class="sr-only">Registrar List</h3>
       <div class="sort-filter-count"><strong>Found:</strong> {{ registrars.paginator.count }} registrar{{ registrars.paginator.count|pluralize }}</div>
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>
         <div class="dropdown">
-          <button class="btn-transparent" role="button" data-toggle="dropdown">
-            Status <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu" role="menu">
+          <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Status <span class="caret"></span></button>
+          <ul class="dropdown-menu">
             <li>
-              <a {% if status == 'approved' %}class="selected" {% endif %}href="?{% current_query_string page='' status="approved" %}"><i class="icon-ok"></i> Approved</a>
-              <a {% if status == 'pending' %}class="selected" {% endif %}href="?{% current_query_string page='' status="pending" %}"><i class="icon-ok"></i> Needs approval</a>
-              <a {% if status == 'denied' %}class="selected" {% endif %}href="?{% current_query_string page='' status="denied" %}"><i class="icon-ok"></i> Denied</a>
+              <a {% if status == 'approved' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' status="approved" %}"><i aria-hidden="true" class="icon-ok"></i> Approved</a>
+            </li>
+            <li>
+              <a {% if status == 'pending' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' status="pending" %}"><i aria-hidden="true" class="icon-ok"></i> Needs approval</a>
+            </li>
+            <li>
+              <a {% if status == 'denied' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' status="denied" %}"><i aria-hidden="true" class="icon-ok"></i> Denied</a>
             </li>
           </ul>
         </div>
         <div class="dropdown">
-          <button class="btn-transparent" role="button" data-toggle="dropdown">
-            Sort <span class="caret"></span>
-          </button>
-
-          <ul class="dropdown-menu" role="menu">
+          <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Sort <span class="caret"></span></button>
+          <ul class="dropdown-menu">
             <li>
-              <a {% if sort == 'name' %}class="selected" {% endif %}href="?{% current_query_string page='' sort="name" %}"><i class="icon-ok"></i> Name A - Z</a>
-              <a {% if sort == '-name' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-name" %}"><i class="icon-ok"></i> Name Z - A</a>
-              <a {% if sort == '-date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-date_created" %}"><i class="icon-ok"></i> Newest</a>
-              <a {% if sort == 'date_created' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="date_created" %}"><i class="icon-ok"></i> Oldest</a>
-              <a {% if sort == '-last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_active" %}"><i class="icon-ok"></i> Recently active</a>
-              <a {% if sort == 'last_active' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="last_active" %}"><i class="icon-ok"></i> Least recently active</a>
-              <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
-              <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i class="icon-ok"></i> Least links</a>
+              <a {% if sort == 'name' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' sort="name" %}"><i aria-hidden="true" class="icon-ok"></i> Name A - Z</a>
+            </li>
+            <li>
+              <a {% if sort == '-name' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-name" %}"><i aria-hidden="true" class="icon-ok"></i> Name Z - A</a>
+            </li>
+            <li>
+              <a {% if sort == '-date_created' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-date_created" %}"><i aria-hidden="true" class="icon-ok"></i> Newest</a>
+            </li>
+            <li>
+              <a {% if sort == 'date_created' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="date_created" %}"><i aria-hidden="true" class="icon-ok"></i> Oldest</a>
+            </li>
+            <li>
+              <a {% if sort == '-last_active' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-last_active" %}"><i aria-hidden="true" class="icon-ok"></i> Recently active</a>
+            </li>
+            <li>
+              <a {% if sort == 'last_active' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="last_active" %}"><i aria-hidden="true" class="icon-ok"></i> Least recently active</a>
+            </li>
+            <li>
+              <a {% if sort == '-link_count' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i aria-hidden="true" class="icon-ok"></i> Most links</a>
+            </li>
+            <li>
+              <a {% if sort == 'link_count' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i aria-hidden="true" class="icon-ok"></i> Least links</a>
             </li>
           </ul>
         </div>
       </div>
     </div>
   </div>
+
   {% if registrars %}
+    <ol class="result-list">
     {% for registrar in registrars %}
-      <div class="item-container {% if registrar.status != "approved" %}muted{% endif %}">
+      <li class="item-container {% if registrar.status != "approved" %}muted{% endif %}">
         <div class="col col-sm-8 col-no-gutter">
-          <div class="item-title">
+          <h4 class="item-title">
             {{ registrar.name }}
             {% if registrar.status == "pending" %}
               <a class="text-warning" href="{% url 'user_management_approve_pending_registrar' registrar.id %}"> needs approval</a>
             {% endif %}
-          </div>
+          </h4>
           <div class="item-subtitle">{{ registrar.email }}</div>
           <div class="item-subtitle"><a href="{{ registrar.website }}">{{registrar.website}}</a></div>
           <div class="row row-half-bleed item-count-groups">
@@ -118,47 +131,54 @@
             <div class="col col-xs-12 col-md-4 col-half-gutter">
               <div class="item-count-group">
                 <strong class="list-count-number">{{ registrar.organizations.count }}</strong>
-                <span class="item-count-label">org{{ registrar.organizations.count | pluralize }} <a href="{% url 'user_management_manage_organization' %}?registrar={{registrar.id}}">View</a></span>
+                <span class="item-count-label">org{{ registrar.organizations.count | pluralize }} <a href="{% url 'user_management_manage_organization' %}?registrar={{registrar.id}}">View <div class="sr-wrapper"><span class="sr-only">orgs</span></div></a></span>
               </div>
             </div>
             <div class="col col-xs-12 col-md-4 col-half-gutter">
               <div class="item-count-group">
                 <strong class="list-count-number right">{{ registrar.registrar_users }}</strong>
-                <span class="item-count-label">registrar users <a href="{% url 'user_management_manage_registrar_user' %}?registrar={{registrar.id}}">View</a></span>
+                <span class="item-count-label">registrar users <a href="{% url 'user_management_manage_registrar_user' %}?registrar={{registrar.id}}">View <div class="sr-wrapper"><span class="sr-only">registrar users</span></div></a></span>
               </div>
             </div>
           </div>
         </div>
 
         <div class="col col-sm-4 col-no-gutter sm-align-right admin-actions">
-          {% if registrar.status != "approved" %}
-            <a class="action action-approve" href="{% url 'user_management_approve_pending_registrar' registrar.id %}">
-              {% if registrar.status == "pending" %}
-                Review and approve
+          <div>
+            <div class="item-activity">
+              {% if registrar.status == "pending" %}requested{% else %}created{% endif %} {{ registrar.date_created|date:'N j, Y'}}
+              <br>
+              {% if registrar.last_active %}
+                last active {{ registrar.last_active|date:'N j, Y'}}
               {% else %}
-                Denied
+                no activity
               {% endif %}
-            </a>
-          {% else %}
-            <a class="action" href="{% url 'user_management_manage_single_registrar' registrar.id %}">edit</a>
-            {% if request.user.is_staff %}
-              <a class="action" href="{% url "admin:perma_registrar_change" registrar.id %}">edit in admin console</a>
-            {% endif %}
-          {% endif %}
-          <p class="item-activity">
-            {% if registrar.status == "pending" %}requested{% else %}created{% endif %} {{ registrar.date_created|date:'N j, Y'}}
-            <br>
-            {% if registrar.last_active %}
-              last active {{ registrar.last_active|date:'N j, Y'}}
-            {% else %}
-              no activity
-            {% endif %}
-          </p>
+            </div>
+          </div>
+          <div>
+            <div class="itlem-status">
+              {% if registrar.status != "approved" %}
+                <a class="action action-approve" href="{% url 'user_management_approve_pending_registrar' registrar.id %}">
+                  {% if registrar.status == "pending" %}
+                    Review and approve <span class="sr-only">{{ registrar.name }}</span>
+                  {% else %}
+                    Denied <span class="sr-only">{{ registrar.name }}</span>
+                  {% endif %}
+                </a>
+              {% else %}
+                <a class="action" href="{% url 'user_management_manage_single_registrar' registrar.id %}">edit <span class="sr-only">{{ registrar.name }}</span></a>
+                {% if request.user.is_staff %}
+                  <a class="action" href="{% url "admin:perma_registrar_change" registrar.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ registrar.name }} </span></div>in admin console</a>
+                {% endif %}
+              {% endif %}
+            </div>
+          </div>
         </div>
-      </div>
+      </li>
     {% endfor %}
+    </ol>
   {% else %}
-    <p class="item-notification">No registrars found.</p>
+    <div class="item-notification">No registrars found.</div>
   {% endif %}
 
 

--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -6,7 +6,7 @@
 {% block dashboardContent %}
   <h2 class="body-ah">Registrars</h2>
 
-  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> registrar</a>
+  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> registrar</span></a>
 
   {% if messages %}
     {% for message in messages %}

--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -182,6 +182,6 @@
   {% endif %}
 
 
-  {% include "user_management/includes/paginator.html" with page=registrars %}
+  {% include "user_management/includes/paginator.html" with page=registrars title='Registrar List'%}
 
 {% endblock %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -25,32 +25,36 @@
   </div><!-- add member -->
 
   <div class="row row-no-bleed admin-data">
+    <h3 class="sr-only">User List Summary</h3>
+
     <div class="col {% if request.user.is_staff and group_name == 'user' %}col-xs-3{% else %}col-xs-4{% endif %} col col-no-gutter admin-data-point">
-      <p class="count-label">Users</p>
-      <p class="count-number">{{ users.paginator.count|intcomma }}</p>
+      <div class="count-label">Users</div>
+      <div class="count-number">
+        {{ users.paginator.count|intcomma }}
+      </div>
     </div>
 
     {% if request.user.is_staff and group_name == 'user' %}
       <div class="col col-xs-3 col-no-gutter admin-data-point">
-        <p class="count-label">Deactivated Users</p>
-        <p class="count-number">{{ deactivated_users }}</p>
+        <div class="count-label">Deactivated Users</div>
+        <div class="count-number">{{ deactivated_users }}</div>
       </div>
     {% endif %}
 
     <div class="col {% if request.user.is_staff and group_name == 'user' %}col-xs-3{% else %}col-xs-4{% endif %} col col-no-gutter admin-data-point">
-      <p class="count-label">Unactivated Users</p>
-      <p class="count-number">{{ unactivated_users }}</p>
+      <div class="count-label">Unactivated Users</div>
+      <div class="count-number">{{ unactivated_users }}</div>
     </div>
 
     <div class="col {% if request.user.is_staff and group_name == 'user' %}col-xs-3{% else %}col-xs-4{% endif %} col col-no-gutter admin-data-point">
-      <p class="count-label">Links</p>
-      <p class="count-number">{{ total_created_links_count|default:0|intcomma }}</p>
+      <div class="count-label">Links</div>
+      <div class="count-number">{{ total_created_links_count|default:0|intcomma }}</div>
     </div>
   </div><!-- admin data -->
 
-
   <div class="row">
     <div class="col col-xs-12">
+      <h3 class="sr-only">Search Users</h3>
       {% include "user_management/includes/search_form.html" with search_placeholder="Search Users" %}
     </div>
   </div><!-- search -->
@@ -59,7 +63,9 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="remove-search-filters">
-          <span class="filters-title">Filters: </span>
+
+          <h3 class="filters-title"><span class="sr-only">Current</span> Filters:</h3>
+
           {% if registrar_filter %}<span class="filter-label">Registrar</span> <strong>{{registrar_filter}}</strong> {% endif %}
           {% if org_filter %}<span class="filter-label">Organization</span> <strong>{{org_filter}}</strong> {% endif %}
           {% if status %}<span class="filter-label">Status</span> <strong>{{status}}</strong> {% endif %}
@@ -73,7 +79,8 @@
 
   <div class="row row-no-bleed">
     <div class="col admin-found col-no-gutter">
-      <div class="sort-filter-count"><strong>Found:</strong> {{ users.paginator.count }} user{{ users.paginator.count|pluralize }}</div>
+      <h3 class="filters-title"><span class="sr-only">User List</h3>
+      <div id="results" class="sort-filter-count"><strong>Found:</strong> {{ users.paginator.count }} user{{ users.paginator.count|pluralize }}</div>
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>
         <div class="dropdown">
@@ -171,17 +178,18 @@
   </div><!-- row -->
 
   {% if users %}
+    <ol class="result-list">
     {% for listed_user in users %}
-      <div class="item-container {% if not listed_user.is_active %}muted{% endif %}">
+      <li class="item-container {% if not listed_user.is_active %}muted{% endif %}">
         <div class="col col-sm-8 col-no-gutter">
-          <div class="item-title">
+          <h4 class="item-title">
             {% if not listed_user.first_name and not listed_user.last_name %}
               {{ listed_user.email }}
             {% else %}
               {{ listed_user.first_name }} {{ listed_user.last_name }}
             {% endif %}
             {% if listed_user == request.user %}(you){% endif %}
-          </div>
+          </h4>
           <div class="item-subtitle">{{ listed_user.email }}</div>
           {% if not listed_user.is_confirmed %}
             <p class="warning">User must activate account</p>
@@ -189,19 +197,20 @@
 
           {% if listed_user|visible_organizations:request.user %}
             <div class="item-affil">
+              <span class="sr-only">Member of:</span>
               {% for organization in listed_user|visible_organizations:request.user %}
-                <a href="{% url 'user_management_manage_organization' %}?q={{organization.name.split|join:'+'|lower}}">{{organization.name.strip}}</a>
+                 <a href="{% url 'user_management_manage_organization' %}?q={{organization.name.split|join:'+'|lower}}">{{organization.name.strip}}</a>
                 {% include "user_management/includes/comma.html" %}
               {% endfor %}
             </div>
           {% endif %}
 
           {% if request.user.is_staff and listed_user.requested_account_type %}
-            <p class="item-org">Interested in a {{listed_user.requested_account_type}} account with {{listed_user.requested_account_note}}</p>
+            <div class="item-org">Interested in a {{listed_user.requested_account_type}} account with {{listed_user.requested_account_note}}</div>
           {% endif %}
 
           {% if group_name == 'registrar_user' and request.user.is_staff %}
-            <div class="item-affil"><a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}">{{ listed_user.registrar.name }}</a></div>
+            <div class="item-affil"><span class="sr-only">Member of:</span> <a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}">{{ listed_user.registrar.name }}</a></div>
           {% endif %}
 
           {% if group_name == 'organization_user' %}
@@ -217,57 +226,62 @@
         </div>
 
         <div class="col col-sm-4 col-no-gutter sm-align-right admin-actions">
-          <p class="item-status">
-            {% if listed_user.is_active %}
-              {% if request.user.is_staff %}
-                {% if group_name != 'admin_user' %}
-                  <a class="action action-delete" href="{% url single_user_url listed_user.id %}">remove/delete</a>
+          <div>
+            <div class="item-activity">
+              created {{ listed_user.date_joined|date:'F j, Y' }}
+              {% if listed_user.is_confirmed %}
+                <br>
+                last active {{ listed_user.last_login|date:'F j, Y' }}
+              {% endif %}
+            </div>
+          </div>
+          <div>
+            <div class="item-status">
+              {% if listed_user.is_active %}
+                {% if request.user.is_staff %}
+                  {% if group_name != 'admin_user' %}
+                    <a class="action action-delete" href="{% url single_user_url listed_user.id %}">remove/delete <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                  {% else %}
+                    <a class="action action-delete" href="{% url 'user_management_manage_single_admin_user_remove' listed_user.id %}">remove <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                  {% endif %}
+                {% elif request.user.is_registrar_user and group_name == 'organization_user' %}
+                  <a class="action action-delete" href="{% url single_user_url listed_user.id %}">remove <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                {% elif request.user.is_registrar_user and group_name == 'registrar_user' %}
+                  <a class="action action-delete" href="{% url 'user_management_manage_single_registrar_user_remove' listed_user.id %}">remove <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
                 {% else %}
-                  <a class="action action-delete" href="{% url 'user_management_manage_single_admin_user_remove' listed_user.id %}">remove</a>
+                  <a class="action action-delete" href="{% url single_user_url listed_user.id %}">remove <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
                 {% endif %}
-              {% elif request.user.is_registrar_user and group_name == 'organization_user' %}
-                <a class="action action-delete" href="{% url single_user_url listed_user.id %}">remove</a>
-              {% elif request.user.is_registrar_user and group_name == 'registrar_user' %}
-                <a class="action action-delete" href="{% url 'user_management_manage_single_registrar_user_remove' listed_user.id %}">remove</a>
+              {% elif listed_user.is_confirmed %}
+                <span class="text-warning">deactivated account</span>
+                {% if request.user.is_staff %}
+                  <a class="action" href="{% url reactivate_user_url listed_user.id %}">reactivate <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                {% endif %}
               {% else %}
-                <a class="action action-delete" href="{% url single_user_url listed_user.id %}">remove</a>
-              {% endif %}
-            {% elif listed_user.is_confirmed %}
-              <span class="text-warning">deactivated account</span>
-              {% if request.user.is_staff %}
-                <a class="action" href="{% url reactivate_user_url listed_user.id %}">reactivate</a>
-              {% endif %}
-            {% else %}
-              {% if request.user.is_staff %}
-                <a class="action action-delete" href="{% url delete_user_url listed_user.id %}">delete</a>
-              {% else %}
-                {% if group_name == 'organization_user' %}
-                  <a class="action action-delete" href="{% url 'user_management_manage_single_organization_user' listed_user.id %}">remove</a>
-                {% elif group_name == 'registrar_user' %}
-                  <a class="action action-delete" href="{% url 'user_management_manage_single_registrar_user_remove' listed_user.id %}">remove</a>
+                {% if request.user.is_staff %}
+                  <a class="action action-delete" href="{% url delete_user_url listed_user.id %}">delete <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                {% else %}
+                  {% if group_name == 'organization_user' %}
+                    <a class="action action-delete" href="{% url 'user_management_manage_single_organization_user' listed_user.id %}">remove <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                  {% elif group_name == 'registrar_user' %}
+                    <a class="action action-delete" href="{% url 'user_management_manage_single_registrar_user_remove' listed_user.id %}">remove <span class="sr-only">{{ listed_user.get_full_name}}</span></a>
+                  {% endif %}
                 {% endif %}
               {% endif %}
+            </div>
+            {% if request.user.is_staff %}
+              <div class="item-status"><a class="action" href="{% url "admin:perma_linkuser_change" listed_user.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ listed_user.get_full_name }} </span></div>in admin console</span></a></div>
             {% endif %}
-          </p>
-          {% if request.user.is_staff %}
-            <p class="item-status"><a class="action" href="{% url "admin:perma_linkuser_change" listed_user.id %}">edit in admin console</a></p>
-          {% endif %}
-          {% if not listed_user.is_confirmed %}
-            <p class="item-status"><a class="action" href="{% url 'user_management_resend_activation' listed_user.id %}">resend activation email</a></p>
-          {% endif %}
-          <p class="item-activity">
-            created {{ listed_user.date_joined|date:'F j, Y' }}
-            {% if listed_user.is_confirmed %}
-              <br>
-              last active {{ listed_user.last_login|date:'F j, Y' }}
+            {% if not listed_user.is_confirmed %}
+              <div class="item-status"><a class="action" href="{% url 'user_management_resend_activation' listed_user.id %}">resend activation email <span class="sr-only"> to {{ listed_user.get_full_name}}</span></a></div>
             {% endif %}
-          </p>
+          </div>
         </div>
-      </div>
+      </li>
     {% endfor %}
+    </ol>
 
   {% else %}
-    <p class="item-notification">No {{ pretty_group_name_plural|lower }} found.</p>
+    <div class="item-notification">No {{ pretty_group_name_plural|lower }} found.</div>
   {% endif %}
 
   {% include "user_management/includes/paginator.html" with page=users %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -73,7 +73,7 @@
           {% if status %}<span class="filter-label">Status</span> <strong>{{status}}</strong> {% endif %}
           {% if upgrade %}<span class="filter-label">Upgrade interest</span> <strong>{{upgrade}}</strong> {% endif %}
           {% if search_query %}<span class="filter-label">Search</span> <strong>{{search_query}}</strong>{% endif %}
-          <a class="action remove-filters" href="?sort=last_name"><i class="icon-remove-sign"></i> Clear all filters</a>
+          <a class="action remove-filters" href="?sort=last_name"><i aria-hidden="true" class="icon-remove-sign"></i> Clear all filters</a>
          </div>
       </div>
     </div>

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -228,7 +228,7 @@
             <div class="item-affil">
               <span class="sr-only">Member of:</span>
               {% for organization in listed_user|visible_organizations:request.user %}
-                 <a href="{% url 'user_management_manage_organization' %}?q={{organization.name.split|join:'+'|lower}}">{{organization.name.strip}}</a>
+                 <a href="{% url 'user_management_manage_organization' %}?q={{organization.name.split|join:'+'|lower}}#org-{{ organization.id }}">{{organization.name.strip}}</a>
                 {% include "user_management/includes/comma.html" %}
               {% endfor %}
             </div>
@@ -239,7 +239,7 @@
           {% endif %}
 
           {% if group_name == 'registrar_user' and request.user.is_staff %}
-            <div class="item-affil"><span class="sr-only">Member of:</span> <a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}">{{ listed_user.registrar.name }}</a></div>
+            <div class="item-affil"><span class="sr-only">Member of:</span> <a href="{% url 'user_management_manage_registrar' %}?q={{listed_user.registrar.name.split|join:'+'|lower}}#registrar-{{ listed_user.registrar.id }}">{{ listed_user.registrar.name }}</a></div>
           {% endif %}
 
           {% if group_name == 'organization_user' %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -313,6 +313,6 @@
     <div class="item-notification">No {{ pretty_group_name_plural|lower }} found.</div>
   {% endif %}
 
-  {% include "user_management/includes/paginator.html" with page=users %}
+  {% include "user_management/includes/paginator.html" with page=users title='User List'%}
 
 {% endblock %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -4,7 +4,6 @@
 {% block title %} | {{ pretty_group_name_plural }}{% endblock %}
 
 {% block dashboardContent %}
-
   <h2 class="body-ah">{{ pretty_group_name_plural|title }}</h2>
 
   <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> {{ pretty_group_name|lower }}</a>

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -6,7 +6,7 @@
 {% block dashboardContent %}
   <h2 class="body-ah">{{ pretty_group_name_plural|title }}</h2>
 
-  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> {{ pretty_group_name|lower }}</a>
+  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> {{ pretty_group_name|lower }}</span></a>
 
   {% if messages %}
     {% for message in messages %}

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -5,7 +5,9 @@
 
 {% block dashboardContent %}
 
-  <h2 class="body-ah">{{ pretty_group_name_plural|title }} <span class="action"><a data-toggle="collapse" data-target="#add-member"><i class="icon-plus-sign"></i> add<span class="_verbose"> {{ pretty_group_name|lower }}</a></a></span></h2>
+  <h2 class="body-ah">{{ pretty_group_name_plural|title }}</h2>
+
+  <a class="action-heading" data-toggle="collapse" href="#add-member" aria-expanded="false" aria-controls="#add-member"><i class="icon-plus-sign" aria-hidden="true"></i> add<span class="_verbose"> {{ pretty_group_name|lower }}</a>
 
   {% if messages %}
     {% for message in messages %}
@@ -17,7 +19,8 @@
     <form method="get" action="{% url add_user_url %}" class="form-inline" role="form">
       <fieldset>
         <div class="form-group fg-100">
-          <input type="text" name="email" value="{{ search_query|default:"" }}" placeholder="{{ search_placeholder|default:"Email" }}"/>
+          <label for="add" class="sr-only">new {{ pretty_group_name|lower }} email</label>
+          <input id="add" type="text" name="email" value="{{ search_query|default:"" }}" placeholder="{{ search_placeholder|default:"Email" }}"/>
         </div>
         <button type="submit" class="btn btn-default btn-inline">Add {{ pretty_group_name }}</button>
       </fieldset>

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -28,8 +28,7 @@
   </div><!-- add member -->
 
   <div class="row row-no-bleed admin-data">
-    <h3 class="sr-only">User List Summary</h3>
-
+    <h3 class="sr-only">Stats</h3>
     <div class="col {% if request.user.is_staff and group_name == 'user' %}col-xs-3{% else %}col-xs-4{% endif %} col col-no-gutter admin-data-point">
       <div class="count-label">Users</div>
       <div class="count-number">
@@ -82,7 +81,7 @@
 
   <div class="row row-no-bleed">
     <div class="col admin-found col-no-gutter">
-      <h3 class="filters-title"><span class="sr-only">User List</h3>
+      <h3 class="sr-only">User List</h3>
       <div id="results" class="sort-filter-count"><strong>Found:</strong> {{ users.paginator.count }} user{{ users.paginator.count|pluralize }}</div>
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -86,46 +86,70 @@
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>
         <div class="dropdown">
-          <button class="btn-transparent" role="button" data-toggle="dropdown">Sort <span class="caret"></span></button>
-          <ul class="dropdown-menu" role="menu">
+          <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Sort <span class="caret"></span></button>
+          <ul class="dropdown-menu">
             <li>
-              <a {% if sort == 'last_name' %}class="selected" {% endif %}href="?{% current_query_string page='' sort="last_name" %}"><i class="icon-ok"></i> Last name A - Z</a>
-              <a {% if sort == '-last_name' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_name" %}"><i class="icon-ok"></i> Last name Z - A</a>
-              <a {% if sort == '-date_joined' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-date_joined" %}"><i class="icon-ok"></i> Newest</a>
-              <a {% if sort == 'date_joined' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="date_joined" %}"><i class="icon-ok"></i> Oldest</a>
-              <a {% if sort == '-last_login' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-last_login" %}"><i class="icon-ok"></i> Recently active</a>
-              <a {% if sort == 'last_login' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="last_login" %}"><i class="icon-ok"></i> Least recently active</a>
-              {% if group_name == 'organization_user' %}
-                <a {% if sort == '-link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i class="icon-ok"></i> Most links</a>
-                <a {% if sort == 'link_count' %}class="selected" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i class="icon-ok"></i> Least links</a>
-              {% endif %}
+              <a {% if sort == 'last_name' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' sort="last_name" %}"><i aria-hidden="true" class="icon-ok"></i> Last name A - Z</a>
             </li>
+            <li>
+              <a {% if sort == '-last_name' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-last_name" %}"><i aria-hidden="true" class="icon-ok"></i> Last name Z - A</a>
+            </li>
+            <li>
+              <a {% if sort == '-date_joined' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-date_joined" %}"><i aria-hidden="true" class="icon-ok"></i> Newest</a>
+            </li>
+            <li>
+              <a {% if sort == 'date_joined' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="date_joined" %}"><i aria-hidden="true" class="icon-ok"></i> Oldest</a>
+            </li>
+            <li>
+              <a {% if sort == '-last_login' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-last_login" %}"><i aria-hidden="true" class="icon-ok"></i> Recently active</a>
+            </li>
+            <li>
+              <a {% if sort == 'last_login' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="last_login" %}"><i aria-hidden="true" class="icon-ok"></i> Least recently active</a>
+            </li>
+            {% if group_name == 'organization_user' %}
+            <li>
+              <a {% if sort == '-link_count' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="-link_count" %}"><i aria-hidden="true" class="icon-ok"></i> Most links</a>
+            </li>
+            <li>
+              <a {% if sort == 'link_count' %}class="selected" aria-current="true" {% endif %} href="?{% current_query_string page='' sort="link_count" %}"><i aria-hidden="true" class="icon-ok"></i> Least links</a>
+            </li>
+            {% endif %}
           </ul>
         </div>
 
         {% if request.user.is_staff and group_name == 'user' %}
           <div class="dropdown">
-            <button class="btn-transparent" role="button" data-toggle="dropdown">Upgrade interest <span class="caret"></span></button>
-            <ul class="dropdown-menu" role="menu">
+            <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Upgrade interest <span class="caret"></span></button>
+            <ul class="dropdown-menu">
               <li>
-                <a {% if upgrade == 'court' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="court" %}"><i class="icon-ok"></i> Court</a>
-                <a {% if upgrade == 'faculty' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="faculty" %}"><i class="icon-ok"></i> Faculty</a>
-                <a {% if upgrade == 'journal' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="journal" %}"><i class="icon-ok"></i> Journal</a>
-                <a {% if upgrade == 'firm' %}class="selected" {% endif %}href="?{% current_query_string page='' upgrade="firm" %}"><i class="icon-ok"></i> Firm</a>
+                <a {% if upgrade == 'court' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' upgrade="court" %}"><i aria-hidden="true" class="icon-ok"></i> Court</a>
+              </li>
+              <li>
+                <a {% if upgrade == 'faculty' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' upgrade="faculty" %}"><i aria-hidden="true" class="icon-ok"></i> Faculty</a>
+              </li>
+              <li>
+                <a {% if upgrade == 'journal' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' upgrade="journal" %}"><i aria-hidden="true" class="icon-ok"></i> Journal</a>
+              </li>
+              <li>
+                  <a {% if upgrade == 'firm' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' upgrade="firm" %}"><i aria-hidden="true" class="icon-ok"></i> Firm</a>
               </li>
             </ul>
           </div>
         {% endif %}
 
         <div class="dropdown">
-          <button class="btn-transparent" role="button" data-toggle="dropdown">Status <span class="caret"></span></button>
-          <ul class="dropdown-menu" role="menu">
+          <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Status <span class="caret"></span></button>
+          <ul class="dropdown-menu">
             <li>
-              <a {% if status == 'active' %}class="selected" {% endif %}href="?{% current_query_string page='' status="active" %}"><i class="icon-ok"></i> Active</a>
-              {% if request.user.is_staff and group_name|slice:"-4:" == 'user' %}
-              <a {% if status == 'deactivated' %}class="selected" {% endif %}href="?{% current_query_string page='' status="deactivated" %}"><i class="icon-ok"></i> Deactivated</a>
-              {% endif %}
-              <a {% if status == 'unactivated' %}class="selected" {% endif %}href="?{% current_query_string page='' status="unactivated" %}"><i class="icon-ok"></i> Unactivated</a>
+              <a {% if status == 'active' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' status="active" %}"><i aria-hidden="true" class="icon-ok"></i> Active</a>
+            </li>
+            {% if request.user.is_staff and group_name|slice:"-4:" == 'user' %}
+            <li>
+              <a {% if status == 'deactivated' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' status="deactivated" %}"><i aria-hidden="true" class="icon-ok"></i> Deactivated</a>
+            </li>
+            {% endif %}
+            <li>
+              <a {% if status == 'unactivated' %}class="selected" aria-current="true" {% endif %}href="?{% current_query_string page='' status="unactivated" %}"><i aria-hidden="true" class="icon-ok"></i> Unactivated</a>
             </li>
           </ul>
         </div>
@@ -133,21 +157,23 @@
         {% if request.user.is_staff or request.user.is_registrar_user %}
           {% if group_name == 'organization_user' %}
             <div class="dropdown">
-              <button class="btn-transparent" role="button" data-toggle="dropdown">Organization <span class="caret"></span></button>
-              <ul class="dropdown-menu" role="menu">
-                <li>
+              <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Organization <span class="caret"></span></button>
+              <ul class="dropdown-menu">
                 {% if orgs %}
                   {% for org in orgs %}
                     {% if organization_filter == org %}
-                      <a class="selected" href="?{% current_query_string page='' org='' %}"><i class="icon-ok"></i> {{org.name}}</a>
+                      <li>
+                        <a class="selected" aria-current="true" href="?{% current_query_string page='' org='' %}"><i aria-hidden="true" class="icon-ok"></i> {{org.name}}</a>
+                      </li>
                     {% else %}
-                      <a href="?{% current_query_string page='' org=org.id %}"><i class="icon-ok"></i> {{org.name}}</a>
+                      <li>
+                        <a href="?{% current_query_string page='' org=org.id %}"><i aria-hidden="true" class="icon-ok"></i> {{org.name}}</a>
+                      </li>
                     {% endif %}
                   {% endfor %}
                 {% else %}
-                  <a href="">None</a>
+                  <li><a href="#">None</a></li>
                 {% endif %}
-                </li>
               </ul>
             </div>
           {% endif %}
@@ -156,21 +182,23 @@
         {% if request.user.is_staff %}
           {% if not group_name == 'user' and not group_name == 'admin_user' %}
           <div class="dropdown">
-            <button class="btn-transparent" role="button" data-toggle="dropdown">Registrar <span class="caret"></span></button>
-            <ul class="dropdown-menu" role="menu">
-              <li>
+            <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Registrar <span class="caret"></span></button>
+            <ul class="dropdown-menu">
                 {% if registrars %}
                   {% for registrar in registrars %}
                     {% if registrar_filter == registrar %}
-                      <a class="selected" href="?{% current_query_string page='' registrar='' organization='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+                      <li>
+                        <a class="selected" aria-current="true" href="?{% current_query_string page='' registrar='' organization='' %}"><i aria-hidden="true" class="icon-ok"></i> {{registrar.name}}</a>
+                      </li>
                     {% else %}
-                      <a href="?{% current_query_string page='' registrar=registrar.id organization='' %}"><i class="icon-ok"></i> {{registrar.name}}</a>
+                      <li>
+                        <a href="?{% current_query_string page='' registrar=registrar.id organization='' %}"><i aria-hidden="true" class="icon-ok"></i> {{registrar.name}}</a>
+                      </li>
                     {% endif %}
                   {% endfor %}
                 {% else %}
-                  <a href="">None</a>
+                  <li><a href="#">None</a></li>
                 {% endif %}
-              </li>
             </ul>
           </div>
           {% endif %}

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -12,6 +12,7 @@ from perma.exceptions import PermaPaymentsCommunicationException
 from .utils import PermaTestCase
 
 from random import random
+import re
 from bs4 import BeautifulSoup
 
 
@@ -230,8 +231,11 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.assertEqual("Found: 6 organizations", count)
         # registrar name appears by each org, once in the filter dropdown, once in the "add an org" markup
         self.assertEqual(response.count('Test Library'), 3 + 2)
-        self.assertEqual(response.count('Another Library'), 1 + 2)
         self.assertEqual(response.count('Test Firm'), 2 + 2)
+        # 'Another Library' needs special handling because of the fixture orgs is
+        # named 'Another Library's journal'. The "string" search finds the instance
+        # by the org and the instance in the filter dropdown, but not the <option> in the "add an org" markup
+        self.assertEqual(len(soup.find_all(string=re.compile(r"Another Library(?!')"))), 1 + 1)
 
         # get orgs for a single registrar
         response = self.get('user_management_manage_organization',

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -254,6 +254,7 @@ def manage_registrar(request):
         # 'users_count': users_count,
         'this_page': 'users_registrars',
         'search_query': search_query,
+        'status': status,
         'sort': sort,
         'form': form,
     })

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -7811,6 +7811,30 @@ input:focus,
   outline: none !important;
 }
 
+/*
+  In certain peculiar cases, screenreader-only text is read
+  out of order:
+  <!-- This is read "two one three" -->
+  <a href="/">One <span class="sr-only">two</span> three.</a>
+
+  IFF inside a block-level element, rather than an inline element
+  (<a> can be either, depending on context...)
+  you can address by wrapping the sr-only element in a div with
+  .sr-wrapper.
+
+  <!-- This is read "one two three" -->
+  <a href="/">One <div class="sr-wrapper"><span class="sr-only">two </span></div>three</a>
+
+  <!-- This is invalid html and won't be parsed correctly by the browser -->
+  <p><a href="/">One <div class="sr-wrapper"><span class="sr-only">two </span></div>three</a></
+
+*/
+
+.sr-wrapper {
+  display: inline-block;
+  position: relative;
+}
+
 ul {
   list-style-type: none;
 }
@@ -12547,6 +12571,28 @@ footer #boilerplate a {
   color: #222;
 }
 
+ol.result-list {
+  list-style-type: none;
+  padding: 0;
+  /* Add zero-width space  to work around Voiceover bug */
+  /* https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/ */
+}
+
+ol.result-list li:before {
+  content: "\200B";
+}
+
+ol.result-list .item-container {
+  margin-top: 0;
+}
+
+ol.result-list .admin-actions {
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+}
+
 .item-container {
   padding: 16px 16px;
   border: 1px solid transparent;
@@ -12638,6 +12684,7 @@ footer #boilerplate a {
 .item-title {
   font-size: 16px;
   font-weight: 700;
+  color: #222;
 }
 
 .item-title a {
@@ -13128,6 +13175,8 @@ span.action [class*=" icon-"] {
 }
 
 .remove-search-filters .filters-title {
+  display: inline-block;
+  color: #DD671A;
   font-size: 14px;
   font-weight: 700;
 }

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -7674,11 +7674,13 @@ a.cc:hover,
 form .btn:hover,
 .navbar-toggle:hover,
 span.action:hover,
+a.action-heading:hover,
 .style-button-hover:focus,
 a.cc:focus,
 form .btn:focus,
 .navbar-toggle:focus,
-span.action:focus {
+span.action:focus,
+a.action-heading:focus {
   background-color: #0092FF;
 }
 
@@ -7686,7 +7688,8 @@ span.action:focus {
 a.cc:active,
 form .btn:active,
 .navbar-toggle:active,
-span.action:active {
+span.action:active,
+a.action-heading:active {
   background-color: #222;
 }
 
@@ -13015,7 +13018,8 @@ body.dragging * {
   }
 }
 
-span.action {
+span.action,
+a.action-heading {
   display: inline-block;
   float: right;
   font-size: 16px;
@@ -13027,15 +13031,25 @@ span.action {
   cursor: pointer;
 }
 
-span.action a {
+span.action a,
+a.action-heading a {
   color: white !important;
 }
 
 span.action .icon-plus-sign,
 span.action [class^="icon-"],
-span.action [class*=" icon-"] {
+span.action [class*=" icon-"],
+a.action-heading .icon-plus-sign,
+a.action-heading [class^="icon-"],
+a.action-heading [class*=" icon-"] {
   color: white;
   top: 1px;
+}
+
+.action-heading {
+  position: absolute;
+  top: 10px;
+  right: 0;
 }
 
 .org-settings {

--- a/perma_web/static/bundles/global-styles.css
+++ b/perma_web/static/bundles/global-styles.css
@@ -9341,7 +9341,8 @@ button #addlink {
   color: #2D76EE;
 }
 
-.body-ah:first-child {
+.body-ah:first-child,
+#main-skip-target ~ .body-ah {
   margin-top: 0;
 }
 

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -4399,7 +4399,7 @@ body.dragging * {
   }
 }
 
-span.action {
+span.action, a.action-heading {
   display: inline-block;
   float: right;
   font-size: 16px;
@@ -4419,6 +4419,12 @@ span.action {
     color: white;
     top: 1px;
   }
+}
+
+.action-heading {
+  position: absolute;
+  top: 10px;
+  right: 0;
 }
 
 .org-settings {

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -198,6 +198,29 @@ input:focus,
   outline: none !important;
 }
 
+/*
+  In certain peculiar cases, screenreader-only text is read
+  out of order:
+  <!-- This is read "two one three" -->
+  <a href="/">One <span class="sr-only">two</span> three.</a>
+
+  IFF inside a block-level element, rather than an inline element
+  (<a> can be either, depending on context...)
+  you can address by wrapping the sr-only element in a div with
+  .sr-wrapper.
+
+  <!-- This is read "one two three" -->
+  <a href="/">One <div class="sr-wrapper"><span class="sr-only">two </span></div>three</a>
+
+  <!-- This is invalid html and won't be parsed correctly by the browser -->
+  <p><a href="/">One <div class="sr-wrapper"><span class="sr-only">two </span></div>three</a></
+
+*/
+.sr-wrapper {
+  display: inline-block;
+  position: relative;
+}
+
 ul { list-style-type: none; }
 
 /* adapted from https://github.com/Automattic/_s/blob/master/sass/modules/_accessibility.scss */
@@ -299,7 +322,7 @@ td {
   margin: 0;
 }
 
-// specificty for bootstrap
+// specificity for bootstrap
 .table thead > tr > th,
 .table tbody > tr > th,
 .table tfoot > tr > th,
@@ -3970,6 +3993,26 @@ footer {
   }
 }
 
+ol.result-list {
+  list-style-type: none;
+  padding: 0;
+
+  /* Add zero-width space  to work around Voiceover bug */
+  /* https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/ */
+  & li:before {
+    content: "\200B";
+  }
+
+  .item-container {
+    margin-top: 0;
+  }
+
+  .admin-actions {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+}
+
 .item-container {
   padding: $double $double;
   border: 1px solid transparent;
@@ -4051,6 +4094,7 @@ footer {
 .item-title {
   font-size: 16px;
   font-weight: 700;
+  color: $color-black;
   a {
     color: $color-black;
     @extend .style-standard-hover;
@@ -4489,6 +4533,8 @@ span.action {
     font-size: 16px;
   }
   .filters-title {
+    display: inline-block;
+    color: $color-orange;
     font-size: 14px;
     font-weight: 700;
     @include respond-desktop {

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -1484,7 +1484,7 @@ button {
   font-family: $font-hed-alt;
   font-weight: 700;
   color: $color-blue;
-  &:first-child {
+  &:first-child, #main-skip-target ~ & {
     margin-top: 0;
   }
   .body-text ~ form &:first-child {


### PR DESCRIPTION
This is an effort to address the (primarily keyboard- and screenreader-) accessibility of Perma pages under the "Manage users and organizations" heading.

Closes:
https://github.com/harvard-lil/perma/issues/2270
https://github.com/harvard-lil/perma/issues/2269
https://github.com/harvard-lil/perma/issues/2265
https://github.com/harvard-lil/perma/issues/2266

The stats/current filters/current sorts/current search query/current page and total number of pages still aren't particularly clearly associated with the list, except visually. But, I came to the conclusion that I can't do this more clearly without redesigning the page with a simplified visual flow, which I think is beyond my modest design skills.

Similarly, keyboard focus is not handled: there are too many page re-loading actions and too many possible interactions to be able to predict where a user would most like to be delivered on a given page load. Keyboard-only users will still likely find these pages to be labor-intensive, but hopefully not too frustrating. Screen-reader users and people using voice navigation hopefully have enough hooks in the headings, etc. to make it convenient, if not ideal. 