### PR TITLE
Retry playbacks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
     depends_on:
       - redis
     volumes:
-      - wr_warcs:/data/warcs:ro
+      - wr_warcs:/data/warcs
       - ./services/docker/webrecorder/wr-custom.yaml:/code/webrecorder/config/wr-custom.yaml:ro
       # Temporary patches for warcio
       # https://github.com/webrecorder/warcio/pull/80

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -4,6 +4,7 @@ from dateutil.tz import tzutc
 from io import StringIO
 from link_header import Link as Rel, LinkHeader
 from urllib.parse import urlencode
+import time
 from timegate.utils import closest
 from warcio.timeutils import datetime_to_http_date
 from werkzeug.http import parse_date
@@ -199,7 +200,17 @@ def single_permalink(request, guid):
     if context['can_view'] \
            and not link.user_deleted \
            and link.ready_for_playback():
-        wr_username = link.init_replay_for_user(request)
+        try:
+            wr_username = link.init_replay_for_user(request)
+        except:
+            # We are experiencing many varieties of transient flakiness in playback:
+            # second attempts, triggered by refreshing the page, almost always seem to work.
+            # While we debug... let's give playback a second try here, and see if this
+            # noticeably improves user experience.
+            logger.exception(f"First attempt to init replay failed. (Retrying: observe whether this error recurs.)")
+            time.sleep(1)
+            wr_username = link.init_replay_for_user(request)
+
         context.update({
             'wr_host': settings.PLAYBACK_HOST,
             'wr_prefix': link.wr_iframe_prefix(wr_username),

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -202,7 +202,7 @@ def single_permalink(request, guid):
            and link.ready_for_playback():
         try:
             wr_username = link.init_replay_for_user(request)
-        except:
+        except:  # noqa
             # We are experiencing many varieties of transient flakiness in playback:
             # second attempts, triggered by refreshing the page, almost always seem to work.
             # While we debug... let's give playback a second try here, and see if this


### PR DESCRIPTION
This PR attempts to hide the playback flakiness we've been experiencing, but have not yet diagnosed. My best guess is that we are seeing failures due to timing and network conditions within our distributed system. I hope to find and make robust the different spots that are susceptible to that sort of problem... but in the meantime, I propose the follow two potential remedies:

- automatically retry playbacks that fail noisy, producing an exception visible in Django, after 1 second
- if Webrecorder looks for a resource in a Perma Link and doesn't find it (404), wait a second and then have it look again... hopefully mitigating these miserable 404s for the main resource that are happening and then getting cached in Cloudflare as per https://github.com/harvard-lil/perma/issues/2633

Both are lousy solutions, but let's see if it makes a dent in the problem...