### PR TITLE
utf-8 encode all data in csv rows

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -627,5 +627,5 @@ class LinkBatchesDetailExportView(BaseView):
         response['Content-Disposition'] = 'attachment; filename="perma-batch-{}.csv"'.format(pk)
         writer = csv.DictWriter(response, fieldnames=formatted_data[0].keys())
         writer.writeheader()
-        writer.writerows(formatted_data)
+        writer.writerows([{k: v.encode('utf-8') for k,v in row.items()} for row in formatted_data])
         return response


### PR DESCRIPTION
note: it turns out Excel doesn't default to utf-8... you have to select it in the import wizard! weird.