### PR TITLE
Replacements and WR

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -11,7 +11,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from perma.utils import run_task, stream_warc, stream_warc_if_permissible
+from perma.utils import run_task, stream_warc, stream_warc_if_permissible, clear_wr_session
 from perma.tasks import upload_to_internet_archive, delete_from_internet_archive, run_next_capture
 from perma.models import Folder, CaptureJob, Link, Capture, Organization, LinkBatch
 
@@ -468,6 +468,10 @@ class AuthenticatedLinkDetailView(BaseView):
 
                 # write new warc and capture
                 link.write_uploaded_file(uploaded_file, cache_break=True)
+
+                # clear the user's Webrecorder session, if any,
+                # so that the new warc is used for playback
+                clear_wr_session(request)
 
             # update internet archive if privacy changes
             if 'is_private' in data and was_private != bool(data.get("is_private")) and link.is_archive_eligible():

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -638,7 +638,6 @@ def get_wr_uploaded(request, link):
 
 def query_wr_api(method, path, cookie, valid_if, json=None, data=None):
     # Make the request
-
     try:
         response = requests.request(
             method,


### PR DESCRIPTION
We keep track in the user's session whether a particular WARC has already been uploaded to webrecorder on behalf of that user, to save some time. If a user wants to replace a capture gone wrong, we need to clear that out, so that the new warc is uploaded. Easiest way is to just clear the whole session.