### PR TITLE
Tweak CaptureJob admin view

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -176,7 +176,7 @@ class FolderAdmin(MPTTModelAdmin):
 
 
 class CaptureJobAdmin(admin.ModelAdmin):
-    list_display = ['id', 'status', 'message', 'created_by', 'link_id', 'link_creation_timestamp', 'human']
+    list_display = ['id', 'status', 'message', 'created_by', 'link_id', 'link_creation_timestamp', 'human', 'submitted_url']
     list_filter = ['status']
     raw_id_fields = ['link', 'created_by']
 

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -178,7 +178,7 @@ class FolderAdmin(MPTTModelAdmin):
 class CaptureJobAdmin(admin.ModelAdmin):
     list_display = ['id', 'status', 'message', 'created_by', 'link_id', 'link_creation_timestamp', 'human']
     list_filter = ['status']
-    raw_id_fields = ['link']
+    raw_id_fields = ['link', 'created_by']
 
     def get_queryset(self, request):
         q = Q(link__isnull=True) | Q(link__user_deleted=False)


### PR DESCRIPTION
- display url in list view
- don't include a dropdown of every perma user in the single CaptureJob view, for much faster page loading