### PR TITLE
Heroku build

### DIFF
--- a/perma_web/Pipfile.lock
+++ b/perma_web/Pipfile.lock
@@ -714,7 +714,6 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "index": "pypi",
-            "markers": null,
             "version": "==2.18.4"
         },
         "requests-file": {

--- a/services/heroku/runtime.txt
+++ b/services/heroku/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.5
+python-3.6.6


### PR DESCRIPTION
- increments runtime because... why not
- manually removes "null" marker that pip 9 + pipenv can't handle 😢 