### PR TITLE
Restore appearance of single-link dropdown

### DIFF
--- a/perma_web/static/bundles/single-link-styles.css
+++ b/perma_web/static/bundles/single-link-styles.css
@@ -5384,6 +5384,55 @@ li.dropdown {
   margin: 0;
 }
 
+.dropdown-inner-list {
+  padding-left: 0;
+}
+
+.dropdown-inner-list > li {
+  list-style: none;
+}
+
+.dropdown-inner-list > li > a,
+.dropdown-inner-list > li button {
+  color: black;
+  font-family: "Roboto", Helvetica, Arial, "Lucida Grande", sans-serif;
+  padding: 4px 12px 4px 24px;
+  font-size: 17px;
+  text-align: right;
+}
+
+.dropdown-inner-list > li > a:hover,
+.dropdown-inner-list > li > a:focus,
+.dropdown-inner-list > li button:hover,
+.dropdown-inner-list > li button:focus {
+  background-color: #0092FF;
+  color: white;
+}
+
+.dropdown-inner-list > li form {
+  margin: 0;
+  text-align: right;
+}
+
+.dropdown-inner-list > li button {
+  font-weight: 400;
+  border: none;
+  background-color: transparent;
+  width: 100%;
+  border-radius: 0;
+}
+
+.dropdown-inner-list a,
+.dropdown-inner-list button {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333333;
+  white-space: nowrap;
+}
+
 /*
 ._expanded .navbar-nav { // review
   position: relative;
@@ -5529,6 +5578,8 @@ li.dropdown {
 }
 
 .dropdown-header {
+  margin-top: 0;
+  margin-bottom: 0;
   font-family: "Roboto", Helvetica, Arial, "Lucida Grande", sans-serif;
   font-weight: 400;
   letter-spacing: 1px;

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -815,6 +815,21 @@ li.dropdown {
   margin: 0;
 }
 
+.dropdown-inner-list {
+  @include style-dropdown-items;
+  padding-left: 0;
+
+  & a, & button {
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: normal;
+    line-height: 1.42857143;
+    color: #333333;
+    white-space: nowrap;
+  }
+}
+
 /*
 ._expanded .navbar-nav { // review
   position: relative;
@@ -921,6 +936,8 @@ li.dropdown {
 }
 
 .dropdown-header {
+  margin-top: 0;
+  margin-bottom: 0;
   font-family: $font-hed-alt;
   font-weight: 400;
   letter-spacing: 1px;


### PR DESCRIPTION
I didn't realize the 'include' for the main dropdown was reused on the single-link page, and broke it in https://github.com/harvard-lil/perma/pull/2271

This restores the appearance. It makes no attempt to fix the accessibility of that page, or apply other changes I made to the main nav in #2271. That's a project for another day!