### PR TITLE
Use django's utils for getting url from wsgi env.

### DIFF
--- a/perma_web/warc_server/pywb_config.py
+++ b/perma_web/warc_server/pywb_config.py
@@ -10,6 +10,7 @@ import requests
 import sys
 from datetime import datetime
 
+from django.core.handlers.wsgi import get_path_info
 from django.db import close_old_connections
 from django.template import loader
 from django.test import RequestFactory
@@ -398,8 +399,7 @@ def ensure_rel_uri_set(env):
         return env['REL_REQUEST_URI']
 
     # ** begin perma changes **
-    path = str(bytes(env.get('PATH_INFO', ''),'iso-8859-1'), 'utf-8')
-    url = archivalrouter.quote(path, safe='/~!$&\'()*+,;=:@')
+    url = get_path_info(env)
     # ** end perma changes **
     query = env.get('QUERY_STRING')
     if query:


### PR DESCRIPTION
```
Non-ASCII values in the WSGI environ are arbitrarily decoded with
# ISO-8859-1. This is wrong for Django websites where UTF-8 is the default.
```
Django solves this using:
- https://github.com/django/django/blob/98e8c0293b96de7dea74817476847c363d9c2496/django/core/handlers/wsgi.py#L155
- https://github.com/django/django/blob/98e8c0293b96de7dea74817476847c363d9c2496/django/utils/encoding.py#L225

I made an effort to emulate that in a previous version of this patch, when I noticed http://www.jamalouki.net/Details/40893/نقشة-الورود-ستكسو-إطلالتك-بالكامل-في-الخريف-المقبل wasn't playing back. But, my patch was incomplete and didn't work for timemap queries like `curl 'http://perma-archives.test:8000/warc/timemap/*/http://example.com/%F6'`.

So, just use Django's own util function.

