### PR TITLE
Noarchive behavior

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -340,7 +340,8 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
         # test favicon captured via favicon.ico well-known URL
         self.assertIn("favicon.ico", link.favicon_capture.url)
 
-    def test_should_not_dark_archive_if_generic_noarchive_in_html(self):
+    @override_settings(PRIVATE_LINKS_IF_GENERIC_NOARCHIVE=False)
+    def test_should_not_dark_archive_if_generic_noarchive_in_html_with_setting(self):
         obj = self.successful_post(self.list_url,
                                    data={'url': self.server_url + "/noarchive.html"},
                                    user=self.org_user)
@@ -374,7 +375,8 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
         self.assertTrue(link.is_private)
         self.assertEqual(link.private_reason, "policy")
 
-    def test_should_not_dark_archive_when_generic_disallowed_in_xrobots(self):
+    @override_settings(PRIVATE_LINKS_IF_GENERIC_NOARCHIVE=False)
+    def test_should_not_dark_archive_when_generic_disallowed_in_xrobots_with_setting(self):
         headers = urllib.parse.quote(json.dumps([("x-robots-tag", "noarchive")]))
         obj = self.successful_post(self.list_url,
                                    data={'url': self.server_url + "/test.html?response_headers=" + headers},

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -520,6 +520,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # If technical problems prevent proper analysis of a capture,
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
 
 
 REST_FRAMEWORK = {

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -520,7 +520,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # If technical problems prevent proper analysis of a capture,
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
-PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = False
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
 
 
 REST_FRAMEWORK = {

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -520,7 +520,7 @@ TAGGIT_CASE_INSENSITIVE = True
 # If technical problems prevent proper analysis of a capture,
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
-PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = False
 
 
 REST_FRAMEWORK = {

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -489,7 +489,7 @@ def xrobots_blacklists_perma(robots_directives):
         for directive in robots_directives.split(";"):
             parsed = directive.lower().split(":")
             # respect tags that target all crawlers (no user-agent specified)
-            if len(parsed) == 1:
+            if settings.PRIVATE_LINKS_IF_GENERIC_NOARCHIVE and len(parsed) == 1:
                 if "noarchive" in parsed:
                     darchive = True
             # look for perma user-agent
@@ -734,7 +734,7 @@ def teardown(link, thread_list, browser, display, warcprox_controller, warcprox_
 def process_metadata(metadata, link):
     ## Privacy Related ##
     meta_tag = metadata['meta_tags'].get('perma')
-    if not meta_tag:
+    if settings.PRIVATE_LINKS_IF_GENERIC_NOARCHIVE and not meta_tag:
         meta_tag = metadata['meta_tags'].get('robots')
     if meta_tag and 'noarchive' in meta_tag.lower():
         safe_save_fields(link, is_private=True, private_reason='policy')

--- a/perma_web/perma/tests/assets/target_capture_files/perma-noarchive.html
+++ b/perma_web/perma/tests/assets/target_capture_files/perma-noarchive.html
@@ -1,0 +1,5 @@
+<html>
+  <head>
+    <meta name="pErMa" content="foo nOaRcHiVe bar">
+  </head>
+</html>


### PR DESCRIPTION
This PR adds a setting, PRIVATE_LINKS_IF_GENERIC_NOARCHIVE.

Perma's current behavior is True: though we only respect robots.txt directives if Perma is mentioned by name, we respect meta tags and x-robots headers directed at generic "robots" (http://noarchive.net/).

This PR keeps the default of `True`; we can toggle in settings_common when we are ready, or override when ready by deployment-specific settings.py