### PR TITLE
Set up directories for the recorder container via entrypoint.

### DIFF
--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -19,7 +19,7 @@ services:
   # Webrecorder
   #
   app:
-    image: harvardlil/webrecorder:0.06
+    image: harvardlil/webrecorder:0.07
     command: uwsgi /code/apps/apiapp.ini
     env_file:
       - ./services/docker/webrecorder/wr.env
@@ -36,8 +36,13 @@ services:
       - webrecorder
 
   recorder:
-    image: harvardlil/webrecorder:0.06
-    command: uwsgi /code/apps/rec.ini
+    image: harvardlil/webrecorder:0.07
+    user: root
+    entrypoint:
+      - "/docker-entrypoint.sh"
+    command:
+      - "uwsgi"
+      - "/code/apps/rec.ini"
     env_file:
       - ./services/docker/webrecorder/wr.env
     depends_on:
@@ -46,11 +51,12 @@ services:
     volumes:
       - wr_warcs:/data/warcs
       - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
+      - ./services/docker/webrecorder/docker-entrypoint.sh:/docker-entrypoint.sh
     networks:
       - webrecorder
 
   warcserver:
-    image: harvardlil/webrecorder:0.06
+    image: harvardlil/webrecorder:0.07
     command: uwsgi /code/apps/load.ini
     env_file:
       - ./services/docker/webrecorder/wr.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
   # Webrecorder
   #
   app:
-    image: harvardlil/webrecorder:0.06
+    image: harvardlil/webrecorder:0.07
     command: uwsgi /code/apps/apiapp.ini
     env_file:
       - ./services/docker/webrecorder/wr.env
@@ -145,8 +145,13 @@ services:
       - webrecorder
 
   recorder:
-    image: harvardlil/webrecorder:0.06
-    command: uwsgi /code/apps/rec.ini
+    image: harvardlil/webrecorder:0.07
+    user: root
+    entrypoint:
+      - "/docker-entrypoint.sh"
+    command:
+      - "uwsgi"
+      - "/code/apps/rec.ini"
     env_file:
       - ./services/docker/webrecorder/wr.env
     depends_on:
@@ -155,11 +160,12 @@ services:
     volumes:
       - wr_warcs:/data/warcs
       - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
+      - ./services/docker/webrecorder/docker-entrypoint.sh:/docker-entrypoint.sh
     networks:
       - webrecorder
 
   warcserver:
-    image: harvardlil/webrecorder:0.06
+    image: harvardlil/webrecorder:0.07
     command: uwsgi /code/apps/load.ini
     env_file:
       - ./services/docker/webrecorder/wr.env

--- a/services/docker/webrecorder/docker-entrypoint.sh
+++ b/services/docker/webrecorder/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# see https://docs.docker.com/engine/reference/builder/#entrypoint
+# and https://success.docker.com/article/use-a-script-to-initialize-stateful-container-data
+set -e
+
+# Make sure the these directories exist and are owned by "archivist".
+# Must be run as root; configure Docker or Docker-Compose accordingly.
+if [ "$1" = 'uwsgi' ]; then
+    mkdir -p "$RECORD_ROOT"
+    mkdir -p "$STORAGE_ROOT"
+    chown -R archivist:archivist "$RECORD_ROOT"
+    chown -R archivist:archivist "$STORAGE_ROOT"
+fi
+
+# Run the original command, as "archivist".
+exec su -m archivist -c "$*"

--- a/services/docker/webrecorder/docker-entrypoint.sh
+++ b/services/docker/webrecorder/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # and https://success.docker.com/article/use-a-script-to-initialize-stateful-container-data
 set -e
 
-# Make sure the these directories exist and are owned by "archivist".
+# Make sure these directories exist and are owned by "archivist".
 # Must be run as root; configure Docker or Docker-Compose accordingly.
 if [ "$1" = 'uwsgi' ]; then
     mkdir -p "$RECORD_ROOT"


### PR DESCRIPTION
Before, we were doing this in the image:
- https://github.com/webrecorder/webrecorder/commit/81eebd5f5c00ee0078a20850780e335fd8290b14
- https://github.com/webrecorder/webrecorder/commit/c7f247f12a2209bfd12285bf79849841098b1d11

That worked well locally, but didn't seem to work with the NFS volume: permissions/contents were getting overwritten, rather than being populated from the container, regardless of how `nocopy` was set.

This uses a different approach: every time you spin up a `recorder` container, it will ensure it has access to the directories it needs.

There's some fanciness involved, because the image runs with `USER archivist` by default, which of course cannot create directories in `/`, etc. So, we specify `user: root` in our `docker-compose.yml` and use shell fanciness in `docker-entrypoint.sh` to ensure that passed-in commands are excuted as `archivist`.

This is my first adventure with entrypoints, so caution is advised 😉 

Hopefully this works with the NFS volumes! We should throw away the current contents of the drive and try it out..... Note the experiment would be with harvard-lil/webrecorder:0.0.7