### PR TITLE
Interstitial needs different url with webrecorder playback.

### DIFF
--- a/perma_web/perma/templates/archive/iframe.html
+++ b/perma_web/perma/templates/archive/iframe.html
@@ -16,7 +16,11 @@
   <div class="record-message">
     <p class="record-message-primary">Perma.cc can’t display this file type but you can view or download the archived file by clicking below.</p>
     <p class="record-message-secondary">File type {{ capture.mime_type }}</p>
-    <div><a href="{{ capture.playback_url_with_access_token }}" class="btn btn-primary">View/Download File</a></div>
+    {% if ENABLE_WR_PLAYBACK %}
+      <div><a href="{{ protocol}}{{ wr_prefix }}im_/{{ wr_url }}" class="btn btn-primary">View/Download File</a></div>
+    {% else %}
+      <div><a href="{{ capture.playback_url_with_access_token }}" class="btn btn-primary">View/Download File</a></div>
+    {% endif %}
   </div>
 {% else %}
   <div class="capture-wrapper">


### PR DESCRIPTION
If we can't playback a link due to its file format, we offer a link to download: that link was pointed at the old pywb-based URL. This PR uses our feature flag to provide a WR-appropriate URL.