### PR TITLE
Let admins review a user's links

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -143,6 +143,8 @@ class LinkUserAdmin(UserAdmin):
     list_filter = ('is_staff', 'is_active', 'in_trial', 'unlimited', 'nonpaying', 'cached_subscription_status')
     ordering = None
     readonly_fields = ['date_joined']
+    # Adds so many fields to the form that it becomes illegal to submit,
+    # for users with many links.
     # inlines = [
     #     new_class("CreatedLinksInline", LinkInline, fk_name='created_by', verbose_name_plural="Created Links", show_change_link=True),
     # ]

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -151,7 +151,7 @@ class LinkUserAdmin(UserAdmin):
 
 class LinkAdmin(SimpleHistoryAdmin):
     list_display = ['guid', 'submitted_url', 'created_by', 'creation_timestamp', 'tag_list', 'is_private', 'user_deleted']
-    search_fields = ['guid', 'submitted_url', 'tags__name']
+    search_fields = ['guid', 'submitted_url', 'tags__name', 'created_by__email']
     fieldsets = (
         (None, {'fields': ('guid', 'submitted_url', 'submitted_title', 'submitted_description', 'created_by', 'creation_timestamp', 'warc_size', 'replacement_link', 'tags')}),
         ('Visibility', {'fields': ('is_private', 'private_reason', 'is_unlisted',)}),

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -184,7 +184,7 @@ class LinkAdmin(SimpleHistoryAdmin):
 
 class FolderAdmin(MPTTModelAdmin):
     list_display = ['name', 'owned_by', 'organization']
-    list_filter = ['owned_by', 'organization']
+    search_fields = ['name', 'owned_by__email', 'organization__name']
     raw_id_fields = ['parent', 'created_by', 'owned_by', 'organization']
 
 

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -183,6 +183,7 @@ class LinkAdmin(SimpleHistoryAdmin):
 class FolderAdmin(MPTTModelAdmin):
     list_display = ['name', 'owned_by', 'organization']
     list_filter = ['owned_by', 'organization']
+    raw_id_fields = ['parent', 'created_by', 'owned_by', 'organization']
 
 
 class CaptureJobAdmin(admin.ModelAdmin):

--- a/perma_web/perma/templates/admin/perma/linkuser/change_form.html
+++ b/perma_web/perma/templates/admin/perma/linkuser/change_form.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_form.html" %}
+
+{% block after_related_objects %}
+  {{ block.super }}
+  <div class="module aligned">
+    <h2>Links</h2>
+    <div class="form-row">
+      <a href="{% url 'admin:perma_link_changelist' %}?q={{ original.email | urlencode }}">
+        View links created by {{ original.email }}
+      </a>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
I had to remove the feature that used to allow admins to inspect a user's links: links were displayed as an inline on the LinkUser admin page. That made the form illegal to submit, for users with medium-to-large numbers of links: every link added two inputs to the form, all of which POSTed! Altering that behavior of the admin was proving gruesome at best, impossible at worst. So, I removed it.

This PR attempts to provide equivalent functionality by:
- making it possible filter the Link admin by searching for an email address
- putting a link to that filtered view at the bottom of the LinkUser admin page

And while I was in there, I fixed the Folder admin page so it should load in prod now without difficulty.

![image](https://user-images.githubusercontent.com/11020492/51710992-cccf5100-1ff8-11e9-9658-ceef8e460524.png)

![image](https://user-images.githubusercontent.com/11020492/51710987-c640d980-1ff8-11e9-9391-bc8f55a8456f.png)