### PR TITLE
CaptureJob failure messages and cleanup of old jobs

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -21,6 +21,7 @@ from time import mktime
 from wsgiref.handlers import format_date_time
 
 from mptt.managers import TreeManager
+from rest_framework.settings import api_settings
 from simple_history.models import HistoricalRecords
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
@@ -1387,7 +1388,12 @@ class CaptureJob(models.Model):
         """
         self.status = status
         self.capture_end_time = timezone.now()
-        self.save(update_fields=['status', 'capture_end_time'])
+        self.save(update_fields=['status', 'capture_end_time', 'message'])
+
+    def mark_failed(self, message):
+        """ Mark job as failed, and record message in format for front-end display. """
+        self.message = json.dumps({api_settings.NON_FIELD_ERRORS_KEY: [message]})
+        self.mark_completed('failed')
 
     def accessible_to(self, user):
         return self.link.accessible_to(user)

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1114,7 +1114,7 @@ def run_next_capture():
         finally:
             capture_job.link.captures.filter(status='pending').update(status='failed')
             if capture_job.status == 'in_progress':
-                capture_job.mark_completed('failed')
+                capture_job.mark_failed('Failed during capture.')
     run_task(run_next_capture.s())
 
 

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -800,6 +800,19 @@ def save_favicons(link, successful_favicon_urls):
         ).save()
         print "Saved favicons %s" % successful_favicon_urls
 
+def clean_up_failed_captures():
+    """
+        Clean up any existing jobs that are marked in_progress but must have timed out by now, based on our hard timeout
+        setting.
+    """
+    # use database time with a custom where clause to ensure consistent time across workers
+    for capture_job in CaptureJob.objects.filter(status='in_progress').select_related('link').extra(
+            where=["capture_start_time < now() - INTERVAL %s second" % settings.CELERYD_TASK_TIME_LIMIT]
+    ):
+        capture_job.mark_failed("Timed out.")
+        capture_job.link.captures.filter(status='pending').update(status='failed')
+        capture_job.link.tags.add('hard-timeout-failure')
+
 ### CONTEXT MANAGERS
 
 @contextmanager
@@ -830,6 +843,9 @@ def run_next_capture():
     """
         Grab and run the next CaptureJob. This will keep calling itself until there are no jobs left.
     """
+    clean_up_failed_captures()
+
+    # get job to work on
     capture_job = CaptureJob.get_next_job(reserve=True)
     if not capture_job:
         return  # no jobs waiting


### PR DESCRIPTION
- Make sure we set CaptureJob.message when setting status='failed', in the same format that we sometimes do now (`'{"errors":["reason"]}'`).
- Whenever `run_next_capture` is run (which should be at least once a minute due to celerybeat), mark any jobs as failed that have been in_progress longer than the celery hard timeout.

Note that this will update all the jobs we currently have on prod that managed to stick around as in_progress in the past. I think it's safe to say we're not planning to do anything with those at this point anyway. But it will also set `capture_job.link.tags.add('hard-timeout-failure')` on those jobs, so we could find them if necessary.