### PR TITLE
Handle keyboard focus; report batch progress.

### DIFF
--- a/perma_web/perma/templates/archive/includes/link_batch_modal.html
+++ b/perma_web/perma/templates/archive/includes/link_batch_modal.html
@@ -8,7 +8,8 @@
         </button>
         <h3 id="batch-modal-title" class="modal-title">Batch Link Creation</h3>
       </div>
-      <div class="spinner _hide"></div>
+      <div class="spinner _hide">
+      <span class="sr-only" id="loading" tabindex="-1">Loading</span></div>
       <div class="modal-body">
 
         <div id="batch-create-input">
@@ -26,7 +27,8 @@
         </div>
 
         <div id="batch-details-wrapper" class="_hide">
-          <div id="batch-details"></div>
+          <div id="batch-progress-report" tabindex="-1" class="sr-only" role="log" aria-atomic="false"></div>
+          <div id="batch-details" aria-describedby="batch-progress-report"></div>
           <div class="form-buttons">
             <button class="btn cancel" data-dismiss="modal">Exit</button>
             <a href="#" id="export-csv" class="btn _hide" target="_blank">Export list as CSV</a>

--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -41,7 +41,7 @@
             </button>
 
             {% if ENABLE_BATCH_LINKS %}
-            <p id="create-batch-links">or <a data-toggle="modal" href="#batch-modal">create multiple links</a></p>
+            <p id="create-batch-links">or <a id="create-batch" data-toggle="modal" href="#batch-modal">create multiple links</a></p>
             {% endif %}
           </div>
 

--- a/perma_web/static/js/hbs/batch-links.handlebars
+++ b/perma_web/static/js/hbs/batch-links.handlebars
@@ -1,6 +1,7 @@
+{{! NB: Tabindexes on these elements and their children are overridden via js}}
 <div class="form-group">
   <label id="batch-target" for="batch-target-path" class="label-affil">These Perma Links were added to (movable batches coming soon!)</label>
-  <select disabled class="form-control"><option>{{ folder }}</option></select>
+  <select id="batch-folder" class="form-control"><option>{{ folder }}</option></select>
 </div>
 <div class="form-group">
 {{#each links}}


### PR DESCRIPTION
Have I mentioned that this is a complex UI?

1) With all these modals popping up and down, we have to make sure keyboard focus gets set back to the element that opened them, on close.

2) When the form is submitted, the submit button is zapped, so we set focus to a hidden "Loading" message wrapped with the spinner. When the batch has been created, the spinner gets zapped, so we have to pass focus off again....

3) But there's still a fair amount of action happening: the list of links gets updated every 2 seconds until every link in the batch is complete. Handlebars is swapping in and out elements like mad: this is a minefield for keyboard/screen reader focus until the batch is complete. So, we rope it off for safety: until the batch is complete: all elements are made impossible to tab to, and the area is marked as aria-hidden.

4) Since that cuts off access to the progress bars, create a summary message of the form "Batch 67% done, 2 errors", and update that every two seconds as well. Make THAT element the focus target, when the spinner gets zapped in (2) above. And use aria-log so that screen readers will politely and sequentially announce the updates.

If a capture job borks and is marked as pending or in_progress forever, we're going to have a problem. But I don't think we can avoid it: we'll just have to fix the data (which we should probably be doing in the first place).