### PR TITLE
Reload folder tree when opening batch

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -52,15 +52,19 @@ class LinkUserSerializer(BaseSerializer):
 
 class FolderSerializer(BaseSerializer):
     has_children = serializers.SerializerMethodField()
+    path = serializers.SerializerMethodField()
 
     class Meta:
         model = Folder
-        fields = ('id', 'name', 'parent', 'has_children', 'organization')
+        fields = ('id', 'name', 'parent', 'has_children', 'path', 'organization')
         extra_kwargs = {'parent': {'required': True, 'allow_null': False}}
         allowed_update_fields = ['name', 'parent']
 
     def get_has_children(self, folder):
         return not folder.is_leaf_node()
+
+    def get_path(self, folder):
+        return '-'.join([str(f.id) for f in folder.get_ancestors(include_self=True)])
 
     def validate_name(self, name):
         if self.instance:
@@ -274,6 +278,15 @@ class AuthenticatedLinkSerializer(LinkSerializer):
 
 class LinkBatchSerializer(BaseSerializer):
     capture_jobs = CaptureJobSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = LinkBatch
+        fields = ('id', 'started_on', 'created_by', 'capture_jobs', 'target_folder')
+
+
+class DetailedLinkBatchSerializer(BaseSerializer):
+    capture_jobs = CaptureJobSerializer(many=True, read_only=True)
+    target_folder = FolderSerializer(read_only=True)
 
     class Meta:
         model = LinkBatch

--- a/perma_web/static/js/folder-tree.module.js
+++ b/perma_web/static/js/folder-tree.module.js
@@ -111,7 +111,13 @@ function getNodeByFolderID (folderId) {
 }
 
 function handleSelectionChange (e, data) {
-  ls.setCurrent(parseInt(data.orgId),[parseInt(data.folderId)]);
+  let folderList;
+  if (Array.isArray(data.folderId)) {
+    folderList = data.folderId.map(x => parseInt(x));
+  } else {
+    folderList = [parseInt(data.folderId)]
+  }
+  ls.setCurrent(parseInt(data.orgId),folderList);
   folderTree.close_all();
   folderTree.deselect_all();
   selectSavedFolder();
@@ -367,6 +373,8 @@ function domTreeInit () {
       // (without this, doesn't select saved folders on load.)
       selectSavedFolder();
 
+    }).on('ready.jstree', function (e, data) {
+      Helpers.triggerOnWindow("folderTree.ready");
     })
 
     // track currently hovered node in the hoveredNode variable:
@@ -404,6 +412,11 @@ function setupEventHandlers () {
   $(window)
     .on('dropdown.selectionChange', function(e, data){
       handleSelectionChange(e, data);
+    })
+    .on('batchLink.reloadTreeForFolder', function(e, data) {
+      handleSelectionChange(e, data);
+      folderTree.destroy();
+      domTreeInit();
     })
     .on('LinksListModule.moveLink', function(evt, data) {
       data = JSON.parse(data);

--- a/perma_web/static/js/hbs/link-batch-history.handlebars
+++ b/perma_web/static/js/hbs/link-batch-history.handlebars
@@ -1,7 +1,7 @@
 <ul class="item-container">
 {{# each link_batches}}
   <li class="item-subtitle">
-    <a href="#" data-batch={{ id }} data-folder="{{ target_folder }}"><span class="sr-only">Batch created </span>{{ human_timestamp started_on }}</a>
+    <a href="#" data-batch={{ id }} data-folderpath="{{ target_folder.path }}" data-org="{{ target_folder.organization}}"><span class="sr-only">Batch created </span>{{ human_timestamp started_on }}</a>
   </li>
 {{/each}}
 </ul>

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -109,7 +109,7 @@ function show_batch(batch_id) {
                 // prevents tabbing to elements that are getting swapped out
                 $batch_details.find('*').each(function(){$(this).attr('tabIndex', '-1')});
             }
-            let folder_path = FolderTreeModule.getPathForId(batch_data.target_folder).join(" > ");
+            let folder_path = FolderTreeModule.getPathForId(batch_data.target_folder.id).join(" > ");
             let all_completed = render_batch(batch_data.capture_jobs, folder_path);
             if (all_completed) {
                 clearInterval(interval);
@@ -238,9 +238,19 @@ function setup_handlers() {
 
     $batch_history.delegate('a[data-batch]', 'click', function(e) {
         e.preventDefault();
-        $input.hide();
-        show_modal_with_batch(this.dataset.batch, parseInt(this.dataset.folder));
-        Modals.returnFocusTo(this);
+        let batch = this.dataset.batch;
+        let folderPath= this.dataset.folderpath;
+        let org = parseInt(this.dataset.org);
+        Helpers.triggerOnWindow('batchLink.reloadTreeForFolder', {
+          folderId: folderPath.split('-'),
+          orgId: org
+        });
+        $(window).bind("folderTree.ready.batchToggle", () => {
+          $input.hide();
+          show_modal_with_batch(batch);
+          Modals.returnFocusTo(this);
+          $(window).unbind("folderTree.ready.batchToggle");
+        });
     });
 
     $batch_history.delegate('#all-batches', 'click', function(e) {


### PR DESCRIPTION
The whole UI updates to display the target folder of the batch. Since folders are lazy-loaded, that target folder may not yet have been retrieved by the API. (This will be the case every time a batch is associated with a child folder not-yet-viewed in the current browser tab). 

This PR reloads the folder tree when you open the modal for a batch in your batch history.

closes https://github.com/harvard-lil/perma/issues/2361