### PR TITLE
Better handing of email we send to ourselves

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -457,7 +457,7 @@ def ping_registrar_users(limit_to="", limit_by_tag="", exclude="", exclude_by_ta
     from datetime import datetime
     from django.http import HttpRequest
     from perma.models import Registrar
-    from perma.email import send_user_email, send_admin_email, registrar_users, registrar_users_plus_stats
+    from perma.email import send_user_email, send_self_email, registrar_users, registrar_users_plus_stats
 
     logger = logging.getLogger(__name__)
 
@@ -515,8 +515,7 @@ def ping_registrar_users(limit_to="", limit_by_tag="", exclude="", exclude_by_ta
         result = "incomplete"
     else:
         result = "ok"
-    send_admin_email("Registrar Users Emailed",
-                     settings.DEFAULT_FROM_EMAIL,
+    send_self_email("Registrar Users Emailed",
                      HttpRequest(),
                      'email/admin/pinged_registrar_users.txt',
                      {"users": users, "result": result})

--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -66,7 +66,8 @@ def send_admin_email(title, from_address, request, template="email/default.txt",
 
 def send_self_email(title, request, template="email/default.txt", context={}, devs_only=True):
     """
-        Send a message to ourselves.By default, sends only to settings.ADMINS
+        Send a message to ourselves. By default, sends only to settings.ADMINS.
+        To contact the main Perma email address, set devs_only=False
     """
     if devs_only:
         EmailMessage(

--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -12,6 +12,7 @@ from .utils import tz_datetime
 
 logger = logging.getLogger(__name__)
 
+
 ###
 ### Send email
 ###
@@ -61,6 +62,29 @@ def send_admin_email(title, from_address, request, template="email/default.txt",
         [settings.DEFAULT_FROM_EMAIL],
         headers={'Reply-To': from_address}
     ).send(fail_silently=False)
+
+
+def send_self_email(title, request, template="email/default.txt", context={}, devs_only=True):
+    """
+        Send a message to ourselves.By default, sends only to settings.ADMINS
+    """
+    if devs_only:
+        EmailMessage(
+            title,
+            render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
+            settings.DEFAULT_FROM_EMAIL,
+            [admin[1] for admin in settings.ADMINS]
+        ).send(fail_silently=False)
+    else:
+        # Use a special reply-to address to avoid Freshdesk's filters: a ticket will be opened.
+        EmailMessage(
+            title,
+            render_to_string(template, context=context, request=request, using="AUTOESCAPE_OFF"),
+            settings.DEFAULT_FROM_EMAIL,
+            [settings.DEFAULT_FROM_EMAIL],
+            headers={'Reply-To': settings.DEFAULT_REPLYTO_EMAIL}
+        ).send(fail_silently=False)
+
 
 def send_user_email_copy_admins(title, from_address, to_addresses, request, template="email/default.txt", context={}):
     """

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -501,6 +501,10 @@ WEBPACK_LOADER = {
     }
 }
 
+# set a default reply-to email address, the same as Django's DEFAULT_FROM_EMAIL
+# in production, must be different than the production DEFAULT_FROM_EMAIL
+DEFAULT_REPLYTO_EMAIL = 'webmaster@localhost'
+
 # Campaign Monitor (override if you want to actually interact with to
 # campaign monitor)
 CAMPAIGN_MONITOR_AUTH = {'api_key':'fake'}

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -20,6 +20,10 @@ SUBDOMAIN_URLCONFS = {}
 DEBUG = False
 TESTING = True
 
+ADMINS = (
+    ("Admin's Name", 'admin@example.com'),
+)
+
 
 ###############
 # Speed Hacks #

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -45,7 +45,7 @@ from django.db.models import Q
 from django.http import HttpRequest
 
 from perma.models import WeekStats, MinuteStats, Registrar, LinkUser, Link, Organization, CDXLine, Capture, CaptureJob, UncaughtError
-from perma.email import sync_cm_list, send_admin_email, registrar_users_plus_stats
+from perma.email import sync_cm_list, send_self_email, registrar_users_plus_stats
 from perma.utils import (run_task, url_in_allowed_ip_range,
     copy_file_data, preserve_perma_warc, write_warc_records_recorded_from_web,
     write_resource_record_from_asset)
@@ -1343,9 +1343,8 @@ def cm_sync():
     reports = sync_cm_list(settings.CAMPAIGN_MONITOR_REGISTRAR_LIST,
                            registrar_users_plus_stats(destination='cm'))
     if reports["import"]["duplicates_in_import_list"]:
-        logger.error("Duplicate reigstrar users sent to Campaign Monitor. Check sync logic.")
-    send_admin_email("Registrar Users Synced to Campaign Monitor",
-                      settings.DEFAULT_FROM_EMAIL,
+        logger.error("Duplicate registrar users sent to Campaign Monitor. Check sync logic.")
+    send_self_email("Registrar Users Synced to Campaign Monitor",
                       HttpRequest(),
                       'email/admin/sync_to_cm.txt',
                       {"reports": reports})
@@ -1362,8 +1361,7 @@ def send_js_errors():
         resolved=False)
     if errors:
         formatted_errors = map(lambda err: err.format_for_reading(), errors)
-        send_admin_email("Uncaught Javascript errors",
-                         settings.DEFAULT_FROM_EMAIL,
+        send_self_email("Uncaught Javascript errors",
                          HttpRequest(),
                          'email/admin/js_errors.txt',
                          {'errors': formatted_errors})

--- a/perma_web/perma/tests/test_tasks.py
+++ b/perma_web/perma/tests/test_tasks.py
@@ -48,7 +48,7 @@ class TaskTestCase(TestCase):
         self.assertIn('40', response)
 
         # check that developers are warned about duplicates
-        mock_logger.error.assert_called_with("Duplicate reigstrar users sent to Campaign Monitor. Check sync logic.")
+        mock_logger.error.assert_called_with("Duplicate registrar users sent to Campaign Monitor. Check sync logic.")
 
         # check contents of sent email
         our_address = settings.DEFAULT_FROM_EMAIL


### PR DESCRIPTION
We send ourselves some administrative emails. Most of those should only go to whoever is currently in settings.ADMINS. Occasionally, we might want to email the main Perma email address and open a ticket. This PR adds a utility function for sending ourselves mail and switches existing code to use it, always with the default (=no ticket).

Perma Payments is going to need the same change.