### PR TITLE
Install commonly used web fonts for better screen shots

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -26,6 +26,15 @@ RUN apt-get update \
     && apt-get install -y nano
 
 
+# Install commonly used web fonts for better screen shots.
+RUN echo "deb http://httpredir.debian.org/debian stretch main contrib" > /etc/apt/sources.list \
+    && echo "deb http://security.debian.org/ stretch/updates main contrib" >> /etc/apt/sources.list \
+    && echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections \
+    && apt-get update \
+    && apt-get install -y ttf-mscorefonts-installer
+RUN apt-get install -y fonts-roboto
+
+
 # npm
 COPY package.json /perma/perma_web
 COPY npm-shrinkwrap.json /perma/perma_web


### PR DESCRIPTION
This PR will add some commonly used web fonts to the web docker image. This will make some screenshots look more accurate. 

<img width="458" alt="image" src="https://user-images.githubusercontent.com/19284/42725003-4071b52c-877d-11e8-88a4-3c6ae96d376e.png">


