### PR TITLE
Some utils for running Perma with WR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,7 @@ services:
       - redis
     volumes:
       - ./data:/data
+      - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml
     networks:
       - webrecorder
 
@@ -130,6 +131,7 @@ services:
       - redis
     volumes:
       - ./data:/data
+      - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml
     networks:
       - webrecorder
 
@@ -142,6 +144,7 @@ services:
       - redis
     volumes:
       - ./data:/data
+      - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml
     networks:
       - webrecorder
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # 1) comment in the perma-redis stanza
   # 2) comment in the data volume
   # 3) add the caches setting found in settings_prod to your settings.py,
-  #.   with "LOCATION": "redis://perma-redis:6379/0"
+  #    with "LOCATION": "redis://perma-redis:6379/0"
   # perma-redis:
   #   image: redis:4.0.6
   #   volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,12 @@ services:
     build: ./perma_web
     image: perma3:0.11
     tty: true
-    command: bash
-    # Some people prefer the below ;-)
-    # command: pipenv run fab run
+    # command: bash
+    # TO AUTOMATICALLY START PERMA:
+    # (sleep hack to give the database and rabbitmq time to start up)
+    # command: >
+    #   sh -c "sleep 10 && pipenv run ./manage.py migrate &&
+    #          pipenv run fab run"
     volumes:
       # NAMED VOLUMES
       # Use a named, persistent volume so that the node_modules directory,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,12 @@ services:
     networks:
       - default
 
-  # TO USE REDIS: add the caches setting found in settings_prod to your settings.py
-  # redis:
+  # TO USE REDIS:
+  # 1) comment in the perma-redis stanza
+  # 2) comment in the data volume
+  # 3) add the caches setting found in settings_prod to your settings.py,
+  #.   with "LOCATION": "redis://perma-redis:6379/0"
+  # perma-redis:
   #   image: redis:4.0.6
   #   volumes:
   #     - redis_data:/data:delegated
@@ -52,11 +56,11 @@ services:
       - ./services/django:/perma/services/django:delegated
       - ./services/logs:/perma/services/logs:delegated
     environment:
-      # Temporary: let Django load Docker-specific settings conditionally
       - DOCKERIZED=True
     extra_hosts:
       - "perma.test:127.0.0.1"
       - "api.perma.test:127.0.0.1"
+      # perma-archives host is unnecessary if playback is handled by WR
       - "perma-archives.test:127.0.0.1"
     ports:
       - "8000:8000"
@@ -64,9 +68,7 @@ services:
       - db
     networks:
       - default
-      # TO CONNECT TO A SEPARATELY-RUNNING WEBRECORDER INSTANCE:
-      # start the WR containers first, then uncomment and start Perma's containers
-      # - webrecorder
+      - webrecorder
 
   #
   # Perma Payments
@@ -101,9 +103,77 @@ services:
       - default
       - perma_payments
 
-networks:
-  default:
-  perma_payments:
+  #
+  # Webrecorder
+  #
+  app:
+    image: harvardlil/webrecorder:0.03
+    command: uwsgi /code/apps/apiapp.ini
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    depends_on:
+      - warcserver
+      - recorder
+      - redis
+    volumes:
+      - ./data:/data
+    networks:
+      - webrecorder
+
+  recorder:
+    image: harvardlil/webrecorder:0.03
+    command: uwsgi /code/apps/rec.ini
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    depends_on:
+      - warcserver
+      - redis
+    volumes:
+      - ./data:/data
+    networks:
+      - webrecorder
+
+  warcserver:
+    image: harvardlil/webrecorder:0.03
+    command: uwsgi /code/apps/load.ini
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    depends_on:
+      - redis
+    volumes:
+      - ./data:/data
+    networks:
+      - webrecorder
+
+  nginx:
+    image: webrecorder/nginx
+    depends_on:
+      - app
+    volumes:
+      - ./data:/data
+      - ./services/docker/webrecorder/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./services/docker/webrecorder/nginx/webrec.conf:/etc/nginx/webrec.conf
+      - ./services/docker/webrecorder/nginx/502.html:/usr/share/nginx/html/502.html
+    ports:
+      # The WR API. See perma_web/perma/settings/settings_common "WR_API"
+      # for a description of when to expose this port
+      # - 8089:80
+      # WR "content"/playback host
+      - 8092:81
+    extra_hosts:
+      - "perma-archives.test:127.0.0.1"
+    networks:
+      - default
+      - webrecorder
+
+  redis:
+    image: redis:4.0.6
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    volumes:
+      - wr_redis_data:/data:delegated
+    networks:
+      - webrecorder
 
 volumes:
   node_modules:
@@ -111,10 +181,20 @@ volumes:
   rabbitmq_home:
   # redis_data:
   pp_db_data:
+  wr_redis_data:
 
 networks:
   default:
   perma_payments:
-  # webrecorder:
+  # TO CONNECT TO A SEPARATELY-RUNNING WEBRECORDER INSTANCE
+  # instead of spinning one up here from our pre-built image
+  # --------------------------------------------------------
+  # 1) start the WR containers first, via WR's own repo and docker-compose file
+  # 2) comment out the Webecorder service and all its associated containers above
+  # 3) uncomment the "external" stanza below,
+  # 4) finally, start Perma's containers
+  #
+  # (recommended for simultaneous Perma and Webrecorder development)
+  webrecorder:
   #   external:
   #     name: webrecorder_default

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -459,19 +459,22 @@ ENABLE_WR_PLAYBACK = False
 # If set, playbacks must be served from PLAYBACK_HOST.
 # On production, this is highly recommended to be different from HOST
 HOST = 'localhost'
+
+# The host and port loaded by Perma's iframe during playback
+# Must be publicly available
 PLAYBACK_HOST = HOST
 
+# The Webrecorder API, used internally by Perma to create WR sessions and upload
+# warcs for playback. Not in use if ENABLE_WR_PLAYBACK = False
 #
-# Webrecorder Playback
+# Use 'http://nginx' and port 80 if running on same docker instance
 #
-# Use 'http://nginx' if running on same docker instance
-WEBRECORDER_HOST = 'http://nginx'
+# Or, if WR is on remote machine and/or not running Perma in Docker,
+# use the remote host and the port that is being publicly exposed
+# and mapped to port 80 on the nginx container by docker-compose. E.g.
+# http://remote-webrecorder-host:8089
+WR_API = 'http://nginx/api/v1'
 
-# Or, external webrecorder host if WR is on remote machine and/or
-# not running perma in Docker, eg:
-#WEBRECORDER_HOST = 'http://remote-webrecorder-host/
-
-WR_API = WEBRECORDER_HOST + '/api/v1'
 
 # Time (in seconds) to wait for upload to finalize
 # after data fully uploaded to Webreccorder

--- a/services/docker/webrecorder/nginx/502.html
+++ b/services/docker/webrecorder/nginx/502.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Webrecorder Under Maintenance</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <!-- Mobile Specific Metas
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Favicon
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+<link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTM4IDc5LjE1OTgyNCwgMjAxNi8wOS8xNC0wMTowOTowMSAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTcgKE1hY2ludG9zaCkiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6RUZEQTQ5ODM0ODg1MTFFN0I5RDJBQTY0Rjg4NTM4REEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6RUZEQTQ5ODQ0ODg1MTFFN0I5RDJBQTY0Rjg4NTM4REEiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpFRkRBNDk4MTQ4ODUxMUU3QjlEMkFBNjRGODg1MzhEQSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpFRkRBNDk4MjQ4ODUxMUU3QjlEMkFBNjRGODg1MzhEQSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PpC16H4AAAAwUExURebm5QQl5XCJ3fX1+N7e3v796zhc5PXz4rG92pSo4MfQ6N3k+u7u7u3t7f///////4opavEAAAAQdFJOU////////////////////wDgI10ZAAAP80lEQVR42rxbi2LjqA4lvMHY8/9/e3UkgfErSTuzl3S7mTa1DtLR09j8+eXaXFvWmmnVdVnd9tvrmN/IJrnFFjst+ich2f4PAJaaSVqM8XVa9CPCkevyXwLwGbJ3abniBX1MPy95+W8ALJAOIZa26baxnH4Lbukf+AmGbwFUubitbUgO9JpWYBwt43OEof5LACuJZ+ldojO+sgf0Veuy6i+dq/zhUts/AuBywaaq7DmQ7xVaLFUXIPCPlqa6yPiLkts/AOAqLobNh7A5Fp6rXx1Wkhd+5dzqBcUimoAaYqnubwGIeDF8xc7rSsJSWy+rOYLB6smetbBYNsRfAWjYh11wPUf+n30KaX2zWguuAWdlhjaA/2AH8576kWzvHBmeQl0lbRuVZB4A4JvbDNTA7lkjqPBLAORRr1eBgUl89iGZ550f/k96CKSGDC248kEJzwA8tu/Be1L+Gtpq2vr9CoHCUoUSlviWCead+i22X20xoRlWu7nffJt2P36RoIWVAqSz78zwBADqz+R4gfYB8ebB7K2RTPom/x0xhJQt24HMUMqPABDlSf3Bbd6WFEzf/AMGEt52FDMlgoESts2ACO57ACw/bbD+2+2LQBbcAbRuEwHhcAl4ZHxCYG7pL+ZvhazP0lt7y38R3/S/4++Dtxnh+QmBud+/bWEzNq/JQH5IKdBKN9JVqkJQc6geOhMKfHkjpd5laXMjn/cP+QHiSX7mQqOaM4Y2bV7ECyWOMFMohWI5OYMt7jMAJDKbNvK+yvJXEzylFSm7MmFoE/fWdVLA2Do+QWlhcofM2QQ6cB8BUOa3TH+v8tdgX3VzCydlpMUwMVCZty/55+p8nfVA21lFB3n7AAD8J/ev1pP5GUEyr9jrEM3M7gDhCIB14Rzt4hAYa0GKhBXeA1D5sn8mgAnlVffCiwIr5YcwQuBZvHyH0sKRB6KD+DrHRHOK//B/8hze/youEF9z6ccJbg0jCO4UGGDWYF52O1DRwAqJvbEszwCW/HpR+jG2svuJBTxd7LgoSvsgbG+7302LxDh3dAWTQiZvdAvlBfMIgGhGlURj+aZTsLzKCcAGnKGdPWBE5FDJSuvZGw0hoNyWyRWeACAAkauXrPZnEGTO5Qxgq6yD9bxzWcnFePDCTlm6srrCPQBTmIClyP6FA2s6UaAjiC3csBCQSEHZ3URt4xqXakcamIMBDNL/2LwYIcYbAJRhbehR8ACC2gPax33ySJ5cgeJaLHcAqP6Ef2kAGBx8ALDh0yMFThjYZncAmFAgIrHK1isAxwYIVEwac9DA6x4AufSaLnGou2DbM/KxUmMakBHMBUCGB1DQ7gRQN2jm4oVDBTW0ayAkE7ewVwpnZzQoUOoUEDuAtbAHdA+cbPCgAaJhagcW8jt1wfWhgDBiBFLBegJACvAu7B4wvOCBA44cMc3pUJYLMd72TdpMmNXBE9Y9GCgAxyHA21m4soCi2g2A+MpJY+GBAYVK2alAvWJItThUJ50FZigggYFnBZiW7gIRSryURk08TBACGcw9dwvQQUDHkoYKBEBjBVDCMuaMgLwq33iAHQQ4ALCSJR4NQK/kS2MVrBMAMOCsgF4O5IsboNfxJmlGnjDABcM7/UtehAqWrgIFgBgwMWDsnwCsZzdAt+dTO1el9N6ZYtyxLr/ogFXgkBKkQDQaBCkGUPHqrxowJxKgIskppbkz0rIdUcAdO7VrMKQXHIHcVcKh0SxAjb+9ise3NOdjHjr4tDvaiHmt++SbJkJpQI5ATUeUjAAAjYNQLmcGqAZ8t8HCs6Lie5/uQl+jIl3bcwwaGljJUkzDRQFkWICSdfI3CiDA9NFKNTHPAEl80iovrDyzKTw4CXtX1N7tH+JNypnjcVUAtLELBSciJq9dATXZZHzevws8vhhzWlvd++HNOu1/bZXjMdvAcB4UC3jj7yAQYIyjs6fNm6S7LyJXv7hpCeHD7rsRwCtqvcUPDPtA7kHgzg1IB8lj5/LilpfJsGy1LNnR/4Ude8PwAYPYILMNAIAye/DF34nvOuBMqkOC0KzMLal92Vohz4CbFm4Y3EfxvKNWKRY5jkUGFIgYKrF8CnCyGn2ypeSoL276V0YTaoIomUU62jt8k+MzPDSENwToHDDiB0ICAmAHBUj+aqr39IVPeloLvU2dPPgKlB7jIjFh2RjAlkuv1u1ExXZAoz6gATblyo3aRgCYAhs7IcnKeicieqrg+9u0a9Bh/5KfeQjGALZSe7W+I2gGAc9cNMAqcLlidGQ9AeAoQB9mBnATT4vSPXeSxfJbHdIQfRNYXxYhwACwWMejXB4stt6TExwTnJlDwKolN7GQOlB0CEZKAXCQNWBfqk0CEDX3UJ3a/xhXXbYMCMXtALaaCRCphH7du1Ly1MisaKcwyF8eFThYaISDuawdgFOpYXrb/9gl4Z+jyBD5tonjYmGpmKBIqRpVBZRDFs5cIUwxaLRcmKpHAHDckPcwdATQNZCkOuTqpOdmvlNWcrE8pKf3o1bMoWug8o0Dig9pAiAQWvGIhZaUK3GQOKgaaF2qjW4HIGksvXpqZverFQAqbiG5MqqFKLkyyVyhFaZCOimA3CCAZc2saHFc2QGo1DqZIGkkgFl7g5x3ICJ4OamAJzs9hRexgxk1n8MFSHQznjuyks0bDSgHGrlgPskbADqizep0ZpqsYKaR4ZI7AgKAhEI1SEYYSOyFgwPuRELtFpsfFnAXAHUgeUVOWYfRDtkhwg5jUTDmbJAPACjfqQbyHQcwXDiLW65vyBPdzoFprGJTGCbgQCAAqCfcTEHYfdRAk/gNlT0CcMXtPUuYOaCriUv2PFezQ13IGkAgRCLwflSgJy/QAtmO6jBfAGylDQDcHR6na50KGH6zBlCTUH+5sAaCaGB4wYUDrAEAsBvfr3MEQN4sKLHpizRQ5SdOWXjWgFKh+FU1wJXxIhrgSOw7B9yFA6K1FCVRIFf0NzaW848war7MF/fhUoEVPGvAf9aAO5nALrJK0Te1v1nseKMauAEAJtbOgQQNeLMnw1kD5U4DZudAveGAmzlgzl4g9UIsWnVxbyAcgBsqAPOsASMaeHbDdgBgLm4ICtKGfY8F4AC5Ib0ZcUA1sBw04GYAeyS+xp/xBrE4XTTALdXU/PY4UM2CUMxdibph3/akgdbV9k0krFpCHbwAkZD6l731aQBQmBEMIOdJA7ptaOBgAkMdysg99SS3TLkgrUcNEPAXWqqp4EYuQEPSDGYTKbzXgP7lTIIeie6yYUnSfPRsyMY/9X09HTuuMbgimjjgbjkgNqizYHJD8j53AEIWaGY3wdn4fQEAFyRUE8bEFZECeOYAO0nUcyschWwPRNnWaXqj7ResWSbX2xf9QCsiLkopUfrC9YDvRWllDWyHOKAqKNqpRz5Mw5URhSOKg05rQp/6cGmB652M3yEUDHSiVsUciboGCm7+WwB48d7ia/YeC0dYqBBbTlXxwmVhBgO0q5eq+Nz0T2GgSlmugUDcwJTejdS0v92HZ2jVoXR30xc4+jmSfuo0g+vd7B6Jd6UCKnB3anRGqQC81xyTx1v05eaAQIlYygCgDCjcRvXBgqeL3G/fDyfYuDeMWpdPK41v/nQRn6U1xqCrKoBSTvIVLLr5h1X83pyiNUq+dNlm/x/v+LwJbh9L704BQIzBTbv35sOSDgy50PT2vEo66jbwRyT6F2cEMUt/TgCqEODF4cZ8XnQ5ZIIwBhRKgt0GZnyp9DWkkHY6JW95XlV5QgJ3qFYHWP6r/fu11BTGiAbdIdnAXjUgvQJdFl1YxSEiuUpKMqHCgAg31uV9Tt/sXhAUapvHkAokONrAHPRvTByzMCOFNWHiU3P7aUbM6r6QLuLZApQ1+5gOIYc2NfmB2Y1PLkNJi9rAIuf0JK6xi1BjaKONOkEz35mfX4WdsLR5VEs28HeLTN7vHLoKDKX7FhzE92/fimaVVtpvmka1fzjypqsfsB54Xs/1tt7AR3jzSgZhxFe23xGsuw8oAPgBbHCrgcTnF3TptD6s6pne3AwX3+1eKOi7D8w3LO5UwP/GXSvndghLlIB/Jze1e/ldNH9BAf54w8IgFJBvpRsKUM5yh8U5V6xwUcCDL87iEYZZAfMtG6HhVQVgO24XnBCwydY7DcRXuBh+l70r4HzT6o9/UsGRApMObBgi5iiNnsDfGH4K7cXj5lbxxxuXhVlgbxwhcpV4hoDY5ScIfhQsJnXK74FPMfAEolD1kfYb6B2AZ0e4xgIqxWNzVwCEoCZzhMBRm1TjD8ofYZXXWimOoBIw55vXooJSLkaI0d0svnd81QBUgJTkNZONr5HkkYbqdIxjv43O1L4xAg6k3CEgbvTI1r9hh5Tlw8n00xUpC6SEe9fpeoBBwuHFCJU10PjrZANvbl6Bq+jzzrtB2QBlPkUyH+F4EYHICGcOvLrwdlSATXOI2XMXefSFej2o2MqV0O0Rjj8VZyiuRiAvINmNxQ8IGMYNtftJHueOEvxB8DAAewAZoN4f4+FzbGSEPBPRYIDhmr4UA9pN/pSZdtnBBKjgJq95ZHw2QHk4R0S9kNCg+rr/Fe6eD/kCAbNAme3O5UNHI654k9aqxXkqMkB4OknliQYJ9db8Z5kPpcwQIL/cVrCy0JZes8qKE3pEgFf2z4fZcmFfPCCgvOWEBIIi8KjrXrSmD/qTcI1otgb2wPzmNF0oHBCProBksDanStBhnz8R/ES2V04X+UTAmwOFlwONcSDoPChiAz6iIncg9OrGP9jBJITJs3yEuY8HGv+4ogjsfn2yQeBWOPAdUu4bHwzQVVBfh8Sq+ycD7yHw6UwpzrQX5UHtNihbW/RQacz+i0Ul56QC3T/kr5+P9VZFUAYT0Y7qDXT7lfiTYoj/Ocn+/TcHm73tOujScNCfH2Hyv1lQJvPvTv7t0e6qPPD7frP/nXDE/4IhDcuv3x5u3xEU/5fL4Hx+wg3v2/0/He/HDD16JkJOfyU/49QFbnjThX7ygEPCbeD6t0qg9M/qx03tkn74iAc/4QIE2ebfaj+z9wV+wCL8+CEXuD16YShBIdSfiS/YgMzVfvGQi1CRD02lvHtg/Q4Iiwd6DPvsPf0+P+jEcxDmYuIHuERy7UDewaDP1779J/p986gXH0mwCmEKRPWkj3qAhNvp/Dfeftj+54fdEs9F2JYJF85nQtabvefM4g0PqvPfPu7nBYLsSB8rfFB+5ccO+cBTCtg9Usc/eOBRnjVlj0qYDI3nHXOl4hFf/YnHvneZosVP2v/+kc+8D6jUGCJvWjnLzhF2vXw6+2+u/eVDrznzc71R9cBr7rj0/FPA3vlRlC/F/+Cx3/7MMUaC1afjCqyXqihxoCX9Fw8+y2CwP2bNbKzggD74LL/hqeF/9+g3KGjt9cHv6Wns9LMr/uLhd6YgnniP48WLfvyLq/3m6Xs0EHBIqINfXImn313pfwIMAC5vH/oyxYFlAAAAAElFTkSuQmCC
+" rel="icon" type="image/x-icon" />
+
+  <style>
+  /* normalize */
+    html {
+      font-family: sans-serif; /* 1 */
+      -ms-text-size-adjust: 100%; /* 2 */
+      -webkit-text-size-adjust: 100%; /* 2 */
+    }
+    body {
+      margin: 0;
+    }
+    a {
+      background-color: transparent;
+    }
+    a, a:link, a:visited, a:hover {
+      color: #0000ee;
+    }
+    /* From skeleton */
+    /* Grid
+    –––––––––––––––––––––––––––––––––––––––––––––––––– */
+    .container {
+      position: relative;
+      width: 100%;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 0 20px;
+      box-sizing: border-box; }
+    .column,
+    .columns {
+      width: 100%;
+      float: left;
+      box-sizing: border-box; }
+
+    /* For devices larger than 400px */
+    @media (min-width: 400px) {
+      .container {
+        width: 85%;
+        padding: 0; }
+    }
+
+    /* For devices larger than 550px */
+    @media (min-width: 550px) {
+      .container {
+        width: 80%; }
+      .column,
+      .columns {
+        margin-left: 4%; }
+      .column:first-child,
+      .columns:first-child {
+        margin-left: 0; }
+        .seven.columns { width: 56.6666666667%; }
+      }
+      html {
+        font-size: 62.5%; }
+      body {
+        font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
+        line-height: 1.6;
+        font-weight: 400;
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        color: #222; }
+        h1, h2, h3, h4, h5, h6 {
+          margin-top: 0;
+          margin-bottom: 2rem;
+          font-weight: 300; }
+      h4 { font-size: 2.4rem; line-height: 1.35;}
+      @media (min-width: 550px) {
+        h4 { font-size: 3.0rem; }
+      }
+  </style>
+
+</head>
+<body>
+
+  <div class="container">
+    <div class="row">
+      <div class="seven columns" style="margin-top: 25%">
+        <h4>Webrecorder will be back shortly.</h4>
+        <p>For any urgent inquiries, please reach us at <a href="mailto:support@webrecorder.io">support@webrecorder.io</a>.</p>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/services/docker/webrecorder/nginx/Dockerfile
+++ b/services/docker/webrecorder/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.13-alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY webrec.conf /etc/nginx/webrec.conf
+COPY 502.html /usr/share/nginx/html/502.html

--- a/services/docker/webrecorder/nginx/nginx.conf
+++ b/services/docker/webrecorder/nginx/nginx.conf
@@ -1,0 +1,214 @@
+#user www-data;
+worker_processes 8;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    ##
+    # Basic Settings
+    ##
+
+    merge_slashes off;
+    sendfile off;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    # server_tokens off;
+
+    # server_names_hash_bucket_size 64;
+    # server_name_in_redirect off;
+
+    include mime.types;
+    default_type application/octet-stream;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    uwsgi_cache_path /rangecache  levels=1:2  keys_zone=DEF:30m max_size=10G;
+    proxy_cache_path /webcache    levels=1:2  keys_zone=WEB:10m max_size=20G;
+    proxy_cache_path /warccache   levels=1:2  keys_zone=WARC:60m max_size=20G;
+
+    uwsgi_buffer_size 64k;
+    uwsgi_buffers 16 64k;
+    uwsgi_busy_buffers_size 64k;
+
+    uwsgi_request_buffering off;
+    uwsgi_buffering off;
+
+    client_max_body_size 0;
+
+    upstream webrec_app {
+        server app:8081;
+    }
+
+    # unnecessary for perma playbacks
+    #upstream shepherd_app {
+    #    server shepherd:9021;
+    #}
+
+    # Content Server
+    server {
+        listen 81;
+
+        # no access to api via content host!
+        location ~ ^/(api|([^/]+/[^/]+/\$download$)|_upload|_client_ws) {
+            return 403;
+        }
+
+        set $upstreamp webrec_app;
+
+        include webrec.conf;
+    }
+
+    # API Server
+    server {
+        listen 80;
+
+        client_max_body_size 0;
+
+        gzip on;
+        gzip_vary on;
+        gzip_comp_level    5;
+        gzip_min_length 1024;
+        gzip_proxied any;
+        gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/json application/xml image/svg+xml;
+
+        # unnecessary for perma playbacks
+        #location / {
+        #    proxy_pass http://frontend:8095;
+        #}
+
+        location /admin {
+            alias /code/webrecorder/static/admin-static;
+            try_files $uri /admin/index.html;
+        }
+
+        # unnecessary for perma playbacks
+        #location ~ ^/api/browsers/(browsers|init_browser) {
+        #    include uwsgi_params;
+        #
+        #    uwsgi_pass shepherd_app;
+        #}
+
+        location ~* ^/(api|_new|_client_ws|_set_session|\$record/|record/) {
+            include uwsgi_params;
+            uwsgi_pass webrec_app;
+
+            uwsgi_param UWSGI_SCHEME $thescheme;
+        }
+
+        location ~* ^/(_upload.*|.*/\$download)$ {
+            include uwsgi_params;
+            uwsgi_pass webrec_app;
+
+            uwsgi_read_timeout 3000s;
+        }
+
+        location /admin-static {
+            root /code/webrecorder/static;
+        }
+
+        # unnecessary for perma playbacks
+        #location /static/ {
+        #    expires 7d;
+        #    alias /frontend/static/dist/;
+        #}
+
+        location /static/app {
+            alias /code/webrecorder/static/;
+        }
+
+        # unnecessary for perma playbacks
+        #location /static/browsers {
+        #    include uwsgi_params;
+        #
+        #    rewrite /static/browsers/(.*) /static/$1 break;
+        #
+        #    uwsgi_pass shepherd_app;
+        #}
+
+        error_page 502 /502.html;
+        location = /502.html {
+            root /usr/share/nginx/html;
+        }
+    }
+
+    # Local WARC Serve
+    server {
+        listen 6090;
+
+        location /data/warcs {
+            alias /data/warcs;
+        }
+
+        location /data/storage {
+            alias /data/storage;
+        }
+    }
+
+    # reverse proxy for warcserver responses
+    server {
+        listen 1211;
+
+        proxy_cache WARC;
+
+        location / {
+            proxy_cache_methods POST;
+            proxy_cache_key "$request_uri|$request_body";
+            proxy_cache_valid 200;
+
+            proxy_pass http://warcserver:8080;
+            proxy_buffer_size  128k;
+            proxy_buffers 100  128k;
+
+            client_max_body_size 1G;
+        }
+    }
+
+    resolver 8.8.8.8;
+
+    upstream ia {
+        server 172.18.0.1:2006;
+        server web.archive.org:80 max_conns=10 backup;
+    }
+
+    # forward proxy for memento requests
+    server {
+        listen 1210;
+
+        proxy_cache WEB;
+
+        proxy_pass_request_headers on;
+        proxy_set_header Via Webrecorder;
+
+        proxy_cache_key $http_accept_datetime$scheme$proxy_host$uri$is_args$args;
+        proxy_buffer_size  128k;
+        proxy_buffers 100  128k;
+
+        proxy_cache_valid 200 302 301 304 307;
+        proxy_cache_valid 404 5m;
+        proxy_cache_valid any 1m;
+
+        proxy_force_ranges on;
+
+        proxy_ignore_headers Set-Cookie Vary X-Accel-Expires X-Accel-Buffering;
+        add_header X-Proxy-Cache $upstream_cache_status;
+
+        # to correctly handled encoded urls, use the unencoded $request_uri instead of default $url
+        rewrite ^ $request_uri;
+
+        location ~* ^/https?://web[.]archive[.]org/(.*) {
+            proxy_set_header Host web.archive.org;
+            proxy_pass http://ia/$1$is_args$args;
+        }
+
+        location ~* ^/(https?://)([^/]+)(/(.*)) {
+            proxy_set_header Host $2;
+            proxy_pass $1$2$3$is_args$args;
+        }
+    }
+}

--- a/services/docker/webrecorder/nginx/webrec.conf
+++ b/services/docker/webrecorder/nginx/webrec.conf
@@ -1,0 +1,74 @@
+    client_max_body_size 0;
+
+    location /robots.txt {
+            return 200 "User-agent: *\nDisallow: /record/\nDisallow: /replay/\nDisallow: /live/\nDisallow: /patch/\nAllow: /index.html";
+    }
+
+    location ~* ^/(live|([^/]+/[^/]+/[^/]+/(record|patch)))/ {
+        include uwsgi_params;
+
+        set $thescheme $scheme;
+
+        if ($http_x_forwarded_proto) {
+            set $thescheme $http_x_forwarded_proto;
+            #more_clear_input_headers X-Forwarded-Proto;
+        }
+
+        uwsgi_param UWSGI_SCHEME $thescheme;
+        uwsgi_param HTTP_X_FORWARDED_PROTO '';
+        uwsgi_pass $upstreamp;
+    }
+
+    location / {
+        uwsgi_cache  DEF;
+        uwsgi_cache_valid  200 10m;
+
+        uwsgi_buffering on;
+
+        uwsgi_ignore_headers Set-Cookie Expires Cache-Control Vary;
+
+        set $nocache 1;
+        set $cache_key $request_uri;
+
+        set $param_http_range '';
+        set $param_noredirect '';
+
+        if ($arg_range) {
+            #more_set_input_headers 'Range: bytes=$arg_range' 'X-pywb-noredirect: True';
+            set $cache_key '$uri?id=$arg_id&mime=$arg_mime&itag=$arg_itag';
+            set $nocache 0;
+            set $param_http_range "bytes=$arg_range";
+            set $param_noredirect 'True';
+        }
+
+        if ($http_range) {
+            #more_set_input_headers 'X-pywb-noredirect: True';
+            set $nocache 0;
+            add_header Accept-Ranges 'bytes';
+        }
+
+        set $thescheme $scheme;
+        if ($http_x_forwarded_proto) {
+            set $thescheme $http_x_forwarded_proto;
+            #more_clear_input_headers X-Forwarded-Proto;
+        }
+
+        uwsgi_cache_key $cache_key;
+        uwsgi_cache_bypass $nocache;
+        uwsgi_no_cache $nocache;
+
+        uwsgi_force_ranges on;
+
+        include uwsgi_params;
+        uwsgi_param REQUEST_URI  $cache_key;
+
+        uwsgi_param UWSGI_SCHEME $thescheme;
+
+        uwsgi_param HTTP_RANGE $param_http_range if_not_empty;
+        uwsgi_param HTTP_X_PYWB_NOREDIRECT $param_noredirect if_not_empty;
+        uwsgi_param HTTP_X_FORWARDED_PROTO '';
+
+        uwsgi_pass $upstreamp;
+
+        add_header X-Proxy-Cache $upstream_cache_status;
+    }

--- a/services/docker/webrecorder/wr-custom.yaml
+++ b/services/docker/webrecorder/wr-custom.yaml
@@ -1,0 +1,16 @@
+# See https://github.com/webrecorder/webrecorder/blob/master/webrecorder/webrecorder/config/wr.yaml
+# for available settings
+# Include the whole top-level key's values: no way to zero in, so far as I can tell
+
+session.durations:
+    # begin customized
+    short:
+        total: 60
+        extend: 0
+    # end customized
+    long:
+        total: 15724800
+        extend: 604800
+    restricted:
+        total: 5400
+        extend: 0

--- a/services/docker/webrecorder/wr.env
+++ b/services/docker/webrecorder/wr.env
@@ -1,6 +1,9 @@
 # Webrecorder Env
 # This file contains deployment specific params
 
+# Perma's customizations of wr.yaml are in this file
+WR_USER_CONFIG=pkg://webrecorder/config/wr-custom.yaml
+
 # Default storage (local, s3, etc...)
 DEFAULT_STORAGE=local
 

--- a/services/docker/webrecorder/wr.env
+++ b/services/docker/webrecorder/wr.env
@@ -1,0 +1,135 @@
+# Webrecorder Env
+# This file contains deployment specific params
+
+# Default storage (local, s3, etc...)
+DEFAULT_STORAGE=local
+
+# Local Storage Root
+STORAGE_ROOT=/data/storage/
+
+# If invites are required before registration
+# If false, users can register directly
+REQUIRE_INVITES=false
+
+# If set to true/1, anonymous recording is disabled
+ANON_DISABLED=false
+
+# Frontend variables
+# ============================
+NODE_ENV=production
+# internal port mapping for node container
+# FRONTEND_PORT=
+# Scheme for app and content hosts, defaults to http
+# SCHEME=
+
+# server side rendering settings
+INTERNAL_HOST=nginx
+INTERNAL_PORT=80
+DISABLE_SSR=false
+
+# Host settings
+# set to use specific host for content and app
+# recommended for security
+# ============================
+# APP_HOST=
+# CONTENT_HOST=
+APP_HOST=perma.test:8000
+CONTENT_HOST=perma-archives.test:8092
+ALLOW_EXTERNAL=1
+CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
+
+
+# Rate limiting for anon users
+# (0 = disabled, no rate limiting)
+# If both > 0,  users can record upto RATE_LIMIT_MAX bytes
+# over RATE_LIMIT_HOURS
+RATE_LIMIT_MAX=0
+RATE_LIMIT_HOURS=0
+
+# S3 Options (onlt if using S3)
+# =============================
+
+# S3 Path to where WARC data will be stored (only if using s3)
+S3_ROOT=s3://bucket/path/
+
+# S3 Creds (only if using S3)
+AWS_ACCESS_KEY_ID=ACCESS_KEY
+AWS_SECRET_ACCESS_KEY=SECRET_KEY
+
+# Email settings -- for confirmation / invite e-mails
+# =============================
+
+# Webrecorder automated emails
+EMAIL_SENDER=test@localhost
+
+# Email for received "Doesn't Look Right"
+# set to enable email notifications
+SUPPORT_EMAIL=
+
+# SMTP URL for email (see Bottle Cork docs for supported SMTP URL formats: http://cork.firelet.net/howto.html)
+
+# Using local service in Docker "mailserver" container
+EMAIL_SMTP_URL=smtp://test@localhost:archive@webrecorder_mailserver_1:25
+
+# SSL SMTP Example: if using an external service, can use the SSL form, as follows
+#EMAIL_SMTP_URL=ssl://user@host:password@smtp.example.com:465
+
+# Mailing list -- optional 3rd party mailing list management (e.g. Mailchimp)
+# =============================
+# Flag to enable
+MAILING_LIST=false
+
+# API endpoint
+MAILING_LIST_ENDPOINT=
+
+# Flag to turn on mailing list removal on account deletion
+REMOVE_ON_DELETE=false
+
+# API removal endpoint taking a md5 hash of the email as a template argument
+MAILING_LIST_REMOVAL=$MAILING_LIST_ENDPOINT/{0}
+
+# API key
+MAILING_LIST_KEY=
+
+# JSON API payload with python template formatting, available feilds: email, name, username
+MAILING_LIST_PAYLOAD={{"email_address":"{email}","status":"subscribed"}}
+
+# GitHub Bug Reports
+# Set these to add bug reports as issues in designated github repo
+#GH_ISSUE_AUTH=<username>:<token-or-password>
+#GH_ISSUE_REPO=<owner>/<repo>
+
+# POST resource to add users to an announce mailing list
+ANNOUNCE_MAILING_LIST=
+
+# API endpoint for the same resource
+ANNOUNCE_MAILING_LIST_ENDPOINT=
+
+# Redis
+# ==============================
+# Redis Urls for reading, and redis server for master
+# Change from "redis_1" if using a remote redis server, outside Docker
+REDIS_BASE_URL=redis://redis:6379/2
+REDIS_BROWSER_URL=redis://redis:6379/0
+REDIS_SESSION_URL=redis://redis:6379/0
+
+# Container Hosts
+WARCSERVER_HOST=http://warcserver:8080
+RECORD_HOST=http://recorder:8010
+
+# Nginx Cache proxy (for remote content)
+CACHE_PROXY_URL=http://nginx:1210/
+
+
+# Record Root
+RECORD_ROOT=/data/warcs/
+
+# Session Keys
+# ==============================
+
+# Run the init-default.sh script to generate random for these values
+
+# These particular values are just for local dev and testing; regenerate for deployments!
+SECRET_KEY=SVKDUWI4KG3QJUWRJ7MIHQ6PWWJULLRR5L2Z6SNA6JPKSPFYLUX3BYXNCC73G2YNTJFWJ7WSGZANNDULD5POBANYB5DTL7XAG2UA6XDG4ODEAOGBRB77K5WZ
+ENCRYPT_KEY=IUOTAHEJRVYP5H5447FPJX7LJRYI4VOMDVRGE6JANZITDJYJGJVCKZKYQDTEKIUDJXRU4YY2URJEYVFHVQZQ7ZI4C42MEJARFNYLS6ZSVCAG6UV63NAG4TP7
+VALIDATE_KEY=H7G7OBHPPTTVYND3IIRCPYQX3PGOYHDCZOKV4B3AVJE7BH6CLSNQL5J6LTD4JMQIKVSVNMLTGO6HR7ZHQYWQFH77NYCGR2FD3V2GKKBV2ZJQC45IKLXH753T


### PR DESCRIPTION
This is a first pass at running WR locally using our pre-built Docker image. 

Includes an alternate command for `web` in `docker-compose.yml`, if you want Perma to start up automatically when you run `docker-compose up`

If doing simultaneous WR and Perma development, see the instructions at the bottom of `docker-compose.yml` to adjust the network.

Includes two utility functions for clearing WR-related data from Perma's session store, useful when debugging/ restarting services.