### PR TITLE
Individual users may request paid accounts

### DIFF
--- a/perma_web/perma/templates/contact.html
+++ b/perma_web/perma/templates/contact.html
@@ -10,13 +10,20 @@
 <div class="container cont-fixed">
   <div class="row">
     <div class="col-sm-12">
-      <h1 class="page-title">Contact</h1>
-      {% if request.user.is_supported_by_registrar %}
-        <p class="page-dek">This form is the easiest way to start a dialog with Perma.cc support at your library.</p>
+      {% if upgrade %}
+        <h1 class="page-title">Upgrade</h1>
+        <p class="page-dek">Premium Perma.cc accounts with unlimited service are available to individual users at a low monthly rate.</p>
+        <p class="page-dek">Organizations may qualify for free unlimited service or a discounted group rate. To find out if your organization qualifies, check out our <a href="{% url 'docs_accounts' %}">accounts page</a>.</p>
+        <p class="page-dek">To request an upgrade or more information, submit the form below, and a Perma.cc team member will be in touch shortly!</p>
       {% else %}
-        <p class="page-dek">This form is the easiest way to start a dialog with Perma.cc.</p>
+        <h1 class="page-title">Contact</h1>
+        {% if request.user.is_supported_by_registrar %}
+          <p class="page-dek">This form is the easiest way to start a dialog with Perma.cc support at your library.</p>
+        {% else %}
+          <p class="page-dek">This form is the easiest way to start a dialog with Perma.cc.</p>
+        {% endif %}
+        <p class="page-dek">Save yourself some time. Is your question one of our <a href="{% url 'docs_faq' %}">Frequently Asked Questions?</a> Do you have questions about <a href="{% url 'sign_up' %}">setting up a Perma.cc account?</a> Have you looked at our <a href="{% url 'docs' %}">Perma.cc Guide</a>? The answer may be right at your fingertips!</p>
       {% endif %}
-      <p class="page-dek">Save yourself some time. Is your question one of our <a href="{% url 'docs_faq' %}">Frequently Asked Questions?</a> Do you have questions about <a href="{% url 'sign_up' %}">setting up a Perma.cc account?</a> Have you looked at our <a href="{% url 'docs' %}">Perma.cc Guide</a>? The answer may be right at your fingertips!</p>
     </div>
   </div> <!-- row -->
   <div class="row">

--- a/perma_web/perma/templates/docs/accounts.html
+++ b/perma_web/perma/templates/docs/accounts.html
@@ -59,7 +59,8 @@ This section of the user guide describes how Perma accounts work.
 
       <h3 id="usage-limits" class="body-bh">Usage Limits</h3>
       <p class="body-text">Individual accounts let you preserve up to 10 web pages per month for free.</p>
-      <p class="body-text">To preserve more pages, you need to be affiliated with an organization that qualifies for free, unlimited service or one that has a paid subscription.</p>
+      <p> To archive more pages, you can <a href="{% url 'contact' %}?upgrade=individual">upgrade to a paid, premium account</a>. </p>
+      <p class="body-text">If you are affiliated with an organization that qualifies for free, unlimited service or an organization with a paid subscription, contact that organization to acquire an unlimited account.</p>
 
       <h2 id="organizations" class="body-ah">Organizations</h2>
 
@@ -70,7 +71,7 @@ This section of the user guide describes how Perma accounts work.
       <p class="body-text">Free organizational accounts also are available to state and federal courts. If you're affiliated with a court, you can use this page to learn more and contact us about signing up: <a href="{% url 'sign_up_courts' %}">https://perma.cc/signup/courts</a>.</p>
 
       <h3 id="paid-service" class="body-bh">Paid Service for Other Organizations</h3>
-      <p class="body-text">Law firms, publishers, news organizations and others may obtain organizational accounts through a paid subscription. To learn more about paid subscriptions, please <a href="/contact?subject=Question%20About%20Paid%20Subscription">contact us</a>.</p>
+      <p class="body-text">Law firms, publishers, news organizations and others may obtain organizational accounts through a paid subscription. To learn more about paid subscriptions, please <a href="{% url 'contact' %}?upgrade=organization">contact us</a>.</p>
 
       <h3 id="authority" class="body-ah">Authority and Responsibilities</h3>
       <p class="body-text">The members of an organization can create Perma Records on behalf of the organization. They also can affiliate other Perma users with the organization or remove users from the organization.</p>

--- a/perma_web/perma/templates/email/new_user.txt
+++ b/perma_web/perma/templates/email/new_user.txt
@@ -1,5 +1,7 @@
 TITLE: A Perma.cc account has been created for you
 
-To activate your account, please click the link below or copy it to your web browser.  You will need to create a new password.
+To activate your account, please click the link below or copy it to your web browser.
 
 http://{{ host }}{{ activation_route }}
+
+If you requested information about upgrading to a premium account with unlimited service, a Perma.cc team member will be in touch shortly.

--- a/perma_web/perma/templates/registration/sign-up.html
+++ b/perma_web/perma/templates/registration/sign-up.html
@@ -24,6 +24,11 @@
       <form method="post" action="">
         {% csrf_token %}
         {% include "includes/fieldset.html" %}
+          <div class="body-text"><div class="checkbox">
+            <label>
+              <input id="upgrade" name="upgrade" type="checkbox"> I'm interested in upgrading to a premium, unlimited account.
+            </label>
+          </div></div>
         <p class="body-text"><small>By registering, you agree to the <a href="{% url 'terms_of_service' %}">terms of service</a>.</small></p>
         <button type="submit" class="btn">Create account</button>
       </form>
@@ -31,7 +36,9 @@
     <div class="col-sm-8 reading-body">
       <h2 class="body-ah">Perma.cc for individual users</h2>
       <p class="body-text">Anyone can create a free, individual Perma.cc account, which will allow you to create ten links per month. Just complete this form to get started.</p>
-      <p class="body-text">Please note that if you need more than ten links per month you should work with a journal or a library that uses Perma.cc. To learn more about how Perma.cc works, please review our <a href="{% url 'docs' %}">user guide</a>.
+      <p class="body-text">If you need more than ten links per month, you can upgrade to a paid premium account. Check the box to indicate your interest, and a Perma.cc team member will be in touch shortly.</p>
+      <p class="body-text">Many organizations qualify for free, unlimited service. To see if your organization qualifies, check out our <a href="{% url 'docs_accounts' %}">accounts page</a>.</p>
+      <p class="body-text">To learn more about how Perma.cc works, please review our <a href="{% url 'docs' %}">user guide</a>.</p>
     </div>
   </div>
 </div>

--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -46,7 +46,7 @@
           </div>
 
           {% if request.user.has_limit %}
-            <p id="links-remaining-message">You have <span class="links-remaining">{{links_remaining}}</span> remaining Perma Links on your free account this month. <a href="{% url 'docs_perma_link_creation' %}#preservation-limits">Learn more about accounts</a>.</p>
+            <p id="links-remaining-message">You have <span class="links-remaining">{{links_remaining}}</span> remaining Perma Links on your free account this month.<br><a href="{% url 'contact' %}?upgrade=individual">Upgrade to unlimited Perma Links</a>.</p>
           {% else %}
             <div id="organization_select_form">
               <span class="label-affil">This Perma Link will be affiliated with</span>

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -313,6 +313,14 @@ def contact(request):
         subject = request.GET.get('subject', '')
         message = request.GET.get('message', '')
 
+        upgrade = request.GET.get('upgrade', '')
+        if upgrade:
+            subject = 'Upgrade to Unlimited Account'
+            if upgrade == 'organization':
+                message = "My organization is interested in a subscription to Perma.cc."
+            else:
+                message = "I am interested in upgrading to an unlimited Perma.cc account."
+
         flagged_archive_guid = request.GET.get('flag', '')
         if flagged_archive_guid:
             subject = 'Reporting Inappropriate Content'
@@ -329,7 +337,8 @@ def contact(request):
             )
         )
 
-        return render(request, 'contact.html', {'form': form})
+        return render(request, 'contact.html', {'form': form, 'upgrade': upgrade})
+
 
 def contact_thanks(request):
     """

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1318,6 +1318,10 @@ def sign_up(request):
         form = UserForm(request.POST)
         if form.is_valid():
             new_user = form.save()
+            upgrade = request.POST.get('upgrade', None)
+            if upgrade:
+                new_user.requested_account_type = 'premium'
+                messages.add_message(request, messages.INFO, "We will be in touch shortly with more information about upgrading to premium, unlimited service.")
             email_new_user(request, new_user)
             return HttpResponseRedirect(reverse('register_email_instructions'))
     else:

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1321,7 +1321,7 @@ def sign_up(request):
             upgrade = request.POST.get('upgrade', None)
             if upgrade:
                 new_user.requested_account_type = 'premium'
-                messages.add_message(request, messages.INFO, "We will be in touch shortly with more information about upgrading to premium, unlimited service.")
+                messages.add_message(request, messages.INFO, "We will be in touch shortly with more information about upgrading to our premium, unlimited service.")
             email_new_user(request, new_user)
             return HttpResponseRedirect(reverse('register_email_instructions'))
     else:


### PR DESCRIPTION
We did not design our infrastructure such that individual users can subscribe to unlimited accounts, but we can reuse the Registrar -> Org -> user setup to make do.

This PR offers "premium,  unlimited" accounts to individual users during sign-up, on their /manage/create page, and in the docs. It sends them to a souped-up version of our contact form to "upgrade".

I put in some copy; I don't imagine it's what we'll want to deploy.

This PR does not address the second half of this project: adapting the code to make the Registrar -> Org setup smoother (and harder to misuse), when it is used to shoehorn individual users into our paid account setup.