### PR TITLE
warcinfo fix for webrecorder player: add 'timestamp' field to warcinfo

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -524,15 +524,18 @@ def get_warc_stream(link):
 
     timestamp = link.creation_timestamp.strftime('%Y%m%d%H%M%S')
 
-    warcinfo = make_detailed_warcinfo( filename = filename,
-                 guid = link.guid,
-                 coll_title = 'Perma Archive, %s' % link.submitted_title,
-                 coll_desc = link.submitted_description,
-                 rec_title = 'Perma Archive of %s' % link.submitted_title,
-                 pages= [{'title': link.submitted_title,
-                          'url': link.submitted_url,
-                          'timestamp': timestamp}
-                        ])
+    warcinfo = make_detailed_warcinfo(
+        filename = filename,
+        guid = link.guid,
+        coll_title = 'Perma Archive, %s' % link.submitted_title,
+        coll_desc = link.submitted_description,
+        rec_title = 'Perma Archive of %s' % link.submitted_title,
+        pages= [{
+            'title': link.submitted_title,
+            'url': link.submitted_url,
+            'timestamp': timestamp
+        }]
+    )
 
     warc_stream = FileWrapper(default_storage.open(link.warc_storage_file()))
     warc_stream = itertools.chain([warcinfo], warc_stream)


### PR DESCRIPTION
The warcinfo metadata added for Webrecorder Player was missing the `timestamp` field, which did not work in latest build. This adds the `timestamp` field to the metadata.