### PR TITLE
Html entities

### DIFF
--- a/perma_web/perma/templates/404.html
+++ b/perma_web/perma/templates/404.html
@@ -5,7 +5,7 @@
   {% with request.META.HTTP_REFERER as referer %}
     <div class="col-xs-12 no-wide">
       <h1 class="page-title">Page not found.</h1>
-      <p class="page-dek">Well that’s ironic — you’ve found our 404 page. The page you’re looking for doesn’t exist at this address. <br/>If that seems wrong to you, <a href="{% url 'contact' %}?subject=Page%20not%20found%20({{ request.path }}{% if referer %}%20via%20{{referer}}{% endif %})">please drop us a note</a>.</p>
+      <p class="page-dek">Well that’s ironic — you’ve found our 404 page. The page you’re looking for doesn’t exist at this address. <br/>If that seems wrong to you, <a href="{% url 'contact' %}?subject=Page%20not%20found%20({{ request_path }}{% if referer %}%20via%20{{referer}}{% endif %})">please drop us a note</a>.</p>
     </div>
   {% endwith %}
 {% endblock %}

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -409,7 +409,7 @@ class CommonViewsTestCase(PermaTestCase):
                           user='test_another_library_org_user@example.com')
         self.assertEqual(len(mail.outbox), 1)
         message = mail.outbox[0]
-        self.assertIn("Affiliations: Another Library&#39;s Journal (Another Library), A Third Journal (Test Library)", message.body)
+        self.assertIn("Affiliations: Another Library's Journal (Another Library), A Third Journal (Test Library)", message.body)
         self.assertIn("Logged in: true", message.body)
 
     def test_contact_reg_user_affiliation_string(self):


### PR DESCRIPTION
1) don't html-encode them in emails
2) url-encode them before printing into the `href`  of the email-sending link on the 404 page