### PR TITLE
See if this quashes the SETEX errors.

### DIFF
--- a/services/docker/webrecorder/session.py
+++ b/services/docker/webrecorder/session.py
@@ -387,34 +387,34 @@ class RedisSessionMiddleware(CookieGuard):
         duration = self.durations[session.dura_type]['total']
 
         if session.should_save:
-            with redis_pipeline(self.redis) as pi:
-                data = base64.b64encode(pickle.dumps(session._sesh))
+            #
+            # BEGIN PERMA CUSTOMIZATION
+            #
+            try:
+                with redis_pipeline(self.redis) as pi:
+                    data = base64.b64encode(pickle.dumps(session._sesh))
 
-                ttl = session.ttl
-                #
-                # BEGIN PERMA CUSTOMIZATION
-                #
-                if ttl == 0:
-                    logger.warning("SETEX error diagnosed! It happens when session.ttl == 0")
-                if ttl <= 0:
-                    ttl = duration
+                    ttl = session.ttl
+                    if ttl == 0:
+                        logger.warning("SETEX error diagnosed! It happens when session.ttl == 0")
+                    if ttl <= 0:
+                        ttl = duration
 
-                try:
-                    pi.setex(session.key, ttl, data)
+                        pi.setex(session.key, ttl, data)
 
-                    if set_cookie:
-                        self.track_long_term(session, pi)
+                        if set_cookie:
+                            self.track_long_term(session, pi)
 
-                    # set redis duration
-                    if session.curr_role != 'anon':
-                        pi.expire(session.key, duration)
+                        # set redis duration
+                        if session.curr_role != 'anon':
+                            pi.expire(session.key, duration)
 
-                except Exception:
-                    logger.error("SETEX error not fully diagnosed.", exc_info=True)
-                    return
-                #
-                # END PERMA CUSTOMIZATION
-                #
+            except Exception:
+                logger.error("SETEX error not fully diagnosed.", exc_info=True)
+                return
+            #
+            # END PERMA CUSTOMIZATION
+            #
 
         elif set_cookie and session.curr_role != 'anon':
             # extend redis duration if extending cookie!

--- a/services/docker/webrecorder/session.py
+++ b/services/docker/webrecorder/session.py
@@ -399,8 +399,6 @@ class RedisSessionMiddleware(CookieGuard):
                 if ttl <= 0:
                     ttl = duration
 
-                sextex = "SETEX args: {}, {}, and {}".format(session.key, ttl, data)
-                expire = "EXPIRE args: {}, {}".format(session.key, duration)
                 try:
                     pi.setex(session.key, ttl, data)
 
@@ -411,9 +409,9 @@ class RedisSessionMiddleware(CookieGuard):
                     if session.curr_role != 'anon':
                         pi.expire(session.key, duration)
 
-                except redis.exceptions.ResponseError:
-                    logger.warning("SETEX error not fully diagnosed.")
-                    raise
+                except Exception:
+                    logger.error("SETEX error not fully diagnosed.", exc_info=True)
+                    return
                 #
                 # END PERMA CUSTOMIZATION
                 #


### PR DESCRIPTION
I'm pretty sure this is it. If we like what we see, with this running, then I can send another PR (here and upstream) that just changes `<` to `<=`.