### PR TITLE
Optionally run tests with Selenium/Chrome and Webrecorder on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ python:
   - "3.5"
 env: CFLAGS="-O0"
 
-dist: precise
+dist: trusty
+
+services:
+  - docker
+  - mysql
 
 # make sure perma.test resolves to localhost so our tests work
 addons:
@@ -33,7 +37,7 @@ before_install:
 install:
   # python reqs
   - pip install -U pip
-  - pip install pipenv
+  - pip install -U pipenv
   - pipenv install --deploy --dev
   - pip install coveralls
 
@@ -53,6 +57,9 @@ before_script:
   - mysql -e 'SET GLOBAL wait_timeout = 36000;'
   - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
 
+  # spin up selenium and webrecorder
+  - docker-compose -f ../docker-compose-travis.yml up -d
+  - sleep 10
   - date
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,13 @@ before_script:
   - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
 
   # spin up selenium and webrecorder
+  # healthcheck adapted from https://stackoverflow.com/a/46005602
   - docker-compose -f ../docker-compose-travis.yml up -d
   - sleep 10
+  - sh -c "[ $(curl -o /dev/null --max-time 10 --head --silent --write-out "%{http_code}" http://perma-archives.test:8089/api/v1) -eq 200 ] && echo 'Webrecorder API is up!' || (echo 'Webrecorder API not available'; exit 1)"
+  - sh -c "[ $(curl -o /dev/null --max-time 10 --head --silent --write-out "%{http_code}" http://perma-archives.test:8092/) -eq 303 ] && echo 'Webrecorder content host responsive!' || (echo 'Webrecorder content host not available'; exit 1)"
+  - docker-compose -f ../docker-compose-travis.yml exec selenium sh -c "[ $(curl -o /dev/null --max-time 10 --head --silent --write-out "%{http_code}" http://perma-archives.test:8089/api/v1) -eq 200 ] && echo 'Selenium container can communicate with Webrecorder' || (echo 'Selenium container cannot communicate with Webrecorder...'; exit 1)"
+
   - date
 
 script:
@@ -68,6 +73,7 @@ script:
 
 after_failure:
   - date
+  - docker-compose -f ../docker-compose-travis.yml logs
 after_success:
   - date
   - coverage report

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -14,3 +14,87 @@ services:
     ports:
       - 4444:4444
     network_mode: "host"
+
+  #
+  # Webrecorder
+  #
+  app:
+    image: harvardlil/webrecorder:0.06
+    command: uwsgi /code/apps/apiapp.ini
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    depends_on:
+      - warcserver
+      - recorder
+      - redis
+    volumes:
+      - wr_warcs:/data/warcs:ro
+      - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
+      - ./services/docker/webrecorder/uploadcontroller.py:/code/webrecorder/uploadcontroller.py:ro
+      - ./services/docker/webrecorder/usercontroller.py:/code/webrecorder/usercontroller.py:ro
+    networks:
+      - webrecorder
+
+  recorder:
+    image: harvardlil/webrecorder:0.06
+    command: uwsgi /code/apps/rec.ini
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    depends_on:
+      - warcserver
+      - redis
+    volumes:
+      - wr_warcs:/data/warcs
+      - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
+    networks:
+      - webrecorder
+
+  warcserver:
+    image: harvardlil/webrecorder:0.06
+    command: uwsgi /code/apps/load.ini
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    depends_on:
+      - redis
+    volumes:
+      - wr_warcs:/data/warcs:ro
+      - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
+    networks:
+      - webrecorder
+
+  nginx:
+    image: nginx:1.13-alpine
+    depends_on:
+      - app
+    volumes:
+      - wr_warcs:/data/warcs:ro
+      - ./services/docker/webrecorder/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./services/docker/webrecorder/nginx/webrec.conf:/etc/nginx/webrec.conf:ro
+      - ./services/docker/webrecorder/nginx/502.html:/usr/share/nginx/html/502.html:ro
+    ports:
+      # The WR API
+      - 8089:80
+      # WR "content"/playback host
+      - 8092:81
+    extra_hosts:
+      - "perma-archives.test:127.0.0.1"
+    networks:
+      default:
+      webrecorder:
+
+  redis:
+    image: redis:4.0.6
+    env_file:
+      - ./services/docker/webrecorder/wr.env
+    volumes:
+      - wr_redis_data:/data:delegated
+    networks:
+      - webrecorder
+
+volumes:
+  wr_warcs:
+  wr_redis_data:
+
+networks:
+  default:
+  webrecorder:

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+
+  #
+  # Perma Functional Tests
+  #
+  selenium:
+    image: selenium/standalone-chrome:3.141.59-fluorine
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - START_XVFB=false
+    ports:
+      - 4444:4444
+    network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,14 +188,8 @@ services:
       - 8092:81
     extra_hosts:
       - "perma-archives.test:127.0.0.1"
-      # See "aliases" for explanation of "perma-archives"
-      - "perma-archives:127.0.0.1"
     networks:
       default:
-        aliases:
-          # Alias this service for functional tests, since WR disallows identical hosts for content and API access.
-          # This permits us to access the API at "nginx" and content at "perma-archives".
-          - perma-archives
       webrecorder:
 
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       - webrecorder
 
   nginx:
-    image: webrecorder/nginx
+    image: nginx:1.13-alpine
     depends_on:
       - app
     volumes:

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -65,6 +65,10 @@ def test(apps=_default_tests):
 @task
 def test_python(apps=_default_tests, travis=False):
     """ Run Python tests. """
+    if os.environ.get('DOCKERIZED'):
+        print("\n\n\n!!!!!!\n!!!!!!\nWarning! Webrecorder requires test-specific settings in this context.\n" +
+              "Be sure to services/docker/webrecorder/wr.env appropriately and\n" +
+              "reload the WR containers by re-running `docker-compose up` before running tests.\n!!!!!!\n!!!!!!\n\n\n")
 
     # .pyc files can contain filepaths; this permits easy switching
     # between a Vagrant- and Docker-based dev environment

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -67,7 +67,7 @@ def test_python(apps=_default_tests, travis=False):
     """ Run Python tests. """
     if os.environ.get('DOCKERIZED'):
         print("\n\n\n!!!!!!\n!!!!!!\nWarning! Webrecorder requires test-specific settings in this context.\n" +
-              "Be sure to services/docker/webrecorder/wr.env appropriately and\n" +
+              "Be sure to edit services/docker/webrecorder/wr.env appropriately and\n" +
               "reload the WR containers by re-running `docker-compose up` before running tests.\n!!!!!!\n!!!!!!\n\n\n")
 
     # .pyc files can contain filepaths; this permits easy switching

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -206,9 +206,10 @@ class FunctionalTest(BaseTestCase):
         options.add_argument('headless')
         options.add_argument('window-size=1024x800')
         cls.driver = webdriver.Remote(
-            command_executor='http://selenium:4444/wd/hub',
+            command_executor='http://{}:4444/wd/hub'.format(settings.REMOTE_SELENIUM_HOST),
             desired_capabilities=options.to_capabilities()
         )
+
 
     @classmethod
     def setUpLocal(cls):

--- a/perma_web/functional_tests/tests.py
+++ b/perma_web/functional_tests/tests.py
@@ -7,7 +7,6 @@ import datetime
 import sys
 from urllib.parse import urlparse
 import requests
-from pyvirtualdisplay import Display
 from selenium import webdriver
 from selenium.common.exceptions import ElementNotVisibleException, NoSuchElementException, StaleElementReferenceException
 import time
@@ -213,13 +212,7 @@ class FunctionalTest(BaseTestCase):
 
     @classmethod
     def setUpLocal(cls):
-        try:
-            # use Firefox if available on local system
-            cls.virtual_display = Display(visible=0, size=(1024, 800))
-            cls.virtual_display.start()
-            cls.driver = webdriver.Firefox(capabilities=cls.base_desired_capabilities)
-        except RuntimeError:
-            cls.driver = webdriver.PhantomJS(desired_capabilities=cls.base_desired_capabilities)
+        cls.driver = webdriver.PhantomJS(desired_capabilities=cls.base_desired_capabilities)
         cls.driver.set_window_size(1024, 800)
         socket.setdefaulttimeout(30)
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -541,6 +541,8 @@ USE_SAUCE = False  # Default to local functional tests
 SAUCE_USERNAME = None
 SAUCE_ACCESS_KEY = None
 TESTING = False
+REMOTE_SELENIUM = False
+REMOTE_SELENIUM_HOST = None
 
 WARC_STORAGE_DIR = 'warcs'  # relative to MEDIA_ROOT
 

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -140,7 +140,7 @@ TIERS = {
     ]
 }
 
-REMOTE_SELENIUM = False
+REMOTE_SELENIUM = True
 if REMOTE_SELENIUM:
     if os.environ.get('DOCKERIZED'):
         HOST = 'web:8000'
@@ -153,7 +153,7 @@ if REMOTE_SELENIUM:
         REMOTE_SELENIUM_HOST = 'localhost'
 
 
-ENABLE_WR_PLAYBACK = False
+ENABLE_WR_PLAYBACK = True
 if ENABLE_WR_PLAYBACK:
     assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
     if os.environ.get('DOCKERIZED'):

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -1,3 +1,5 @@
+import os
+
 from .settings_dev import *
 
 #########
@@ -140,9 +142,16 @@ TIERS = {
 
 REMOTE_SELENIUM = False
 if REMOTE_SELENIUM:
-    HOST = 'web:8000'
-    PLAYBACK_HOST = 'web:8000'
-    ALLOWED_HOSTS.append('web')
+    if os.environ.get('DOCKERIZED'):
+        HOST = 'web:8000'
+        PLAYBACK_HOST = 'web:8000'
+        ALLOWED_HOSTS.append('web')
+        REMOTE_SELENIUM_HOST = 'selenium'
+    else:
+        HOST = 'perma.test:8000'
+        PLAYBACK_HOST = 'perma-archives.test:8000'
+        REMOTE_SELENIUM_HOST = 'localhost'
+
 
 ENABLE_WR_PLAYBACK = False
 if ENABLE_WR_PLAYBACK:

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -156,5 +156,9 @@ if REMOTE_SELENIUM:
 ENABLE_WR_PLAYBACK = False
 if ENABLE_WR_PLAYBACK:
     assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
-    WR_API = 'http://nginx:80/api/v1'
-    PLAYBACK_HOST = 'nginx:81'
+    if os.environ.get('DOCKERIZED'):
+        WR_API = 'http://nginx:80/api/v1'
+        PLAYBACK_HOST = 'nginx:81'
+    else:
+        WR_API = 'http://perma-archives.test:8089/api/v1'
+        PLAYBACK_HOST = 'perma-archives.test:8092'

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -140,7 +140,7 @@ TIERS = {
     ]
 }
 
-REMOTE_SELENIUM = True
+REMOTE_SELENIUM = False
 if REMOTE_SELENIUM:
     if os.environ.get('DOCKERIZED'):
         HOST = 'web:8000'
@@ -153,7 +153,7 @@ if REMOTE_SELENIUM:
         REMOTE_SELENIUM_HOST = 'localhost'
 
 
-ENABLE_WR_PLAYBACK = True
+ENABLE_WR_PLAYBACK = False
 if ENABLE_WR_PLAYBACK:
     assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
     if os.environ.get('DOCKERIZED'):

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -157,4 +157,4 @@ ENABLE_WR_PLAYBACK = False
 if ENABLE_WR_PLAYBACK:
     assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
     WR_API = 'http://nginx:80/api/v1'
-    PLAYBACK_HOST = 'perma-archives:81'
+    PLAYBACK_HOST = 'nginx:81'

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -102,7 +102,7 @@ class CommonViewsTestCase(PermaTestCase):
 
     def test_replacement_link(self):
         response = self.client.get(reverse('single_permalink', kwargs={'guid': 'ABCD-0006'}))
-        self.assertRedirects(response, reverse('single_permalink', kwargs={'guid': '3SLN-JHX9'}))
+        self.assertRedirects(response, reverse('single_permalink', kwargs={'guid': '3SLN-JHX9'}), fetch_redirect_response=False)
 
 
     ###

--- a/services/docker/webrecorder/nginx/nginx.conf
+++ b/services/docker/webrecorder/nginx/nginx.conf
@@ -46,9 +46,9 @@ http {
     }
 
     # unnecessary for perma playbacks
-    #upstream shepherd_app {
-    #    server shepherd:9021;
-    #}
+    # upstream shepherd_app {
+    #    server shepherd:9020;
+    # }
 
     # Content Server
     server {
@@ -78,9 +78,9 @@ http {
         gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/json application/xml image/svg+xml;
 
         # unnecessary for perma playbacks
-        #location / {
+        # location / {
         #    proxy_pass http://frontend:8095;
-        #}
+        # }
 
         location /admin {
             alias /code/webrecorder/static/admin-static;
@@ -88,10 +88,13 @@ http {
         }
 
         # unnecessary for perma playbacks
-        #location ~ ^/api/browsers/(browsers|init_browser) {
-        #    include uwsgi_params;
+        # location ~ ^/api/browsers/(browsers|api/start_flock) {
+        #    #include uwsgi_params;
         #
-        #    uwsgi_pass shepherd_app;
+        #    rewrite /api/browsers/(.*) /$1 break;
+        #
+        #    #uwsgi_pass shepherd_app;
+        #    proxy_pass http://shepherd:9020;
         #}
 
         location ~* ^/(api|_new|_client_ws|_set_session|\$record/|record/) {
@@ -113,7 +116,7 @@ http {
         }
 
         # unnecessary for perma playbacks
-        #location /static/ {
+        # location /static/ {
         #    expires 7d;
         #    alias /frontend/static/dist/;
         #}
@@ -123,13 +126,14 @@ http {
         }
 
         # unnecessary for perma playbacks
-        #location /static/browsers {
+        # location /static/browsers {
         #    include uwsgi_params;
         #
         #    rewrite /static/browsers/(.*) /static/$1 break;
         #
-        #    uwsgi_pass shepherd_app;
-        #}
+        #    #uwsgi_pass shepherd_app;
+        #    proxy_pass http://shepherd:9020;
+        # }
 
         error_page 502 /502.html;
         location = /502.html {
@@ -173,7 +177,7 @@ http {
 
     upstream ia {
         server 172.18.0.1:2006;
-        server web.archive.org:80 max_conns=10 backup;
+        #server web.archive.org:80 max_conns=10 backup;
     }
 
     # forward proxy for memento requests

--- a/services/docker/webrecorder/wr.env
+++ b/services/docker/webrecorder/wr.env
@@ -36,18 +36,19 @@ DISABLE_SSR=false
 # ============================
 ALLOW_EXTERNAL=1
 
-# If running the Perma dev server and loading from your localhost
-# (e.g., from the docker machine, not from a container),
-# use hosts and ports appropriate for localhost + docker-compose
 APP_HOST=perma.test:8000
 CONTENT_HOST=perma-archives.test:8092
 CONTENT_ERROR_REDIRECT=http://perma.test:8000/archive-error
 
-# If running the Perma tests, which take place entirely within containers,
-# use hosts that docker can resolve, and the ports the services are expecting
-# (e.g., the ports AFTER the colon, in docker-compose)
+# If running the Perma tests locally, the Perma test server,
+# the browser used for the functional tests, and Webrecorder
+# are all inside Docker: the containers speak to each other
+# over the Docker network, not the host network,
+# so we need to direct traffic to the services by name,
+# using the internal ports (not the ports docker-compose maps
+# them to on the host system)
 #APP_HOST=web:8000
-#CONTENT_HOST=perma-archives:81
+#CONTENT_HOST=nginx:81
 #CONTENT_ERROR_REDIRECT=http://web:8000/archive-error
 
 # Rate limiting for anon users


### PR DESCRIPTION
- upgraded to Trusty to get a recent-enough Docker/Docker-Compose
- upgrading to Trusty required losing the option to run functional tests w/ the Travis pre-installed Firefox; our Selenium is too old to handle the slightly-more-modern Firefox that comes with Trusty. To run tests with Firefox, we should get the dockerized Selenium/Firefox working.

This PR does *not* toggle on Selenium/Chrome or Webrecorder playbacks. You can test with Selenium/Chrome + pywb playback, if you want, but Webrecorder playback cannot be tested with PhantomJS; best I can tell, it requires a more modern browser.

If you want Travis to test with Webrecorder playbacks, toggle `REMOTE_SELENIUM` and `ENABLE_WR_PLAYBACK` from `False` to `True` in `settings_testing.py` (....necessary so that the related settings also get toggled appropriately).

If you want to run tests locally, do as above, but also toggle `wr.env` to use the special local settings mentioned there, and re-run `docker-compose up` before running tests. Switch back and restart again if you want your own web browser to work again. (Sub-optimal, but I can't work out a better alternative at the moment.)

(toggling on to demo seems to have uncovered a bug that didn't show up locally... dunno, maybe I never ran it, somehow.... but fixed in this PR in any case)