### PR TITLE
Tests w/ WR playback (local only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ dist: precise
 addons:
   hosts:
     - perma.test
+    - perma-archives.test
 
   # anything we might want to see from a failed build
   artifacts:
     paths:
       - perma_web/failed_test_files
+    debug: true
 
 cache:
   pip: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - default
 
-  # TO USE REDIS:
+  # TO USE REDIS FOR CACHING:
   # 1) comment in the perma-redis stanza
   # 2) comment in the data volume
   # 3) add the caches setting found in settings_prod to your settings.py,
@@ -63,8 +63,10 @@ services:
     extra_hosts:
       - "perma.test:127.0.0.1"
       - "api.perma.test:127.0.0.1"
-      # perma-archives host is unnecessary if playback is handled by WR
+      # N.B. the "perma-archives.test" host is unnecessary if playback is handled by WR
       - "perma-archives.test:127.0.0.1"
+      # N.B. the "web" host is required for functional tests if playback is handled by WR
+      - "web:127.0.0.1"
     ports:
       - "8000:8000"
     depends_on:
@@ -72,6 +74,22 @@ services:
     networks:
       - default
       - webrecorder
+
+
+  #
+  # Perma Functional Tests
+  #
+  selenium:
+    image: selenium/standalone-chrome:3.141.59-fluorine
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - START_XVFB=false
+    ports:
+      - 4444:4444
+    networks:
+      - default
+
 
   #
   # Perma Payments
@@ -168,9 +186,15 @@ services:
       - 8092:81
     extra_hosts:
       - "perma-archives.test:127.0.0.1"
+      # See "aliases" for explanation of "perma-archives"
+      - "perma-archives:127.0.0.1"
     networks:
-      - default
-      - webrecorder
+      default:
+        aliases:
+          # Alias this service for functional tests, since WR disallows identical hosts for content and API access.
+          # This permits us to access the API at "nginx" and content at "perma-archives".
+          - perma-archives
+      webrecorder:
 
   redis:
     image: redis:4.0.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,8 @@ services:
     volumes:
       - wr_warcs:/data/warcs:ro
       - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
+      - ./services/docker/webrecorder/uploadcontroller.py:/code/webrecorder/uploadcontroller.py:ro
+      - ./services/docker/webrecorder/usercontroller.py:/code/webrecorder/usercontroller.py:ro
     networks:
       - webrecorder
 

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -137,3 +137,15 @@ TIERS = {
         }
     ]
 }
+
+REMOTE_SELENIUM = False
+if REMOTE_SELENIUM:
+    HOST = 'web:8000'
+    PLAYBACK_HOST = 'web:8000'
+    ALLOWED_HOSTS.append('web')
+
+ENABLE_WR_PLAYBACK = False
+if ENABLE_WR_PLAYBACK:
+    assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
+    WR_API = 'http://nginx:80/api/v1'
+    PLAYBACK_HOST = 'perma-archives:81'

--- a/perma_web/perma/tests/test_urls.py
+++ b/perma_web/perma/tests/test_urls.py
@@ -10,9 +10,14 @@ class UrlsTestCase(PermaTestCase):
         A really simple test for 500 errors. We test all views that don't
         take parameters (it's not easy to guess what params they want).
         """
+        exclude = {
+            'archive_error': 'because it returns 500 by default'
+        }
 
         for urlpattern in urlpatterns:
-            if '?P<' not in urlpattern.regex.pattern and urlpattern.name:
+            if '?P<' not in urlpattern.regex.pattern \
+                     and urlpattern.name \
+                     and urlpattern.name not in exclude:
                 response = self.client.get(reverse(urlpattern.name))
                 self.assertNotEqual(response.status_code, 500)
 

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -598,12 +598,13 @@ def clear_wr_session(request):
     """
     Clear Webrecorder session info in Perma and in WR
     """
-    wr_username = request.session.pop('wr_username', None)
-    wr_session_cookie = request.session.pop('wr_session_cookie', None)
+    wr_username = request.session.get('wr_username')
+    wr_session_cookie = request.session.get('wr_session_cookie')
 
     for key in list(request.session.keys()):
-        if key.startswith('wr_uploaded:'):
-            request.session.pop(key, None)
+        if key.startswith('wr_'):
+            del request.session[key]
+    request.session.save()
 
     if not wr_username or not wr_session_cookie:
         return

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -637,6 +637,7 @@ def get_wr_uploaded(request, link):
 
 def query_wr_api(method, path, cookie, valid_if, json=None, data=None):
     # Make the request
+
     try:
         response = requests.request(
             method,
@@ -644,7 +645,9 @@ def query_wr_api(method, path, cookie, valid_if, json=None, data=None):
             json=json,
             data=data,
             headers={'Host': settings.HOST},
-            cookies={'__wr_sesh': cookie}
+            cookies={'__wr_sesh': cookie},
+            timeout=10,
+            allow_redirects=False
         )
     except requests.exceptions.RequestException as e:
         raise WebrecorderException() from e

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -195,7 +195,7 @@ def single_permalink(request, guid):
         'protocol': protocol(),
     }
 
-    if settings.ENABLE_WR_PLAYBACK:
+    if settings.ENABLE_WR_PLAYBACK and context['can_view'] and not link.user_deleted:
         wr_username = link.init_replay_for_user(request)
         context.update({
             'wr_host': settings.PLAYBACK_HOST,

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -424,16 +424,13 @@ def archive_error(request):
         set_options_headers(request, response)
         return response
 
-    status = request.GET.get('status')
-    status_line = '{0} {1}'.format(status, responses.get(int(status), ''))
-
+    status_code = int(request.GET.get('status', '500'))
     response = render(request, 'archive/archive-error.html', {
         'err_url': request.GET.get('url'),
         'timestamp': request.GET.get('timestamp'),
-        'status': status_line,
+        'status': '{0} {1}'.format(status_code, responses.get(status_code)),
         'err_msg': request.GET.get('error'),
-    }, status=status)
-
+    }, status=status_code)
 
     # even if not setting full headers (eg. if Origin is not set)
     # still set set Access-Control-Allow-Origin to content host to avoid Chrome CORB issues

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1200,6 +1200,7 @@ def limited_login(request, template_name='registration/login.html',
     """
 
     if request.method == "POST" and not request.user.is_authenticated:
+        clear_wr_session(request)
         username = request.POST.get('username')
         try:
             target_user = LinkUser.objects.get(email=username)
@@ -1218,7 +1219,6 @@ def limited_login(request, template_name='registration/login.html',
             super(LoginForm, self).__init__(*args, **kwargs)
             self.fields['username'].widget.attrs['autofocus'] = ''
 
-    clear_wr_session(request)
     return auth_views.LoginView.as_view(template_name=template_name, redirect_field_name=redirect_field_name, authentication_form=LoginForm, extra_context=extra_context, redirect_authenticated_user=True)(request)
 
 

--- a/services/docker/webrecorder/uploadcontroller.py
+++ b/services/docker/webrecorder/uploadcontroller.py
@@ -1,0 +1,74 @@
+from webrecorder.basecontroller import BaseController
+from webrecorder.models.importer import UploadImporter
+from webrecorder.models.stats import Stats
+
+from bottle import request
+
+
+# ============================================================================
+class UploadController(BaseController):
+    def __init__(self, *args, **kwargs):
+        super(UploadController, self).__init__(*args, **kwargs)
+        content_app = kwargs['content_app']
+
+        self.uploader = UploadImporter(self.redis,
+                                       self.config,
+                                       wam_loader=content_app.wam_loader)
+
+    def init_routes(self):
+        @self.app.put(['/_upload', '/api/v1/upload'])
+        def upload_file():
+            user = self.access.session_user
+            force_coll_name = request.query.getunicode('force-coll', '')
+
+            if force_coll_name:
+                collection = user.get_collection_by_name(force_coll_name)
+            else:
+                collection = None
+
+            # allow uploading to external collections
+            if not collection or not collection.is_external():
+                if user.is_anon():
+                    return self._raise_error(400, 'not_logged_in')
+
+            expected_size = int(request.headers['Content-Length'])
+
+            if not expected_size:
+                return self._raise_error(400, 'no_file_specified')
+
+            filename = request.query.getunicode('filename')
+            stream = request.environ['wsgi.input']
+
+            res = self.uploader.upload_file(user,
+                                    stream,
+                                    expected_size,
+                                    filename,
+                                    force_coll_name)
+
+            if 'error' in res:
+                return self._raise_error(400, res['error'])
+
+            Stats(self.redis).incr_upload(user, expected_size)
+            return res
+
+        @self.app.get(['/_upload/<upload_id>', '/api/v1/upload/<upload_id>'])
+        def get_upload_status(upload_id):
+            # By default, this method redirects you to the "APP_HOST",
+            # which is not correct for the Perma / WR integration as
+            # currently designed, where Perma is the "APP_HOST".
+            #
+            # Disable redir_check to prevent this improper redirect.
+            # https://github.com/webrecorder/webrecorder/blob/master/webrecorder/webrecorder/basecontroller.py#L114
+            #
+            # What's the correct way to solve this, going forward?
+            # Perma customizing WR code like this is not it :-)
+            #
+            user = self.get_user(api=True, redir_check=False)
+
+            props = self.uploader.get_upload_status(user, upload_id)
+
+            if not props:
+                return self._raise_error(400, 'upload_expired')
+
+            return props
+

--- a/services/docker/webrecorder/usercontroller.py
+++ b/services/docker/webrecorder/usercontroller.py
@@ -1,0 +1,284 @@
+
+import json
+import redis
+
+from bottle import request, response
+
+from webrecorder.basecontroller import BaseController, wr_api_spec
+
+from webrecorder.webreccork import ValidationException
+from webrecorder.utils import get_bool
+
+from urllib.parse import urlencode
+
+
+# ============================================================================
+class UserController(BaseController):
+    def __init__(self, *args, **kwargs):
+        super(UserController, self).__init__(*args, **kwargs)
+        config = kwargs['config']
+
+        self.default_user_desc = config['user_desc']
+
+    def load_user(self, username=None):
+        include_colls = get_bool(request.query.get('include_colls', False))
+
+        if username:
+            user = self.get_user(user=username)
+        else:
+            user = self.access.session_user
+
+        return {'user': user.serialize(include_colls=include_colls)}
+
+    def new_auth(self):
+        user = self.access.init_session_user(persist=True)
+
+        return {'user': user.serialize()}
+
+    def get_user_or_raise(self, username=None, status=403, msg='unauthorized'):
+        # With the Perma / WR integration as currently designed,
+        # Perma is the APP_HOST, so this check will always
+        # fail. Commenting it out for now.
+        #
+        # What's the correct way to solve this, going forward?
+        # Perma customizing WR code like this is not it :-)
+        #
+        # ensure correct host
+        # if self.app_host and request.environ.get('HTTP_HOST') != self.app_host:
+        #     return self._raise_error(403, 'unauthorized')
+
+        # if no username, check if logged in
+        if not username:
+            if self.access.is_anon():
+                self._raise_error(status, msg)
+            return
+
+        #
+        # get_user also attempts to redirect to APP_HOST,
+        # which doesn't work for the Perma use case, for the same reason
+        user = self.get_user(user=username, redir_check=False)
+
+        # check permissions
+        if not self.access.is_logged_in_user(user) and not self.access.is_superuser():
+            self._raise_error(status, msg)
+
+        return user
+
+    def init_routes(self):
+        wr_api_spec.set_curr_tag('Auth')
+
+        # USER CHECKS
+        @self.app.get('/api/v1/auth/check_username/<username>')
+        def test_username(username):
+            """async precheck username availability on signup form"""
+
+            if self.user_manager.is_username_available(username):
+                return {'success': True}
+            else:
+                return self._raise_error(400, 'username_not_available')
+
+        # GET CURRENT USER
+        @self.app.get('/api/v1/auth/curr_user')
+        def load_user():
+            return self.load_user()
+
+        # AUTH NEW SESSION
+        @self.app.post('/api/v1/auth/anon_user')
+        def new_auth():
+            return self.new_auth()
+
+        # REGISTRATION
+        @self.app.post('/api/v1/auth/register')
+        def api_register_user():
+            data = request.json or {}
+
+            msg, redir_extra = self.user_manager.register_user(data, self.get_host())
+
+            if 'success' in msg:
+                return msg
+
+            response.status = 400
+
+            return {'errors': msg}
+
+        @self.app.post('/api/v1/auth/validate')
+        def api_validate_reg_user():
+            data = request.json or {}
+            reg = data.get('reg')
+
+            cookie = request.environ.get('webrec.request_cookie', '')
+
+            username = request.query.getunicode('username')
+
+            result = self.user_manager.validate_registration(reg, cookie, username)
+            if 'error' in result or 'errors' in result:
+                response.status = 400
+
+            return result
+
+        # LOGIN
+        @self.app.post('/api/v1/auth/login')
+        def login():
+            """Authenticate users"""
+
+            if not self.access.is_anon():
+                return self._raise_error(403, 'already_logged_in')
+
+            include_colls = get_bool(request.query.get('include_colls', False))
+
+            result = self.user_manager.login_user(request.json or {})
+
+            if 'success' in result:
+                data = {'user': self.access.session_user.serialize(include_colls)}
+                if result.get('new_coll_name'):
+                    data['new_coll_name'] = result['new_coll_name']
+
+                return data
+
+            #self._raise_error(401, result.get('error', ''))
+            response.status = 401
+            return result
+
+        @self.app.post('/api/v1/auth/logout')
+        def logout():
+            self.get_user_or_raise()
+
+            self.user_manager.logout()
+
+            data = {'success': 'logged_out'}
+
+            return data
+
+        # PASSWORD
+        @self.app.post('/api/v1/auth/password/reset_request')
+        def request_reset_password():
+            data = request.json or {}
+            email = data.get('email', '')
+            username = data.get('username', '')
+            host = self.get_host()
+
+            try:
+                self.user_manager.cork.send_password_reset_email(
+                                          username=username,
+                                          email_addr=email,
+                                          subject='webrecorder.io password reset confirmation',
+                                          email_template='webrecorder/templates/emailreset.html',
+                                          host=host)
+
+                return {'success': True}
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                self._raise_error(404, 'no_such_user')
+
+        @self.app.post('/api/v1/auth/password/reset')
+        def reset_password():
+            #self.get_user_or_raise()
+            if not self.access.is_anon():
+                return self._raise_error(403, 'already_logged_in')
+
+            data = request.json or {}
+
+            password = data.get('newPass', '')
+            confirm_password = data.get('newPass2', '')
+            reset_code = data.get('resetCode', '')
+
+            try:
+                self.user_manager.reset_password(password, confirm_password, reset_code)
+                return {'success': True}
+            except ValidationException as ve:
+                self._raise_error(403, str(ve))
+
+        @self.app.post('/api/v1/auth/password/update')
+        def update_password():
+            self.get_user_or_raise()
+
+            data = request.json or {}
+
+            curr_password = data.get('currPass', '')
+            password = data.get('newPass', '')
+            confirm_password = data.get('newPass2', '')
+
+            try:
+                self.user_manager.update_password(curr_password, password,
+                                                  confirm_password)
+                return {'success': True}
+            except ValidationException as ve:
+                return self._raise_error(403, str(ve))
+
+        # Skip POST request recording
+        @self.app.post('/api/v1/auth/skipreq')
+        def skip_req():
+            data = request.json or {}
+            url = data.get('url', '')
+            self.access.session_user.mark_skip_url(url)
+            return {'success': True}
+
+
+        # USER API
+        wr_api_spec.set_curr_tag('Users')
+
+        @self.app.get('/api/v1/user/<username>')
+        def api_get_user(username):
+            """API enpoint to return user info"""
+            return self.load_user(username)
+
+        @self.app.delete('/api/v1/user/<username>')
+        def api_delete_user(username):
+            """API enpoint to delete a user"""
+
+            self.get_user_or_raise(username, 404, 'not_found')
+
+            # TODO? add validation
+            #self.validate_csrf()
+            try:
+                assert(self.user_manager.delete_user(username))
+                request.environ['webrec.delete_all_cookies'] = 'all'
+            except:
+                #return {'error_message': 'Could not delete user: ' + username}
+                return self._raise_error(400, 'error_deleting')
+
+            data = {'deleted_user': username}
+            return data
+
+        @self.app.post('/api/v1/user/<username>')
+        def update_user(username):
+            user = self.get_user(user=username)
+
+            data = request.json or {}
+
+            if 'desc' in data:
+                user['desc'] = data['desc']
+
+            if 'full_name' in data:
+                user['full_name'] = data['full_name'][:150]
+
+            if 'display_url' in data:
+                user['display_url'] = data['display_url'][:500]
+
+            return {'success': True}
+
+
+        # OLD VIEWS BELOW
+        # ====================================================================
+        @self.app.get(['/<username>', '/<username>/'])
+        @self.jinja2_view('user.html')
+        def user_info(username):
+            self.redir_host()
+
+            user = self.get_user(user=username)
+
+            if self.access.is_anon(user):
+                self.redirect('/' + user.my_id + '/temp')
+
+            result = {
+                'user': user.name,
+                'user_info': user.serialize(),
+                'collections': [coll.serialize() for coll in user.get_collections()],
+            }
+
+            if not result['user_info'].get('desc'):
+                result['user_info']['desc'] = self.default_user_desc.format(user)
+
+            return result
+

--- a/services/docker/webrecorder/wr.env
+++ b/services/docker/webrecorder/wr.env
@@ -39,16 +39,16 @@ ALLOW_EXTERNAL=1
 # If running the Perma dev server and loading from your localhost
 # (e.g., from the docker machine, not from a container),
 # use hosts and ports appropriate for localhost + docker-compose
-#APP_HOST=perma.test:8000
-#CONTENT_HOST=perma-archives.test:8092
-#CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
+APP_HOST=perma.test:8000
+CONTENT_HOST=perma-archives.test:8092
+CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
 
 # If running the Perma tests, which take place entirely within containers,
 # use hosts that docker can resolve, and the ports the services are expecting
 # (e.g., the ports AFTER the colon, in docker-compose)
-APP_HOST=web:8000
-CONTENT_HOST=perma-archives:81
-CONTENT_ERROR_REDIRECT=http://web:8000/archive-error
+#APP_HOST=web:8000
+#CONTENT_HOST=perma-archives:81
+#CONTENT_ERROR_REDIRECT=http://web:8000/archive-error
 
 # Rate limiting for anon users
 # (0 = disabled, no rate limiting)

--- a/services/docker/webrecorder/wr.env
+++ b/services/docker/webrecorder/wr.env
@@ -34,13 +34,21 @@ DISABLE_SSR=false
 # set to use specific host for content and app
 # recommended for security
 # ============================
-# APP_HOST=
-# CONTENT_HOST=
-APP_HOST=perma.test:8000
-CONTENT_HOST=perma-archives.test:8092
 ALLOW_EXTERNAL=1
-CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
 
+# If running the Perma dev server and loading from your localhost
+# (e.g., from the docker machine, not from a container),
+# use hosts and ports appropriate for localhost + docker-compose
+#APP_HOST=perma.test:8000
+#CONTENT_HOST=perma-archives.test:8092
+#CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
+
+# If running the Perma tests, which take place entirely within containers,
+# use hosts that docker can resolve, and the ports the services are expecting
+# (e.g., the ports AFTER the colon, in docker-compose)
+APP_HOST=web:8000
+CONTENT_HOST=perma-archives:81
+CONTENT_ERROR_REDIRECT=http://web:8000/archive-error
 
 # Rate limiting for anon users
 # (0 = disabled, no rate limiting)
@@ -49,7 +57,7 @@ CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
 RATE_LIMIT_MAX=0
 RATE_LIMIT_HOURS=0
 
-# S3 Options (onlt if using S3)
+# S3 Options (only if using S3)
 # =============================
 
 # S3 Path to where WARC data will be stored (only if using s3)


### PR DESCRIPTION
This PR fixes a number of issues that were uncovered by running tests locally with `ENABLE_WR_PLACKBACK=True`, and adds infrastructure for running functional tests using headless Chrome in a Docker container whose image is managed by SeleniumHQ.

It does not change how tests run by default: `ENABLE_WR_PLAYBACK` and `REMOTE_SELENIUM` are both False.

To-dos and remarks:
- It does not appear that Webrecorder playback works in PhantomJS; TBD.
- Perma's JS error reporting does not appear to work with the dockerized Chrome; TBD
- This includes two workarounds for WR auth difficulties; TBD with WR team.
- This does not include a mechanism for easily switching between WR "dev" and "testing" settings (toggle comments, restart the containers in between)
- Next: Travis config for running with `REMOTE_SELENIUM` True..... Docker!