### PR TITLE
Give warcprox threads a chance to stop

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -493,6 +493,7 @@ CELERY_ROUTES = {
 
 ENABLE_AV_CAPTURE = False
 RESOURCE_LOAD_TIMEOUT = 45 # seconds to wait for at least one resource to load before giving up on capture
+SHUTDOWN_GRACE_PERIOD = 10 # seconds to allow slow threads to finish before we complete the capture job
 MAX_PROXY_THREADS = 100
 
 WEBPACK_LOADER = {

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -86,3 +86,5 @@ SUBSCRIBE_URL = '/subscribe/'
 CANCEL_URL = '/cancel-request/'
 SUBSCRIPTION_STATUS_URL = '/subscription/'
 UPDATE_URL = '/update/'
+
+SHUTDOWN_GRACE_PERIOD = 0


### PR DESCRIPTION
Some warcprox threads aren't stopping promptly, despite the patch, and I'm not sure why at this moment. I'd like to investigate more, but I think we should try to make Perma robust even if I never figure out all the edge cases.

This PR changes the `warcprox_controller.proxy.pool.shutdown` call to non-blocking, which should prevent the capture process from hanging and eventually timing out and failing. 

It also introduces a short `SHUTDOWN_GRACE_PERIOD` to allow warcprox a little time to deal with threads stopped via https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/tasks.py#L956. During quick, normal captures, there are often 2 active threads at this point: if any more are active, we'll wait up to `SHUTDOWN_GRACE_PERIOD` for them to finish up.

This adds up to 5s to the total capture time of slow sites, which I think is acceptable. If not, we can reduce one or other of the other timeouts, or reduce this grace period.

I'm also moving the call to `warcprox_controller.warc_writer_processor.pool.shutdown` to the very end of the teardown process, which I think will reduce (though perhaps not eliminate) the occasional "RuntimeError: cannot schedule new futures after shutdown" my last PR introduced. The call might be unnecessary, but I think it is helpful for ensuring resources are released properly.

To test, I've been making link batches of the following URLS, pasted three times in each batch:
```
http://partytronic.com/
http://bangordailynews.com/2011/11/16/news/hancock/blue-hill-farmer-cited-for-violating-state-law/
https://www.dailyprogress.com/news/local/when-it-comes-to-college-sports-revenue-even-a-powerhouse/article_29eb808c-edd8-11e3-9f88-0017a43b2370.html
https://fox13now.com/2017/08/24/federal-appeals-court-upholds-injunction-against-vidangels-streaming-service/
http://time.com/money/5304493/us-exports-tariffs-list/
https://lil.law.harvard.edu/collaborate
http://example.com
```
Some of the partytronic captures are coming out poorly, but so far, all these captures have at least completed without failing (fingers crossed).

We should try this on stage, making sure that each worker handles a good number of captures.... dev will not be up to it.