### PR TITLE
Capture User-Agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - perma_payments
 
   perma-payments:
-    image: harvardlil/perma-payments:0.12
+    image: harvardlil/perma-payments:0.13
     # hack: sleep to give the database time to start up
     command: >
       sh -c "sleep 5 && pipenv run ./manage.py migrate &&

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -533,6 +533,8 @@ TEMPLATE_VISIBLE_SETTINGS = (
 CAPTURE_BROWSER = 'PhantomJS'  # or 'Chrome' or 'Firefox'
 # Default user agent is adapted from the PhantomJS default
 CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Safari/538.1"
+PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
+DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
 
 APPEND_SLASH = False
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -531,8 +531,8 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 
 CAPTURE_BROWSER = 'PhantomJS'  # or 'Chrome' or 'Firefox'
-# Default user agent is the Chrome on Linux that's most like PhantomJS 2.1.1.
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.37 Safari/537.36"
+# Default user agent is adapted from the PhantomJS default
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Safari/538.1"
 
 APPEND_SLASH = False
 


### PR DESCRIPTION
An attempt to address https://github.com/harvard-lil/perma/issues/2131 and https://github.com/harvard-lil/perma/issues/2584 without breaking anything else.

We should test thoroughly on stage before deploying, by capturing lots of domains on stage, observing whether the capture attempt was rejected/blocked by the domain, and checking to see if we get the same results on prod. With any luck, we will not find any domains that ACCEPTED the old user-agent, but REJECT the new one.

To close 2584, we will also have to tell their developers about our unique suffix.