### PR TITLE
Don't attempt playback unless warc is available/ready

### DIFF
--- a/perma_web/api/tests/test_current_user_resource.py
+++ b/perma_web/api/tests/test_current_user_resource.py
@@ -22,8 +22,8 @@ class CurrentUserResourceTestCase(ApiResourceTestCase):
         self.successful_get(self.detail_url, user=self.org_user, fields=self.fields)
 
     def test_get_archives_json(self):
-        self.successful_get(self.detail_url + 'archives/', user=self.org_user, count=10)
-        self.successful_get(self.detail_url + 'archives/', user=self.regular_user, count=11)
+        self.successful_get(self.detail_url + 'archives/', user=self.org_user, count=11)
+        self.successful_get(self.detail_url + 'archives/', user=self.regular_user, count=12)
 
     def test_get_folders_json(self):
         self.successful_get(self.detail_url + 'folders/', user=self.org_user, count=2)

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -88,7 +88,7 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
     #######
 
     def test_get_list_json(self):
-        self.successful_get(self.public_list_url, count=4)
+        self.successful_get(self.public_list_url, count=5)
 
     def test_get_detail_json(self):
         self.successful_get(self.public_link_detail_url, fields=self.logged_out_fields)

--- a/perma_web/fixtures/archive.json
+++ b/perma_web/fixtures/archive.json
@@ -242,6 +242,23 @@
     }
   },
   {
+    "pk": "ABCD-0007",
+    "model": "perma.link",
+    "fields": {
+      "folders": [
+        30,
+        34
+      ],
+      "notes": "Screenshot Only",
+      "created_by": 4,
+      "submitted_title": "Wikipedia",
+      "submitted_url": "https://www.wikipedia.org/",
+      "creation_timestamp": "2014-07-19T20:21:31Z",
+      "archive_timestamp": "2014-07-20T20:21:31Z",
+      "organization": 1
+    }
+  },
+  {
   "fields": {
     "status": "pending",
     "url": "http://dolekemp96.org",
@@ -382,7 +399,7 @@
     "link": "ABCD-0004"
   },
   "model": "perma.capture",
-  "pk": 10
+  "pk": 11
   },
   {
   "fields": {
@@ -395,6 +412,76 @@
     "link": "ABCD-0005"
   },
   "model": "perma.capture",
-  "pk": 10
+  "pk": 12
+  },
+  {
+  "fields": {
+    "status": "success",
+    "url": "file:///ABCD-0007/cap.png",
+    "user_upload": false,
+    "record_type": "resource",
+    "role": "screenshot",
+    "content_type": "image/png",
+    "link": "ABCD-0007"
+  },
+  "model": "perma.capture",
+  "pk": 13
+  },
+  {
+  "fields": {
+    "link": "UU32-XY8I",
+    "status": "completed",
+    "message": null,
+    "human": true,
+    "order": 966.0,
+    "submitted_url": "https://www.wikipedia.org/",
+    "created_by": 4,
+    "link_batch": null,
+    "attempt": 1,
+    "step_count": 6.0,
+    "step_description": "Saving web archive file",
+    "capture_start_time": "2019-03-27T19:03:49Z",
+    "capture_end_time": "2019-03-27T19:03:55.493Z"
+  },
+  "model": "perma.capturejob",
+  "pk": 1
+  },
+  {
+  "fields": {
+    "link": "TE73-AKWM",
+    "status": "completed",
+    "message": null,
+    "human": true,
+    "order": 966.0,
+    "submitted_url": "http://metafilter.com",
+    "created_by": 4,
+    "link_batch": null,
+    "attempt": 1,
+    "step_count": 6.0,
+    "step_description": "Saving web archive file",
+    "capture_start_time": "2019-03-27T19:03:49Z",
+    "capture_end_time": "2019-03-27T19:03:55.493Z"
+  },
+  "model": "perma.capturejob",
+  "pk": 2
+  },
+  {
+  "fields": {
+    "link": "ABCD-0007",
+    "status": "completed",
+    "message": null,
+    "human": true,
+    "order": 966.0,
+    "submitted_url": "https://www.wikipedia.org/",
+    "created_by": 4,
+    "link_batch": null,
+    "attempt": 1,
+    "step_count": 6.0,
+    "step_description": "Saving web archive file",
+    "capture_start_time": "2019-03-27T19:03:49Z",
+    "capture_end_time": "2019-03-27T19:03:55.493Z"
+  },
+  "model": "perma.capturejob",
+  "pk": 3
   }
 ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1450,6 +1450,33 @@ class Link(DeletableModel):
     ###
     ### Methods for playback via Webrecorder
     ###
+    def ready_for_playback(self):
+        """
+        Reports whether a Perma Link has been successfully captured and
+        is ready for playback:
+        - CaptureJob succeeded
+        - Either primary or screenshot capture succeeded
+
+        See also /perma/perma_web/static/js/helpers/link.helpers.js
+        """
+        ready = False
+
+        for capture in self.captures.all():
+            if capture.status == 'success':
+                if capture.role in ['primary', 'screenshot']:
+                    ready = True
+
+        # Early Perma Links do not have CaptureJobs; if no CaptureJob,
+        # judge based on Capture statuses alone.
+        job = None
+        try:
+            job = self.capture_job
+        except CaptureJob.DoesNotExist:
+            pass
+        if job and job.status != 'completed':
+            ready = False
+
+        return ready
 
     @cached_property
     def wr_collection_slug(self):

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -195,7 +195,11 @@ def single_permalink(request, guid):
         'protocol': protocol(),
     }
 
-    if settings.ENABLE_WR_PLAYBACK and context['can_view'] and not link.user_deleted:
+    if (settings.ENABLE_WR_PLAYBACK
+           and context['can_view']
+           and not link.user_deleted
+           and link.ready_for_playback()
+        ):
         wr_username = link.init_replay_for_user(request)
         context.update({
             'wr_host': settings.PLAYBACK_HOST,


### PR DESCRIPTION
Fixes https://github.com/harvard-lil/perma/issues/2566

Coverage will go down a little, until we start running with `ENABLE_WR_PLAYBACK` in Travis.

This exposed a rare corner case: with both pywb playback and WR playback, Perma happily serves up a blank iframe in this case: https://github.com/harvard-lil/perma/issues/2574. To address later.