### PR TITLE
Capture requests initiated by the modal are "human" for timing purposes.

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -567,7 +567,8 @@ class LinkBatchesListView(BaseView):
                         'verb': 'POST',
                         'data': {
                             'url': url,
-                            'folder': request.data['target_folder']
+                            'folder': request.data['target_folder'],
+                            'human': request.data.get('human', False)
                         }
                     } for url in request.data.get('urls', [])
                 ]

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -14010,7 +14010,8 @@ webpackJsonp([1],[
 	        "target_folder": target_folder,
 	        "urls": $input_area.val().split("\n").map(function (s) {
 	            return s.trim();
-	        }).filter(Boolean)
+	        }).filter(Boolean),
+	        "human": true
 	    }).then(function (data) {
 	        show_batch(data.id);
 	        populate_link_batch_list();

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -138,7 +138,8 @@ function start_batch() {
     $loading.focus();
     APIModule.request('POST', '/archives/batches/', {
         "target_folder": target_folder,
-        "urls": $input_area.val().split("\n").map(s => {return s.trim()}).filter(Boolean)
+        "urls": $input_area.val().split("\n").map(s => {return s.trim()}).filter(Boolean),
+        "human": true
     }).then(function(data) {
         show_batch(data.id);
         populate_link_batch_list();


### PR DESCRIPTION
Otherwise, batch links will see too big of a delay.