### PR TITLE
Remove reference to screenshot view.

### DIFF
--- a/perma_web/perma/templates/archive/archive-error.html
+++ b/perma_web/perma/templates/archive/archive-error.html
@@ -15,8 +15,8 @@
         <a href="{{ err_url }}" target="_top">view the link as it exists on the live site</a>.</p>
     {% else %}
       <p class="record-message-primary">Playback Unavailable</p>
-      <p class="record-message-secondary">We’re having trouble playing back this record’s Capture View. If this problem persists, please let us know. In the meantime, you could try the Screenshot View above.</p>
-      {% if DEBUG %}
+      <p class="record-message-secondary">We’re having trouble playing back this record’s Capture View. If this problem persists, please let us know.</p>
+      {% if DEBUG %} 
         <div>
           Error details (you are seeing this because DEBUG mode is on):<br><br>
 


### PR DESCRIPTION
Closes https://github.com/harvard-lil/perma/issues/1946.

This particular error page is displayed by our custom pywb error handler during playback. It doesn't have access to a Link object, only a url and an error message: not enough to recover the GUID being played back, and so not enough to determine whether a screenshot is available. So, I'm just removing the whole reference to the screenshot.