### PR TITLE
Throw together a mechanism for requesting account deletion.

### DIFF
--- a/perma_web/perma/templates/email/admin/deletion_request.txt
+++ b/perma_web/perma/templates/email/admin/deletion_request.txt
@@ -1,0 +1,1 @@
+{{ email }}{% if first_name or last_name %} ({{ first_name }} {{ last_name }}){% endif %} has requested the deletion of their Perma.cc account.

--- a/perma_web/perma/templates/user_management/settings-profile.html
+++ b/perma_web/perma/templates/user_management/settings-profile.html
@@ -16,4 +16,20 @@
     <button type="submit" class="btn">Save changes</button>
   </form>
 
+  {% if "Requested account deletion" in request.user.notes %}
+    <h2 class="body-ah">Deletion Request Received</h2>
+    <p>We've received the request to delete your account. We're sorry to see you go!</p>
+    <p>Please note that it can take up to one full business day for us to process your request.</p>
+  {% else %}
+    <h2 class="body-ah">Request Account Deletion</h2>
+    <p>On request, a team member will delete your Perma.cc account. It may take up to one full business day for us to process your request. Please note that the deletion of your account will not affect the visibility of any Perma Links you have created.</p>
+    <p>If you have any questions, please <a href="{% url 'contact' %}?subject=Question%20About%20Account%20Deletion">contact us</a>.</p>
+    <form method="post" action="{% url 'user_management_delete_account' %}">
+      {% csrf_token %}
+      <button class="btn cancel" type="submit">
+        Please delete my account.
+      </button>
+    </form>
+  {% endif %}
+
 {% endblock %}

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -79,6 +79,7 @@ urlpatterns = [
 
     # Settings
     url(r'^settings/profile/?$', user_management.settings_profile, name='user_management_settings_profile'),
+    url(r'^settings/profile/delete/?$', user_management.delete_account, name='user_management_delete_account'),
     url(r'^settings/password/?$', user_management.settings_password, name='user_management_settings_password'),
     url(r'^settings/affiliations/?$', user_management.settings_affiliations, name='user_management_settings_affiliations'),
     url(r'^settings/organizations-change-privacy/(?P<org_id>\d+)/?$', user_management.settings_organizations_change_privacy, name='user_management_settings_organizations_change_privacy'),

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -965,6 +965,18 @@ def settings_profile(request):
 
 
 @login_required
+def delete_account(request):
+    """
+    Generate or regenerate an API key for the user
+    """
+    if request.method == "POST":
+        request.user.notes = "Requested account deletion {}\n".format(timezone.now()) + request.user.notes
+        request.user.save()
+        email_deletion_request(request)
+    return HttpResponseRedirect(reverse('user_management_settings_profile'))
+
+
+@login_required
 def settings_password(request):
     """
     Settings change password ...
@@ -1653,5 +1665,21 @@ def email_premium_request(request, user):
             "first_name": user.first_name,
             "last_name": user.last_name,
             "email": user.email
+        }
+    )
+
+def email_deletion_request(request):
+    """
+    Send email to Perma.cc admins when a user requests a premium account
+    """
+    send_admin_email(
+        "Perma.cc account deletion request",
+        request.user.email,
+        request,
+        "email/admin/deletion_request.txt",
+        {
+            "first_name": request.user.first_name,
+            "last_name": request.user.last_name,
+            "email": request.user.email
         }
     )


### PR DESCRIPTION
Logged in users can request account deletion via their profile page:
![image](https://user-images.githubusercontent.com/11020492/45184476-00017700-b1f5-11e8-8599-8ccdc566eb0f.png)
After pressing the button, in the Django admin:
![image](https://user-images.githubusercontent.com/11020492/45184497-0e4f9300-b1f5-11e8-9222-263f9b7c0ddd.png)
User then sees:
![image](https://user-images.githubusercontent.com/11020492/45184511-1c051880-b1f5-11e8-9678-a0d890e89ad8.png)
We also get an email, like when a special user signs up. It should create a ticket in FreshDesk.