### PR TITLE
Memento tweaks

### DIFF
--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -201,6 +201,7 @@ class CommonViewsTestCase(PermaTestCase):
         expected =b"""\
 <wikipedia.org>; rel=original,
 <http://testserver/timegate/wikipedia.org>; rel=timegate,
+<http://testserver/timemap/link/wikipedia.org>; rel=self; type=application/link-format,
 <http://testserver/timemap/link/wikipedia.org>; rel=timemap; type=application/link-format,
 <http://testserver/timemap/json/wikipedia.org>; rel=timemap; type=application/json,
 <http://testserver/timemap/html/wikipedia.org>; rel=timemap; type=text/html,
@@ -228,6 +229,8 @@ class CommonViewsTestCase(PermaTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response._headers['location'][1], 'http://testserver/ABCD-0009')
         self.assertIn('accept-datetime', response._headers['vary'][1])
+        self.assertIn('<http://testserver/ABCD-0007>; rel="first memento"; datetime="Sat, 19 Jul 2014 20:21:31 GMT"', response._headers['link'][1])
+        self.assertIn('<http://testserver/ABCD-0009>; rel="last memento"; datetime="Tue, 19 Jul 2016 20:21:31 GMT"', response._headers['link'][1])
         self.assertIn('<http://testserver/ABCD-0009>; rel=memento; datetime="Tue, 19 Jul 2016 20:21:31 GMT"', response._headers['link'][1])
         self.assertIn('<wikipedia.org>; rel=original,', response._headers['link'][1])
         self.assertIn('<http://testserver/timegate/wikipedia.org>; rel=timegate,', response._headers['link'][1])
@@ -240,6 +243,8 @@ class CommonViewsTestCase(PermaTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response._headers['location'][1], 'http://testserver/ABCD-0008')
         self.assertIn('accept-datetime', response._headers['vary'][1])
+        self.assertIn('<http://testserver/ABCD-0007>; rel="first memento"; datetime="Sat, 19 Jul 2014 20:21:31 GMT"', response._headers['link'][1])
+        self.assertIn('<http://testserver/ABCD-0009>; rel="last memento"; datetime="Tue, 19 Jul 2016 20:21:31 GMT"', response._headers['link'][1])
         self.assertIn('<http://testserver/ABCD-0008>; rel=memento; datetime="Sun, 19 Jul 2015 20:21:31 GMT"', response._headers['link'][1])
         self.assertIn('<wikipedia.org>; rel=original,', response._headers['link'][1])
         self.assertIn('<http://testserver/timegate/wikipedia.org>; rel=timegate,', response._headers['link'][1])

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -323,6 +323,8 @@ def timegate(request, url):
             Rel(data['timemap_uri']['link_format'], rel='timemap', type='application/link-format'),
             Rel(data['timemap_uri']['json_format'], rel='timemap', type='application/json'),
             Rel(data['timemap_uri']['html_format'], rel='timemap', type='text/html'),
+            Rel(data['mementos']['first']['uri'], rel='first memento', datetime=datetime_to_http_date(data['mementos']['first']['datetime'])),
+            Rel(data['mementos']['last']['uri'], rel='last memento', datetime=datetime_to_http_date(data['mementos']['last']['datetime'])),
             Rel(target, rel='memento', datetime=datetime_to_http_date(target_datetime)),
         ])
     )

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -266,10 +266,6 @@ def timemap(request, response_format, url):
     data = memento_data_for_url(request, url)
     if data:
         if response_format == 'json':
-            # Should 'self' be included?
-            # It's included in https://memgator.cs.odu.edu/timemap/json/http://www.cs.odu.edu/~mln/
-            # but is not mentioned by http://mementoweb.org/guide/timemap-json/
-            # del data['self']
             response = JsonResponse(data)
         elif response_format == 'html':
             response = render(request, 'memento/timemap.html', data)
@@ -279,6 +275,7 @@ def timemap(request, response_format, url):
             file.writelines(f"{line},\n" for line in [
                 Rel(data['original_uri'], rel='original'),
                 Rel(data['timegate_uri'], rel='timegate'),
+                Rel(data['self'], rel='self', type='application/link-format'),
                 Rel(data['timemap_uri']['link_format'], rel='timemap', type='application/link-format'),
                 Rel(data['timemap_uri']['json_format'], rel='timemap', type='application/json'),
                 Rel(data['timemap_uri']['html_format'], rel='timemap', type='text/html')


### PR DESCRIPTION
Subsequent to messages from the validator. Not positive this fixes, "First Memento in Header not the same as first in TimeMap".... but, since "first memento" and "last memento" weren't being included in the timegate header, we'll see if merely adding them takes care of it.

If it does.... I'm undecided whether I'm going to add that to the header of actual playbacks. I think I'd prefer not to do the extra DB query.... TBD.