### PR TITLE
No "upgrades" for individuals on contact form or sign up form

### DIFF
--- a/perma_web/perma/templates/contact.html
+++ b/perma_web/perma/templates/contact.html
@@ -11,10 +11,9 @@
   <div class="row">
     <div class="col-sm-12">
       {% if upgrade %}
-        <h1 class="page-title">Upgrade</h1>
-        <p class="page-dek">Premium Perma.cc accounts with unlimited service are available to individual users at a rate of $20 per month.</p>
-        <p class="page-dek">Organizations may qualify for free unlimited service or a discounted group rate. To find out if your organization qualifies, check out our <a href="{% url 'docs_accounts' %}">accounts page</a>.</p>
-        <p class="page-dek">To request an upgrade or more information, submit the form below, and a Perma.cc team member will be in touch shortly!</p>
+        <h1 class="page-title">Request Information For Organization</h1>
+        <p class="page-dek">Organizations may purchase unlimited Perma.cc service for their members at a discounted group rate. Certain organizations qualify for free unlimited service. To find out if your organization qualifies, check out our <a href="{% url 'docs_accounts' %}">accounts page</a>.</p>
+        <p class="page-dek">For more information, submit the form below, and a Perma.cc team member will be in touch shortly!</p>
       {% else %}
         <h1 class="page-title">Contact</h1>
         {% if request.user.is_supported_by_registrar %}

--- a/perma_web/perma/templates/email/new_user.txt
+++ b/perma_web/perma/templates/email/new_user.txt
@@ -3,5 +3,3 @@ TITLE: A Perma.cc account has been created for you
 To activate your account, please click the link below or copy it to your web browser.
 
 http://{{ host }}{{ activation_route }}
-
-If you requested information about upgrading to a premium account with unlimited service, a Perma.cc team member will be in touch shortly.

--- a/perma_web/perma/templates/registration/sign-up.html
+++ b/perma_web/perma/templates/registration/sign-up.html
@@ -24,11 +24,6 @@
       <form method="post" action="">
         {% csrf_token %}
         {% include "includes/fieldset.html" %}
-          <div class="body-text"><div class="checkbox">
-            <label>
-              <input id="upgrade" name="upgrade" type="checkbox"> I'm interested in upgrading to a premium, unlimited account.
-            </label>
-          </div></div>
         <p class="body-text"><small>By registering, you agree to the <a href="{% url 'terms_of_service' %}">terms of service</a>.</small></p>
         <button type="submit" class="btn">Create account</button>
       </form>

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -102,7 +102,7 @@ def user_with_links():
     today = now.replace(day=5)
     earlier_this_month = today.replace(day=1)
     last_calendar_year = today - relativedelta(years=1)
-    within_the_last_year = now - relativedelta(months=6)
+    within_the_last_year = today - relativedelta(months=6)
     over_a_year_ago = today - relativedelta(years=1, days=2)
     three_years_ago = today - relativedelta(years=3)
     links = [
@@ -1124,12 +1124,12 @@ class ModelsTestCase(PermaTestCase):
 
     def test_annual_link_limit(self):
         '''
-        Why is this passing locally and failing on Travis?
+        How was this ever passing with 4/3?
         '''
         u = user_with_links()
         self.assertFalse(u.unlimited)
-        self.assertEqual(u.links_remaining_in_period('annually', 4), 1)
-        self.assertEqual(u.links_remaining_in_period('annually', 3), 0)
+        self.assertEqual(u.links_remaining_in_period('annually', 5), 1)
+        self.assertEqual(u.links_remaining_in_period('annually', 4), 0)
 
 
     def test_unlimited_user_link_limit(self):

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -314,12 +314,12 @@ def contact(request):
         message = request.GET.get('message', '')
 
         upgrade = request.GET.get('upgrade', '')
-        if upgrade:
+        if upgrade == 'organization' :
             subject = 'Upgrade to Unlimited Account'
-            if upgrade == 'organization':
-                message = "My organization is interested in a subscription to Perma.cc."
-            else:
-                message = "I am interested in upgrading to an unlimited Perma.cc account."
+            message = "My organization is interested in a subscription to Perma.cc."
+        else:
+            # all other values of `upgrade` are disallowed
+            upgrade = None
 
         flagged_archive_guid = request.GET.get('flag', '')
         if flagged_archive_guid:

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1363,11 +1363,6 @@ def sign_up(request):
         form = UserForm(request.POST)
         if form.is_valid():
             new_user = form.save()
-            upgrade = request.POST.get('upgrade', None)
-            if upgrade:
-                new_user.requested_account_type = 'premium'
-                email_premium_request(request, new_user)
-                messages.add_message(request, messages.INFO, "We will be in touch shortly with more information about upgrading to our premium, unlimited service.")
             email_new_user(request, new_user)
             return HttpResponseRedirect(reverse('register_email_instructions'))
     else:


### PR DESCRIPTION
There should be no conflicts with https://github.com/harvard-lil/perma/pull/2519/files, which doesn't alter the actual forms.

Currently, when an organization clicks the links to request more information about a paid organizational account, they see the below:
![image](https://user-images.githubusercontent.com/11020492/50612342-a4e04800-0ea7-11e9-8477-dfdecb06aa2f.png)

This PR switches it to:
![image](https://user-images.githubusercontent.com/11020492/50612350-aad62900-0ea7-11e9-9d82-6f1713cd7d72.png)
