### PR TITLE
Load warcs from default storage to avoid permissions complications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
   - date
 
 script:
-  - fab dev.test_python
+  - fab dev.test_python:travis=True
   - fab dev.test_js
 
 after_failure:

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -64,15 +64,15 @@ def run_ssl(port="0.0.0.0:8000"):
 _default_tests = "perma api functional_tests lockss"
 
 @task
-def test(apps=_default_tests, pytest=True):
+def test(apps=_default_tests):
     """ Run perma tests. (For coverage, run `coverage report` after tests pass.) """
     reset_failed_test_files_folder()
-    test_python(apps, pytest)
+    test_python(apps)
     if apps == _default_tests:
         test_js()
 
 @task
-def test_python(apps=_default_tests, pytest=True):
+def test_python(apps=_default_tests, travis=False):
     """ Run Python tests. """
 
     # .pyc files can contain filepaths; this permits easy switching
@@ -88,12 +88,12 @@ def test_python(apps=_default_tests, pytest=True):
     tmp = tempfile.mkdtemp()
     try:
         shell_envs = {
-            'DJANGO__MEDIA_ROOT': tmp
+            'DJANGO__MEDIA_ROOT': os.path.join(tmp, '') #join ensures path ends in /
         }
         with shell_env(**shell_envs):
-            # all arguments to Fabric tasks are interpretted as strings
-            if pytest == 'False':
-                local("coverage run manage.py test --settings perma.settings.deployments.settings_testing %s" % (apps))
+            # NB: all arguments to Fabric tasks are interpreted as strings
+            if travis == 'True':
+                local("pytest %s --ds=perma.settings --cov --cov-report= " % (apps))
             else:
                 local("pytest %s --ds=perma.settings.deployments.settings_testing --cov --cov-report= " % (apps))
     finally:

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -8,7 +8,7 @@ DEBUG = False
 # DEBUG_PROPAGATE_EXCEPTIONS = True
 
 # The base location, on disk, where we want to store our generated assets
-MEDIA_ROOT = '/perma/assets/generated'
+MEDIA_ROOT = '/perma/assets/generated/'
 
 # Schedule celerybeat jobs.
 # These will be added to CELERYBEAT_SCHEDULE in settings.utils.post_processing

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -1,4 +1,4 @@
-from ..__init__ import *
+from .settings_dev import *
 
 #########
 # Setup #
@@ -8,12 +8,6 @@ FIXTURE_DIRS = (
     PROJECT_ROOT,
 )
 
-# Uncomment to enable Nose as your test runner
-# from settings_dev import INSTALLED_APPS
-# import logging
-# TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-# INSTALLED_APPS += ("django_nose",)
-# logging.getLogger('subdomains.middleware').setLevel(logging.ERROR)
 
 #############
 # Overrides #
@@ -23,6 +17,7 @@ RUN_TASKS_ASYNC = False  # avoid sending celery tasks to queue -- just run inlin
 
 SUBDOMAIN_URLCONFS = {}
 
+DEBUG = False
 TESTING = True
 
 

--- a/perma_web/perma/settings/deployments/settings_travis.py
+++ b/perma_web/perma/settings/deployments/settings_travis.py
@@ -1,9 +1,7 @@
 # Travis is our continuous integration test server.
 # This file gets copied by .travis.yml to perma_web/perma/settings/
 
-from .deployments.settings_dev import *
-
-DEBUG = False
+from .deployments.settings_testing import *
 
 DATABASES['default']['HOST'] = '127.0.0.1'
 DATABASES['default']['USER'] = 'root'
@@ -12,14 +10,3 @@ DATABASES['default']['PASSWORD'] = ''
 DATABASES['perma-cdxline']['HOST'] = '127.0.0.1'
 DATABASES['perma-cdxline']['USER'] = 'root'
 DATABASES['perma-cdxline']['PASSWORD'] = ''
-
-# To populate the from field of emails sent from Perma
-DEFAULT_FROM_EMAIL = 'email@example.com'
-
-# The host we want to display (used when DEBUG=False)
-HOST = 'perma.cc'
-WARC_HOST = 'perma-archives.org'
-ALLOWED_HOSTS = ['perma.cc', 'perma-archives.org']
-
-# Where we store our generated assets (phantomjs images)
-MEDIA_ROOT = '/tmp/perma/assets'

--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -447,8 +447,8 @@ class CachedLoader(BlockLoader):
     def load(self, url, offset=0, length=-1):
 
         # first try to fetch url contents from cache
-        cache_key = Link.get_warc_cache_key(url.split(settings.MEDIA_ROOT,1)[-1])
-
+        path = url.split(settings.MEDIA_ROOT,1)[-1]
+        cache_key = Link.get_warc_cache_key(path)
 
         mirror_name_cache_key = cache_key+'-mirror-name'
         mirror_name = ''
@@ -477,9 +477,9 @@ class CachedLoader(BlockLoader):
                     except (requests.ConnectionError, requests.Timeout, AssertionError) as e:
                         logging.info("Couldn't get from lockss: %s" % e)
 
-            # If url wasn't in LOCKSS yet or LOCKSS is disabled, fetch from local storage using super()
+            # If url wasn't in LOCKSS yet or LOCKSS is disabled, fetch from default storage
             if file_contents is None:
-                file_contents = super(CachedLoader, self).load(url).read()
+                file_contents = default_storage.open(path).read()
                 logging.debug("Got content from local disk")
 
             # cache file contents


### PR DESCRIPTION
This also tidies our testing settings.