### PR TITLE
Monitor WR api for availability.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -140,7 +140,7 @@ TIERS = {
     ]
 }
 
-REMOTE_SELENIUM = False
+REMOTE_SELENIUM = True
 if REMOTE_SELENIUM:
     if os.environ.get('DOCKERIZED'):
         HOST = 'web:8000'
@@ -153,7 +153,7 @@ if REMOTE_SELENIUM:
         REMOTE_SELENIUM_HOST = 'localhost'
 
 
-ENABLE_WR_PLAYBACK = False
+ENABLE_WR_PLAYBACK = True
 if ENABLE_WR_PLAYBACK:
     assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
     if os.environ.get('DOCKERIZED'):

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -140,7 +140,7 @@ TIERS = {
     ]
 }
 
-REMOTE_SELENIUM = True
+REMOTE_SELENIUM = False
 if REMOTE_SELENIUM:
     if os.environ.get('DOCKERIZED'):
         HOST = 'web:8000'
@@ -153,7 +153,7 @@ if REMOTE_SELENIUM:
         REMOTE_SELENIUM_HOST = 'localhost'
 
 
-ENABLE_WR_PLAYBACK = True
+ENABLE_WR_PLAYBACK = False
 if ENABLE_WR_PLAYBACK:
     assert REMOTE_SELENIUM, "WR Playback must be tested with REMOTE_SELENIUM = True"
     if os.environ.get('DOCKERIZED'):

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -41,6 +41,10 @@ def post_process_settings(settings):
         'run-next-capture': {
             'task': 'perma.tasks.run_next_capture',
             'schedule': crontab(minute='*'),
+        },
+        'verify_webrecorder_api_available': {
+            'task': 'perma.tasks.verify_webrecorder_api_available',
+            'schedule': crontab(minute='*')
         }
     }
     settings['CELERYBEAT_SCHEDULE'] = dict(((job, celerybeat_job_options[job]) for job in settings.get('CELERYBEAT_JOB_NAMES', [])),

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1469,3 +1469,18 @@ def send_js_errors():
                          'email/admin/js_errors.txt',
                          {'errors': formatted_errors})
         return errors
+
+
+@shared_task()
+def verify_webrecorder_api_available():
+    """
+    UptimeRobot-like helper to verify that the Webrecorder API is available.
+    Necessary because the api should not be exposed to the public internet.
+    """
+    r = requests.get(
+        settings.WR_API,
+        timeout=5,
+        allow_redirects=False
+    )
+    r.raise_for_status()
+    assert "description: Webrecorder API" in r.text

--- a/perma_web/perma/tests/test_tasks.py
+++ b/perma_web/perma/tests/test_tasks.py
@@ -1,7 +1,10 @@
+from mock import patch
+import requests
+
 from django.core import mail
 
 from django.test import TestCase, override_settings
-from perma.tasks import update_stats, upload_all_to_internet_archive, upload_to_internet_archive, delete_from_internet_archive, send_js_errors
+from perma.tasks import update_stats, upload_all_to_internet_archive, upload_to_internet_archive, delete_from_internet_archive, send_js_errors, verify_webrecorder_api_available
 from perma.models import Link, UncaughtError
 
 @override_settings(CELERY_ALWAYS_EAGER=True, UPLOAD_TO_INTERNET_ARCHIVE=True)
@@ -47,3 +50,17 @@ class TaskTestCase(TestCase):
         self.assertIn('Function: getNextContents', message_parts)
         self.assertIn('File: static/bundles/create.js', message_parts)
         self.assertNotIn('showFolderContents', message_parts)
+
+    def test_verify_webrecorder_api_available(self):
+        # this test really verifies that Webrecorder is available in the test environment,
+        # as well as testing the task
+        self.assertTrue(verify_webrecorder_api_available.delay())
+
+    @patch('perma.tasks.requests.get')
+    def test_verify_webrecorder_api_available_fails(self, mocked_get):
+        response = requests.Response()
+        for code in [400, 404, 500, 502]:
+            response.status_code = code
+            mocked_get.return_value = response
+            with self.assertRaises(requests.exceptions.RequestException):
+                self.assertFalse(verify_webrecorder_api_available.delay())

--- a/perma_web/perma/tests/test_tasks.py
+++ b/perma_web/perma/tests/test_tasks.py
@@ -3,6 +3,7 @@ import requests
 
 from django.core import mail
 
+from django.conf import settings
 from django.test import TestCase, override_settings
 from perma.tasks import update_stats, upload_all_to_internet_archive, upload_to_internet_archive, delete_from_internet_archive, send_js_errors, verify_webrecorder_api_available
 from perma.models import Link, UncaughtError
@@ -51,16 +52,18 @@ class TaskTestCase(TestCase):
         self.assertIn('File: static/bundles/create.js', message_parts)
         self.assertNotIn('showFolderContents', message_parts)
 
-    def test_verify_webrecorder_api_available(self):
-        # this test really verifies that Webrecorder is available in the test environment,
-        # as well as testing the task
-        self.assertTrue(verify_webrecorder_api_available.delay())
+    if settings.ENABLE_WR_PLAYBACK:
+        def test_verify_webrecorder_api_available(self):
+            # this test really verifies that Webrecorder is available in the test environment,
+            # as well as testing the task
+            self.assertTrue(verify_webrecorder_api_available.delay())
 
-    @patch('perma.tasks.requests.get')
-    def test_verify_webrecorder_api_available_fails(self, mocked_get):
-        response = requests.Response()
-        for code in [400, 404, 500, 502]:
-            response.status_code = code
-            mocked_get.return_value = response
-            with self.assertRaises(requests.exceptions.RequestException):
-                self.assertFalse(verify_webrecorder_api_available.delay())
+    if settings.ENABLE_WR_PLAYBACK:
+        @patch('perma.tasks.requests.get')
+        def test_verify_webrecorder_api_available_fails(self, mocked_get):
+            response = requests.Response()
+            for code in [400, 404, 500, 502]:
+                response.status_code = code
+                mocked_get.return_value = response
+                with self.assertRaises(requests.exceptions.RequestException):
+                    self.assertFalse(verify_webrecorder_api_available.delay())


### PR DESCRIPTION
Try it out locally by setting `RUN_TASKS_ASYNC = False` and `CELERYBEAT_JOB_NAMES = [ 'verify_webrecorder_api_available']` and re-running `fab run`.

Enable on a Perma server by appending this new celerybeat job to the existing setting array `CELERYBEAT_JOB_NAMES`