### PR TITLE
Document atypical route

### DIFF
--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -81,7 +81,7 @@ urlpatterns = [
         # /user
         url(r'^user/?$', views.LinkUserView.as_view(), name='user'),
 
-        # /
+        # / ('/v1/' only, not '/v1')
         url(r'^$', root_view)
     ])),
 


### PR DESCRIPTION
I noticed this when setting up the new UptimeRobot monitors: the "root" api view is only available with a trailing slash, due to the way we've structured the "include."

I don't think it's worth rewriting every single api route to explicitly include an initial slash so that we can avoid this one quirk.  But if others disagree, I'm happy to.