### PR TITLE
Pass along the HTTP_HOST so that DRF can produce absolute URLs.

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -569,7 +569,7 @@ class LinkBatchesListView(BaseView):
                         }
                     } for url in request.data.get('urls', [])
                 ]
-                dispatch_multiple_requests(request.user, call_list, {"batch": batch_id})
+                dispatch_multiple_requests(request, call_list, {"batch": batch_id})
                 # TODO: how can we communicate these errors to the user?
                 # if dispatch_multiple_requests returns to "responses"
                 # internal_server_errors = [
@@ -581,7 +581,7 @@ class LinkBatchesListView(BaseView):
                     'path': reverse_api_view_relative('link_batch', kwargs={"pk": batch_id}),
                     'verb': 'GET'
                 }]
-                response = dispatch_multiple_requests(request.user, call_for_fresh_serializer_data)
+                response = dispatch_multiple_requests(request, call_for_fresh_serializer_data)
                 data = response[0]['data'].copy()
                 data['links_remaining'] = request.user.get_links_remaining()
                 return Response(data, status=status.HTTP_201_CREATED)

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -3,7 +3,12 @@ from settings_common import *
 import os
 
 DEBUG = True
+HOST = 'perma.test:8000'
 WARC_HOST = 'perma-archives.test:8000'
+
+# Hosts/domain names that are valid for this site; required if DEBUG is False
+# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['perma.test', 'perma-archives.test']
 
 # logging
 LOGGING_DIR = os.path.join(SERVICES_DIR, 'logs')
@@ -22,16 +27,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'secret'
 
-# Hosts/domain names that are valid for this site; required if DEBUG is False
-# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['*']
-
 # Google Analytics
 GOOGLE_ANALYTICS_KEY = 'UA-XXXXX-X'
 GOOGLE_ANALYTICS_DOMAIN = 'example.com'
-
-# The host we want to display (used when DEBUG=False)
-HOST = 'perma.test:8000'
 
 CELERY_RESULT_BACKEND = 'amqp'
 

--- a/perma_web/perma/settings/deployments/settings_travis.py
+++ b/perma_web/perma/settings/deployments/settings_travis.py
@@ -19,6 +19,7 @@ DEFAULT_FROM_EMAIL = 'email@example.com'
 # The host we want to display (used when DEBUG=False)
 HOST = 'perma.cc'
 WARC_HOST = 'perma-archives.org'
+ALLOWED_HOSTS = ['perma.cc', 'perma-archives.org']
 
 # Where we store our generated assets (phantomjs images)
 MEDIA_ROOT = '/tmp/perma/assets'


### PR DESCRIPTION
This should solve the `Exception Value: Invalid HTTP_HOST header: 'testserver'.` we're seeing on stage when creating link batches as a result of my implementation of `dispatch_multiple_requests`.

The batch and all the links in the batch are being created correctly, but when serializing the individual links, DRF is trying to produce the absolute URL to download the WARC, and it can't, because the RequestFactory is setting the SERVER_NAME to `testserver`, which is not in ALLOWED_HOSTS:

```
    def _get_raw_host(self):
        """
        Return the HTTP host using the environment or request headers. Skip
        allowed hosts protection, so may return an insecure host.
        """
        # We try three options, in order of decreasing preference.
        if settings.USE_X_FORWARDED_HOST and (
                'HTTP_X_FORWARDED_HOST' in self.META):
            host = self.META['HTTP_X_FORWARDED_HOST']
        elif 'HTTP_HOST' in self.META:
            host = self.META['HTTP_HOST']
        else:
            # Reconstruct the host using the algorithm from PEP 333.
            host = self.META['SERVER_NAME']
            server_port = self.get_port()
            if server_port != ('443' if self.is_secure() else '80'):
                host = '%s:%s' % (host, server_port)
        return host

[docs]    def get_host(self):
        """Return the HTTP host using the environment or request headers."""
        host = self._get_raw_host()

        # Allow variants of localhost if ALLOWED_HOSTS is empty and DEBUG=True.
        allowed_hosts = settings.ALLOWED_HOSTS
        if settings.DEBUG and not allowed_hosts:
            allowed_hosts = ['localhost', '127.0.0.1', '[::1]']

        domain, port = split_domain_port(host)
        if domain and validate_host(domain, allowed_hosts):
            return host
        else:
            msg = "Invalid HTTP_HOST header: %r." % host
            if domain:
                msg += " You may need to add %r to ALLOWED_HOSTS." % domain
            else:
                msg += " The domain name provided is not valid according to RFC 1034/1035."
            raise DisallowedHost(msg)
```
By setting HTTP_HOST using the original request, this should now work.

If dispatch_multiple proves fragile, we could try copying much or all of the original request object instead, but hopefully this will not prove necessary.

The reason the user isn't seeing any errors is:
1) I have not yet worked out the correct way to report/display these errors: https://github.com/harvard-lil/perma/blob/develop/perma_web/api/views.py#L573
2) The modal populates based on a fresh call for info: https://github.com/harvard-lil/perma/blob/develop/perma_web/api/views.py#L584, not based on the results returned from the link-creating call. The fresh call does not include any absolute URLS, so did not run into this problem.