### PR TITLE
Don't wait unless its MitmProxyHandler threads.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -87,4 +87,3 @@ CANCEL_URL = '/cancel-request/'
 SUBSCRIPTION_STATUS_URL = '/subscription/'
 UPDATE_URL = '/update/'
 
-SHUTDOWN_GRACE_PERIOD = 0


### PR DESCRIPTION
This should get the test speed back to about 9 min: if it doesn't, there's a problem.

Note this fixes a typo from my last PR: I never set `SHUTDOWN_GRACE_PERIOD = settings.SHUTDOWN_GRACE_PERIOD` in tasks.py, so the testing override had no effect. But, testing on my fork suggests an override for testing is not necessary.