### PR TITLE
Filter out empty lines

### DIFF
--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -13915,7 +13915,7 @@ webpackJsonp([1],[
 	        "target_folder": target_folder,
 	        "urls": $input_area.val().split("\n").map(function (s) {
 	            return s.trim();
-	        })
+	        }).filter(Boolean)
 	    }).then(function (batch_object) {
 	        $modal_close.show();
 	        show_batch(batch_object.id);

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -108,7 +108,7 @@ function start_batch() {
     $spinner.removeClass("_hide");
     APIModule.request('POST', '/archives/batches/', {
         "target_folder": target_folder,
-        "urls": $input_area.val().split("\n").map(s => {return s.trim()})
+        "urls": $input_area.val().split("\n").map(s => {return s.trim()}).filter(Boolean)
     }).then(function(batch_object) {
         $modal_close.show();
         show_batch(batch_object.id);


### PR DESCRIPTION
Instead of submitting them and generating invalid capture jobs with the message "URL is a required field".