### PR TITLE
Deleted links, batch interface and API

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -107,16 +107,20 @@ class OrganizationSerializer(BaseSerializer):
 class CaptureJobSerializer(BaseSerializer):
     guid = serializers.PrimaryKeyRelatedField(source='link', read_only=True)
     title = serializers.SerializerMethodField()
+    user_deleted = serializers.SerializerMethodField()
 
     class Meta:
         model = CaptureJob
-        fields = ('guid', 'status', 'message', 'submitted_url', 'attempt', 'step_count', 'step_description', 'capture_start_time', 'capture_end_time', 'queue_position', 'title')
+        fields = ('guid', 'status', 'message', 'submitted_url', 'attempt', 'step_count', 'step_description', 'capture_start_time', 'capture_end_time', 'queue_position', 'title', 'user_deleted')
 
     def get_title(self, capture_job):
         if capture_job.link is None:
             return ""
         else:
             return capture_job.link.submitted_title
+
+    def get_user_deleted(self, capture_job):
+        return capture_job.link and capture_job.link.user_deleted
 
 ### CAPTURE ###
 
@@ -168,7 +172,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
     organization = OrganizationSerializer(read_only=True)
 
     class Meta(LinkSerializer.Meta):
-        fields = LinkSerializer.Meta.fields + ('notes', 'created_by', 'is_private', 'private_reason', 'archive_timestamp', 'organization')
+        fields = LinkSerializer.Meta.fields + ('notes', 'created_by', 'is_private', 'private_reason', 'user_deleted', 'archive_timestamp', 'organization')
         allowed_update_fields = ['submitted_title', 'submitted_description', 'notes', 'is_private', 'private_reason']
 
     def get_warc_download_url(self, link):

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -14148,6 +14148,8 @@ webpackJsonp([1],[
 	
 	  return "  <div class=\"item-container "
 	    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isError : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+	    + " "
+	    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.user_deleted : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
 	    + "\">\n    <div class=\"row\">\n"
 	    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isError : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "")
 	    + "    </div>\n  </div>\n";
@@ -14162,24 +14164,28 @@ webpackJsonp([1],[
 	    + alias2(alias1((depth0 != null ? depth0.submitted_url : depth0), depth0))
 	    + "</div>\n        </div>\n";
 	},"6":function(container,depth0,helpers,partials,data) {
-	    var stack1, alias1=container.lambda, alias2=container.escapeExpression;
+	    var stack1, alias1=depth0 != null ? depth0 : {}, alias2=container.lambda, alias3=container.escapeExpression;
 	
-	  return "        <div class=\"link-desc col col-sm-6 col-md-60\">\n          <div class=\"item-title\">"
-	    + alias2(alias1((depth0 != null ? depth0.title : depth0), depth0))
+	  return "        <div class=\"link-desc col col-sm-6 col-md-60\">\n          "
+	    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.user_deleted : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+	    + "\n          <div class=\"item-title\">"
+	    + alias3(alias2((depth0 != null ? depth0.title : depth0), depth0))
 	    + "</div>\n          <div class=\"item-subtitle\">"
-	    + alias2(alias1((depth0 != null ? depth0.submitted_url : depth0), depth0))
+	    + alias3(alias2((depth0 != null ? depth0.submitted_url : depth0), depth0))
 	    + "</div>\n        </div>\n        <div class=\"link-progress col col-sm-6 col-md-40 align-right item-permalink\">\n"
-	    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isProcessing : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.program(9, data, 0),"data":data})) != null ? stack1 : "")
+	    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isProcessing : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "")
 	    + "        </div>\n";
 	},"7":function(container,depth0,helpers,partials,data) {
-	    var stack1;
-	
-	  return ((stack1 = container.invokePartial(__webpack_require__(154),depth0,{"name":"progress-bar","hash":{"progress":(depth0 != null ? depth0.progress : depth0)},"data":data,"indent":"            ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+	    return "<div class=\"failed_header\">Deleted</div>";
 	},"9":function(container,depth0,helpers,partials,data) {
 	    var stack1;
 	
-	  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isComplete : depth0),{"name":"if","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-	},"10":function(container,depth0,helpers,partials,data) {
+	  return ((stack1 = container.invokePartial(__webpack_require__(154),depth0,{"name":"progress-bar","hash":{"progress":(depth0 != null ? depth0.progress : depth0)},"data":data,"indent":"            ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+	},"11":function(container,depth0,helpers,partials,data) {
+	    var stack1;
+	
+	  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isComplete : depth0),{"name":"if","hash":{},"fn":container.program(12, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+	},"12":function(container,depth0,helpers,partials,data) {
 	    var alias1=container.lambda, alias2=container.escapeExpression;
 	
 	  return "            <a class=\"perma no-drag\" href=\"//"

--- a/perma_web/static/js/hbs/batch-links.handlebars
+++ b/perma_web/static/js/hbs/batch-links.handlebars
@@ -5,7 +5,7 @@
 </div>
 <div class="form-group">
 {{#each links}}
-  <div class="item-container {{#if isError}} _isFailed{{/if}}">
+  <div class="item-container {{#if isError}} _isFailed{{/if}} {{#if user_deleted}} _isFailed{{/if}}">
     <div class="row">
       {{#if isError }}
         <div class="link-desc col col-sm-6 col-md-60">
@@ -15,6 +15,7 @@
         </div>
       {{ else }}
         <div class="link-desc col col-sm-6 col-md-60">
+          {{#if user_deleted}}<div class="failed_header">Deleted</div>{{/if}}
           <div class="item-title">{{ title }}</div>
           <div class="item-subtitle">{{ submitted_url }}</div>
         </div>


### PR DESCRIPTION
In the regular link list, deleted links do not appear. That's appropriate, because the link list shows the "contents" of a folder: you would not expect deleted things to remain.

The batch modal is different: if you subsequently delete all the links in a batch, you wouldn't expect to see an empty modal!

This PR adds deletion status to the CaptureJob and Link api results, and adds some styling etc. to the batch modal.

![image](https://user-images.githubusercontent.com/11020492/40068109-cffc47a6-5835-11e8-8762-22742caff3ac.png)
