### PR TITLE
Upgrade Django taggit; pin pip for now.

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -36,6 +36,6 @@ RUN npm install \
 
 # pip
 COPY requirements.txt /perma/perma_web
-RUN pip install -U pip \
+RUN pip install -U "pip>=9,<10" \
     &&  pip install -r requirements.txt --src /usr/local/src \
     && rm requirements.txt

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -40,7 +40,7 @@ django-settings-context-processor==0.2
 django-simple-history==1.9.0
 django-sslserver==0.14
 django-storages==1.5.2
-django-taggit==0.20.2
+django-taggit==0.22.2
 django-webpack-loader==0.5.0
 django==1.11.13
 djangorestframework==3.6.2


### PR DESCRIPTION
Closes https://github.com/harvard-lil/perma/issues/1934.

Also pins pip in Docker, since not all our packages can handle pip 10. Sigh.