### PR TITLE
Less aggressive handling of 404s during WR temp user deletion attempts.

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -614,7 +614,7 @@ def clear_wr_session(request, error_if_wr_user_not_found=False):
             method='delete',
             path='/user/{user}'.format(user=wr_username),
             cookie=wr_session_cookie,
-            valid_if=lambda code, data: (code == 200) or (code == 404 and data.get('error') == 'not_found')
+            valid_if=lambda code, data: (code == 200) or (code == 404 and data.get('error') in ['not_found', 'no_such_user'])
         )
     except WebrecorderException:
         # Record the exception, but don't halt execution: this should be non-fatal

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -621,8 +621,7 @@ def clear_wr_session(request, error_if_wr_user_not_found=False):
         logger.exception('Unexpected response from DELETE /user/{user}'.format(user=wr_username))
         return
 
-    session_already_expired = response.status_code == 404
-    if session_already_expired:
+    if response.status_code == 404:
         if error_if_wr_user_not_found:
             log_level = logging.ERROR
         else:


### PR DESCRIPTION
404s are expected here: if the WR session has timed out, WR will delete the temp user. Perma will still have a cookie stored in the user's session (Django has no mechanism for automatically expiring individual keys stored in sessions, only for expiring the whole session). So, Perma will send the DELETE request just to make sure. Don't count that as an error, unless we're doing something fancy; we can call with `error_if_wr_user_not_found=True` if we need to for some reason.