### PR TITLE
Noarchive behavior

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -520,6 +520,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # If technical problems prevent proper analysis of a capture,
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
 
 
 REST_FRAMEWORK = {

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -520,7 +520,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # If technical problems prevent proper analysis of a capture,
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
-PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = False
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
 
 
 REST_FRAMEWORK = {

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -520,7 +520,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # If technical problems prevent proper analysis of a capture,
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
-PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = False
 
 
 REST_FRAMEWORK = {

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -489,7 +489,7 @@ def xrobots_blacklists_perma(robots_directives):
         for directive in robots_directives.split(";"):
             parsed = directive.lower().split(":")
             # respect tags that target all crawlers (no user-agent specified)
-            if len(parsed) == 1:
+            if settings.PRIVATE_LINKS_IF_GENERIC_NOARCHIVE and len(parsed) == 1:
                 if "noarchive" in parsed:
                     darchive = True
             # look for perma user-agent
@@ -734,7 +734,7 @@ def teardown(link, thread_list, browser, display, warcprox_controller, warcprox_
 def process_metadata(metadata, link):
     ## Privacy Related ##
     meta_tag = metadata['meta_tags'].get('perma')
-    if not meta_tag:
+    if settings.PRIVATE_LINKS_IF_GENERIC_NOARCHIVE and not meta_tag:
         meta_tag = metadata['meta_tags'].get('robots')
     if meta_tag and 'noarchive' in meta_tag.lower():
         safe_save_fields(link, is_private=True, private_reason='policy')

--- a/perma_web/perma/tests/assets/target_capture_files/perma-noarchive.html
+++ b/perma_web/perma/tests/assets/target_capture_files/perma-noarchive.html
@@ -1,0 +1,5 @@
+<html>
+  <head>
+    <meta name="pErMa" content="foo nOaRcHiVe bar">
+  </head>
+</html>


### PR DESCRIPTION
This PR adds a setting, `PRIVATE_LINKS_IF_GENERIC_NOARCHIVE`. 

Perma's current behavior is True: though we only respect robots.txt directives if Perma is mentioned by name, we respect meta tags and x-robots headers directed at generic "robots" (http://noarchive.net/).

This PR also toggles the default setting to False.