### PR TITLE
Batch folder selection dropdown

### DIFF
--- a/perma_web/perma/templates/archive/includes/link_batch_modal.html
+++ b/perma_web/perma/templates/archive/includes/link_batch_modal.html
@@ -21,7 +21,7 @@
             <textarea aria-label="Paste your URLs here (one URL per line)" placeholder="Paste your URLs here (one URL per line)"></textarea>
           </div>
           <div class="form-buttons">
-            <button id="start-batch" class="btn">Create Links</button>
+            <button id="start-batch" class="btn" disabled="disabled">Create Links</button>
             <button class="btn cancel" data-dismiss="modal">Cancel</button>
           </div>
         </div>

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -1940,7 +1940,7 @@ webpackJsonp([1],[
 /* 103 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function($) {'use strict';
+	/* WEBPACK VAR INJECTION */(function($) {"use strict";
 	
 	Object.defineProperty(exports, "__esModule", {
 	    value: true
@@ -1950,6 +1950,7 @@ webpackJsonp([1],[
 	
 	function makeFolderSelector($folder_selector, current_folder_id) {
 	    $folder_selector.empty();
+	    $folder_selector.append("<option disabled selected value> Please select a folder </option>");
 	
 	    // recursively populate select ...
 	    function addChildren(node, depth) {
@@ -1962,7 +1963,8 @@ webpackJsonp([1],[
 	            $folder_selector.append($("<option/>", {
 	                value: childNode.data.folder_id,
 	                text: childNode.text.trim(),
-	                selected: childNode.data.folder_id == current_folder_id
+	                selected: childNode.data.folder_id == current_folder_id,
+	                "data-orgid": childNode.data.organization_id
 	            }).prepend(new Array(depth).join('&nbsp;&nbsp;&nbsp;&nbsp;')));
 	
 	            // recurse
@@ -13810,6 +13812,7 @@ webpackJsonp([1],[
 	var ErrorHandler = __webpack_require__(79);
 	var FolderTreeModule = __webpack_require__(104);
 	var FolderSelectorHelper = __webpack_require__(103);
+	var Helpers = __webpack_require__(92);
 	var Modals = __webpack_require__(155);
 	var ProgressBarHelper = __webpack_require__(153);
 	
@@ -13967,6 +13970,7 @@ webpackJsonp([1],[
 	
 	function refresh_target_path_dropdown() {
 	    FolderSelectorHelper.makeFolderSelector($batch_target_path, target_folder);
+	    $start_button.prop('disabled', !Boolean(target_folder));
 	};
 	
 	function set_folder_from_trigger(evt, data) {
@@ -14006,7 +14010,23 @@ webpackJsonp([1],[
 	}
 	
 	function setup_handlers() {
+	    // listen for folder changes from other UI components
 	    $(window).on('FolderTreeModule.selectionChange', set_folder_from_trigger).on('dropdown.selectionChange', set_folder_from_trigger);
+	
+	    // update all UI components when folder changed using the modal's dropdown
+	    $batch_target_path.change(function () {
+	        var new_folder_id = $(this).val();
+	        if (new_folder_id) {
+	            $start_button.prop('disabled', false);
+	            set_folder_from_dropdown(new_folder_id);
+	            Helpers.triggerOnWindow("dropdown.selectionChange", {
+	                folderId: $(this).val(),
+	                orgId: $(this).data('orgid')
+	            });
+	        } else {
+	            $start_button.prop('disabled', true);
+	        }
+	    });
 	
 	    $modal.on('shown.bs.modal', refresh_target_path_dropdown).on('hidden.bs.modal', function () {
 	        $input.show();
@@ -14019,11 +14039,6 @@ webpackJsonp([1],[
 	        $batch_progress_report.empty();
 	    }).on('hide.bs.modal', function () {
 	        clearInterval(interval);
-	    });
-	
-	    $batch_target_path.change(function () {
-	        var new_folder_id = $(this).val();
-	        set_folder_from_dropdown(new_folder_id);
 	    });
 	
 	    $start_button.click(start_batch);

--- a/perma_web/static/js/helpers/folder-selector.helper.js
+++ b/perma_web/static/js/helpers/folder-selector.helper.js
@@ -2,6 +2,7 @@ var FolderTreeModule = require('../folder-tree.module.js');
 
 export function makeFolderSelector($folder_selector, current_folder_id) {
     $folder_selector.empty();
+    $folder_selector.append("<option disabled selected value> Please select a folder </option>");
 
     // recursively populate select ...
     function addChildren(node, depth) {
@@ -15,7 +16,8 @@ export function makeFolderSelector($folder_selector, current_folder_id) {
                 $("<option/>", {
                     value: childNode.data.folder_id,
                     text: childNode.text.trim(),
-                    selected: childNode.data.folder_id == current_folder_id
+                    selected: childNode.data.folder_id == current_folder_id,
+                    "data-orgid": childNode.data.organization_id
                 }).prepend(
                     new Array(depth).join('&nbsp;&nbsp;&nbsp;&nbsp;')
                 )


### PR DESCRIPTION
1) Make it clear when no folder is selected by including a default, blank option in the dropdown, labeled, "Please select a folder".
2) Disable the button for creating a batch unless a folder is selected.
3) When a user selects a folder, announce that change so that the FolderTree and LinkList modules update the UI accordingly and everything works as expected. (Since links are being added to the link list in the background, etc., this is actually necessary, even if you can't see what's happening behind the modal.)