### PR TITLE
List on "about" page

### DIFF
--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -68,7 +68,7 @@ Perma.cc prevents link rot.
     <div class="col-sm-8 docs reading-body col-right">
       <h2 class="body-ah">Accounts</h2>
       <p class="body-text">Academic institutions and courts can become registrars of Perma.cc for free, and can provide accounts to their users for free as well.</p>
-      <p class="body-text">Organizations (such as law firms, publishers, non-profits and others) or individuals not associated with an academic institution or court are both able to use Perma via paid subscription:>
+      <p class="body-text">Organizations (such as law firms, publishers, non-profits and others) or individuals not associated with an academic institution or court are both able to use Perma via paid subscription:</p>
       <ul class="body-text" style="list-style: circle;">
         <li>Organizations can administer unlimited Perma accounts for their users for a monthly flat group rate. These registrar accounts also include collaboration tools and administrative controls.</li>
         <li>Individuals can access Perma via tiered subscriptions that fit their particular needs.</li>

--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -68,9 +68,11 @@ Perma.cc prevents link rot.
     <div class="col-sm-8 docs reading-body col-right">
       <h2 class="body-ah">Accounts</h2>
       <p class="body-text">Academic institutions and courts can become registrars of Perma.cc for free, and can provide accounts to their users for free as well.</p>
-      <p class="body-text">Organizations (such as law firms, publishers, non-profits and others) or individuals not associated with an academic institution or court are both able to use Perma via paid subscription:
-      <ul>• Organizations can administer unlimited Perma accounts for their users for a monthly flat group rate. These registrar accounts also include collaboration tools and administrative controls.</ul>
-      <ul>• Individuals can access Perma via tiered subscriptions that fit their particular needs.</ul>
+      <p class="body-text">Organizations (such as law firms, publishers, non-profits and others) or individuals not associated with an academic institution or court are both able to use Perma via paid subscription:>
+      <ul class="body-text" style="list-style: circle;">
+        <li>Organizations can administer unlimited Perma accounts for their users for a monthly flat group rate. These registrar accounts also include collaboration tools and administrative controls.</li>
+        <li>Individuals can access Perma via tiered subscriptions that fit their particular needs.</li>
+      </ul>
       <p class="body-text">Subscription status does not affect the preservation, access, or visibility of already-made links, just the amount of Perma Links a user can create in a given month.</p>
     </div>
   </div>


### PR DESCRIPTION
- tidies HTML
- adds some styling (lists have no bullets in general in our styles; seems unnecessary to add a whole class just for this one list)

before:
![image](https://user-images.githubusercontent.com/11020492/51567341-f192bf80-1e64-11e9-9fca-ddd72c386d57.png)

after:
![image](https://user-images.githubusercontent.com/11020492/51567347-f6f00a00-1e64-11e9-9e41-15355d2134be.png)
