### PR TITLE
Status codes

### DIFF
--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -45,9 +45,9 @@ class CommonViewsTestCase(PermaTestCase):
             self.assert_can_view_capture('3SLN-JHX9')
 
     def test_dark_archive(self):
-        response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'ABCD-0001'}})
+        response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'ABCD-0001'}}, require_status_code=403)
         self.assertIn("This record is private and cannot be displayed.", response.content)
-
+ 
         # check that top bar is displayed to logged-in users
         for user in self.users:
             self.log_in_user(user)
@@ -71,7 +71,7 @@ class CommonViewsTestCase(PermaTestCase):
         self.assertNotIn("Perma.cc can\'t display this file type on mobile", response.content)
 
     def test_deleted(self):
-        response = self.get('single_permalink', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}})
+        response = self.get('single_permalink', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}}, require_status_code=410)
         self.assertIn("This record has been deleted.", response.content)
 
     def test_misformatted_nonexistent_links_404(self):

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -190,6 +190,12 @@ def single_permalink(request, guid):
 
     response = render(request, 'archive/single-link.html', context)
 
+    # Adjust status code
+    if link.user_deleted:
+        response.status_code = 410
+    elif not context['can_view'] and link.is_private:
+        response.status_code = 403
+
     # Add memento headers
     response['Memento-Datetime'] = link.memento_formatted_date
     link_memento_headers = '<{0}>; rel="original"; datetime="{1}",<{2}>; rel="memento"; datetime="{1}",<{3}>; rel="timegate",<{4}>; rel="timemap"; type="application/link-format"'

--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -170,7 +170,7 @@ class PermaRoute(archivalrouter.Route):
                 # This will filter out links that have user_deleted=True
                 link = Link.objects.get(guid=guid)
             except Link.DoesNotExist:
-                raise_not_found(wbrequest.wb_url, timestamp=wbrequest.wb_url.timestamp)
+                raise_not_found(wbrequest.wb_url, timestamp=wbrequest.wb_url.timestamp if wbrequest.wb_url else None)
 
             if not wbrequest.wb_url:
                 # This is a bare request to /warc/1234-5678/ -- return so we can send a forward to submitted_url in PermaGUIDHandler.


### PR DESCRIPTION
Don't return 200 when users attempt to view deleted links or private links they aren't allowed to access.

Closes https://github.com/harvard-lil/perma/issues/2332 and https://github.com/harvard-lil/perma/issues/2331.

Note: if you attempt to access the public archives api route for deleted links, or if you attempt to access the link's playback directly at perma-archives, you will get 404, not 510, but altering that behavior is a little more intrusive and I'm not sure it's worth changing at this time. 