### PR TITLE
Pass urls to LinkBatch creation API route

### DIFF
--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -57,9 +57,9 @@ urlpatterns = [
         # /archives
         url(legacy_user_prefix + r'archives/?$', views.AuthenticatedLinkListView.as_view(), name='archives'),
         # /archives/batches
-        url(legacy_user_prefix + r'archives/batches/?$', views.LinkBatchesListView.as_view()),
+        url(legacy_user_prefix + r'archives/batches/?$', views.LinkBatchesListView.as_view(), name='link_batches'),
         # /batches/archives/:id
-        url(legacy_user_prefix + r'archives/batches/(?P<pk>[0-9]+)/?$', views.LinkBatchesDetailView.as_view()),
+        url(legacy_user_prefix + r'archives/batches/(?P<pk>[0-9]+)/?$', views.LinkBatchesDetailView.as_view(), name='link_batch'),
         # /archives/:guid
         url(legacy_user_prefix + r'archives/%s/?$' % guid_pattern, views.AuthenticatedLinkDetailView.as_view(), name='archives'),
         # /archives/:guid/download

--- a/perma_web/api/utils.py
+++ b/perma_web/api/utils.py
@@ -5,13 +5,16 @@ from functools import wraps
 import json
 
 from django.http import Http404
+from django.urls import resolve, reverse
 from django.urls.exceptions import NoReverseMatch
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
+from rest_framework.reverse import reverse as drf_reverse
 from rest_framework.settings import api_settings
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import exception_handler
 
 from perma.models import Folder
 
@@ -152,6 +155,17 @@ def url_is_invalid_unicode(url_string):
     return False
 
 def reverse_api_view(viewname, *args, **kwargs):
+    # Requires request as a kwarg.
+    #
+    # Reverse needs to be called with the api namespace when the
+    # request is made to perma.cc/api, and cannot be called with
+    # a namespace when the request is made to api.perma.cc
+    try:
+        return drf_reverse('api:' + viewname, *args, **kwargs)
+    except NoReverseMatch:
+        return drf_reverse(viewname, *args, **kwargs)
+
+def reverse_api_view_relative(viewname, *args, **kwargs):
     # Reverse needs to be called with the api namespace when the
     # request is made to perma.cc/api, and cannot be called with
     # a namespace when the request is made to api.perma.cc
@@ -166,3 +180,39 @@ def get_or_none(model, pk):
         return model.objects.get(pk=pk)
     except model.DoesNotExist:
         return None
+
+def dispatch_multiple_requests(user, call_list):
+    """
+    Makes a series of internal api "calls" on behalf of a user,
+    all within a single http request/response cycle.
+
+    The call_list should be series of dictionaries specifying:
+        "path", the api route to "call" (e.g. /v1/folders/22/archives/)
+        "verb", the http verb to use (e.g. "GET")
+        (optional)
+        "data": a dictionary of data to send with the request,
+                i.e., the data that would normally be sent as JSON
+                when hitting the api route
+
+    A list of dictionaries will be returned reporting:
+        "status_code": the http status code returned by the "call"
+        "status_text": the text associated with the http status code
+        "data": the data returned by the call, i.e., the data that would
+                normally be converted to JSON and transmitted as the http body
+    """
+    factory = APIRequestFactory()
+    responses = []
+    for call in call_list:
+        try:
+            view, args, kwargs = resolve(call['path'])
+            request = getattr(factory, call['verb'].lower())(call['path'], data=call.get('data', {}))
+            request.user = user
+            response = view(request, *args, **kwargs)
+        except Exception as exception:
+            response = exception_handler(exception, {})
+        responses.append({
+            'status_code': response.status_code,
+            'status_text': response.status_text,
+            'data': response.data
+        })
+    return responses

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -13582,35 +13582,15 @@ webpackJsonp([1],[
 	    $input.hide();
 	    spinner.spin($spinner[0]);
 	    APIModule.request('POST', '/archives/batches/', {
-	        "target_folder": target_folder
+	        "target_folder": target_folder,
+	        "urls": $input_area.val().split("\n").map(function (s) {
+	            return s.trim();
+	        })
 	    }).then(function (batch_object) {
 	        var batch_id = batch_object.id;
-	        var urls = $input_area.val().split("\n").map(function (s) {
-	            return s.trim();
-	        });
-	        var num_requests = 0;
-	        urls.forEach(function (url) {
-	            return APIModule.request('POST', '/archives/', {
-	                folder: target_folder,
-	                link_batch_id: batch_id,
-	                url: url
-	            }, { "error": function error(jqXHR) {} }).then(function (response) {
-	                num_requests += 1;
-	            }).fail(function (err) {
-	                num_requests += 1;
-	                console.error(err);
-	            });
-	        });
-	        var check_status = function check_status() {
-	            if (num_requests === urls.length) {
-	                clearInterval(interval);
-	                show_batch(batch_object.id);
-	                var template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', { "link_batches": [batch_object] });
-	                $batch_history.prepend(template);
-	            }
-	        };
-	        check_status();
-	        var interval = setInterval(check_status, 500);
+	        show_batch(batch_object.id);
+	        var template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', { "link_batches": [batch_object] });
+	        $batch_history.prepend(template);
 	    });
 	};
 	

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -13567,6 +13567,9 @@ webpackJsonp([1],[
 	            if (all_completed) {
 	                clearInterval(interval);
 	            }
+	        }).catch(function () {
+	            clearInterval(interval);
+	            $modal.modal("hide");
 	        });
 	    };
 	    retrieve_and_render();
@@ -13591,6 +13594,8 @@ webpackJsonp([1],[
 	        show_batch(batch_object.id);
 	        var template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', { "link_batches": [batch_object] });
 	        $batch_history.prepend(template);
+	    }).catch(function () {
+	        $modal.modal("hide");
 	    });
 	};
 	
@@ -13616,9 +13621,13 @@ webpackJsonp([1],[
 	
 	function populate_link_batch_list() {
 	    if (settings.ENABLE_BATCH_LINKS) {
-	        APIModule.request("GET", "/archives/batches/", { "limit": 15 }).done(function (data) {
+	        APIModule.request("GET", "/archives/batches/", {
+	            "limit": 15
+	        }).then(function (data) {
 	            var template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', { "link_batches": data.objects });
 	            $batch_history.append(template);
+	        }).catch(function () {
+	            $batch_history.append('<p>(unavailable)</p>');
 	        });
 	    }
 	}

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -93,35 +93,13 @@ function start_batch() {
     $input.hide();
     spinner.spin($spinner[0]);
     APIModule.request('POST', '/archives/batches/', {
-        "target_folder": target_folder
+        "target_folder": target_folder,
+        "urls": $input_area.val().split("\n").map(s => {return s.trim()})
     }).then(function(batch_object) {
         let batch_id = batch_object.id;
-        let urls = $input_area.val()
-            .split("\n")
-            .map(s => {return s.trim()});
-        let num_requests = 0;
-        urls.forEach(function(url) {
-            return APIModule.request('POST', '/archives/', {
-                folder: target_folder,
-                link_batch_id: batch_id,
-                url: url
-            }, { "error": function(jqXHR) {} }).then(function(response) {
-                num_requests += 1;
-            }).fail(function(err) {
-                num_requests += 1;
-                console.error(err);
-            });
-        });
-        let check_status = function(){
-            if (num_requests === urls.length) {
-                clearInterval(interval);
-                show_batch(batch_object.id);
-                let template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', {"link_batches": [batch_object]});
-                $batch_history.prepend(template);
-            }
-        }
-        check_status();
-        let interval = setInterval(check_status, 500);
+        show_batch(batch_object.id);
+        let template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', {"link_batches": [batch_object]});
+        $batch_history.prepend(template);
     });
 };
 

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -72,13 +72,18 @@ function show_batch(batch_id) {
         spinner.spin($spinner[0]);
     }
     let retrieve_and_render = function() {
-        APIModule.request('GET', `/archives/batches/${batch_id}`).then(function(batch_data) {
+        APIModule.request(
+            'GET', `/archives/batches/${batch_id}`
+        ).then(function(batch_data) {
             let folder_path = FolderTreeModule.getPathForId(batch_data.target_folder).join(" > ");
             let all_completed = render_batch(batch_data.capture_jobs, folder_path);
             if (all_completed) {
                 clearInterval(interval);
             }
-        })
+        }).catch(function(){
+            clearInterval(interval);
+            $modal.modal("hide");
+        });
     }
     retrieve_and_render();
     let interval = setInterval(retrieve_and_render, 2000);
@@ -100,6 +105,8 @@ function start_batch() {
         show_batch(batch_object.id);
         let template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', {"link_batches": [batch_object]});
         $batch_history.prepend(template);
+    }).catch(function(){
+        $modal.modal("hide");
     });
 };
 
@@ -125,10 +132,14 @@ function set_folder_from_dropdown(new_folder_id) {
 
 function populate_link_batch_list() {
     if (settings.ENABLE_BATCH_LINKS) {
-        APIModule.request("GET", "/archives/batches/", {"limit": 15}).done(function(data) {
+        APIModule.request("GET", "/archives/batches/", {
+            "limit": 15
+        }).then(function(data) {
             let template = HandlebarsHelpers.renderTemplate('#link-batch-history-template', {"link_batches": data.objects});
             $batch_history.append(template);
-        })
+        }).catch(function(){
+            $batch_history.append('<p>(unavailable)</p>')
+        });
     }
 }
 


### PR DESCRIPTION
Pass urls to LinkBatch creation API route, instead of having to first create a batch and then add individual links to that batch via the standard archive creation api route. This:
-  streamlines the batch creation process and simplifies the js
-  prevents the addition of links to batches at arbitrary times
-  eliminates the need to add code to make sure users aren't attempting to add links to someone else's batch (code that was not present to this point: you could simply guess a batch id and if you were right, you could add links to that batch)

But the code is unusual. It is an adaptation of one of the experiments from this January (https://github.com/harvard-lil/perma/compare/develop...rebeccacremona:bulk-experimenting), where I created a route for sending Perma a "batch" of arbitrary Perma API requests, bundled up, and getting the results back. This uses the same technique, but instead of exposing a route to the world, adds a private utility function for use within api view functions. 

It's a little wacky, but I don't think it's sketchy, and it comes in handy twice in the BatchLink creation route. I think it will also come in handy later, when we add the functionality to move all links in a batch from one folder to another, and other bulk functionality like creating many org users at once, etc.

But we should have a think on this one.