### PR TITLE
Move worker count to settings.utils.post_processing

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -390,7 +390,6 @@ CELERYD_TASK_SOFT_TIME_LIMIT=300
 CELERYD_TASK_TIME_LIMIT = 420
 # Estimate of active celery workers
 # https://github.com/harvard-lil/perma/issues/2438
-FALLBACK_WORKER_COUNT = 2
 # this value will be reset in settings.utils.post_processing
 WORKER_COUNT = 2
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -391,6 +391,8 @@ CELERYD_TASK_TIME_LIMIT = 420
 # Estimate of active celery workers
 # https://github.com/harvard-lil/perma/issues/2438
 FALLBACK_WORKER_COUNT = 2
+# this value will be reset in settings.utils.post_processing
+WORKER_COUNT = 2
 
 # Control whether Celery tasks should be run in the background or during a request.
 # This should normally be True, but it's handy to not require rabbitmq and celery sometimes.

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -50,15 +50,13 @@ def post_process_settings(settings):
     settings['CELERYBEAT_SCHEDULE'] = dict(((job, celerybeat_job_options[job]) for job in settings.get('CELERYBEAT_JOB_NAMES', [])),
                                            **settings.get('CELERYBEAT_SCHEDULE', {}))
 
-    # Figure out number of celery workers; at the moment, this is slow,
-    # so we do it once on application start-up rather than at each load
-    # of the /manage/create page. The call to inspector.active() takes
-    # almost two seconds.
-
-    # count celery capture workers, by convention named w1, w2, etc.
+    # Count celery capture workers, by convention named w1, w2, etc.
+    # At the moment, this is slow, so we do it once on application
+    # start-up rather than at each load of the /manage/create page.
+    # The call to inspector.active() takes almost two seconds.
     try:
         inspector = celery_inspect()
         active = inspector.active()
         settings['WORKER_COUNT'] = len([key for key in active.keys() if key.split('@')[0][0] == 'w']) if active else 0
     except TimeoutError:
-        settings['WORKER_COUNT'] = settings.FALLBACK_WORKER_COUNT
+        pass

--- a/perma_web/perma/views/link_management.py
+++ b/perma_web/perma/views/link_management.py
@@ -1,6 +1,4 @@
-from celery.task.control import inspect as celery_inspect
 from datetime import timedelta
-
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import Http404
@@ -27,14 +25,6 @@ def create_link(request):
         if link:
             messages.add_message(request, messages.INFO, 'Deleted - ' + link.submitted_title)
 
-    # count celery capture workers, by convention named w1, w2, etc.
-    try:
-        inspector = celery_inspect()
-        active = inspector.active()
-        workers = len([key for key in active.keys() if key.split('@')[0][0] == 'w']) if active else 0
-    except TimeoutError:
-        workers = settings.FALLBACK_WORKER_COUNT
-
     # approximate 'average' capture time during last 24 hrs
     # based on manage/stats
     capture_time_fields = CaptureJob.objects.filter(
@@ -54,7 +44,7 @@ def create_link(request):
         'links_remaining': request.user.get_links_remaining(),
         'suppress_reminder': 'true' if 'url' in request.GET else request.COOKIES.get('suppress_reminder'),
         'max_size': settings.MAX_ARCHIVE_FILE_SIZE / 1024 / 1024,
-        'workers': workers,
+        'workers': settings.WORKER_COUNT,
         'average': average
     })
 


### PR DESCRIPTION
Closes #2448. Counting celery workers is slow, so we're moving it to settings.utils.post_processing; the database query and computation are fast.