### PR TITLE
Use settings instead of hard-coding sleeps.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -477,6 +477,9 @@ WR_REPLAY_UPLOAD_TIMEOUT = 20
 # WR_REPLAY_UPLOAD_TIMEOUT (Perma settings)
 WR_COOKIE_PERMITTED_AGE = 60
 
+# Seconds to wait before retrying a failed WR playback.
+WR_PLAYBACK_RETRY_AFTER = 1
+
 # Sorl settings. This relates to our thumbnail creation.
 # The prod and dev configs are considerably different. See those configs for details.
 THUMBNAIL_ENGINE = 'sorl.thumbnail.engines.wand_engine.Engine'

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -209,7 +209,7 @@ def single_permalink(request, guid):
             # While we debug... let's give playback a second try here, and see if this
             # noticeably improves user experience.
             logger.exception(f"First attempt to init replay failed. (Retrying: observe whether this error recurs.)")
-            time.sleep(1)
+            time.sleep(settings.WR_PLAYBACK_RETRY_AFTER)
             wr_username = link.init_replay_for_user(request)
 
         context.update({

--- a/services/docker/webrecorder/contentcontroller.py
+++ b/services/docker/webrecorder/contentcontroller.py
@@ -85,6 +85,9 @@ class ContentController(BaseController, RewriterApp):
         # URLs or domains. This is a temporary workaround, until we devise
         # a more universally satisfactory solution.
         self.refuse_playback = [url for url in os.environ.get('REFUSE_PLAYBACK', '').split(',') if url]
+        # We are experiencing unexpected, transient 404s that resolve on refrsh.
+        # This is a temporary workaround/diagnostic experiment.
+        self.sleep_on_404 = int(os.environ.get('SLEEP_ON_404', '2'))
         # END PERMA CUSTOMIZATION
 
     def _init_client_archive_info(self):
@@ -810,7 +813,7 @@ class ContentController(BaseController, RewriterApp):
                     # Retry all 404s after 1s, in a broad effort to allay
                     # https://github.com/harvard-lil/perma/issues/2633
                     # until I pinpoint the real problem.
-                    time.sleep(1)
+                    time.sleep(self.sleep_on_404)
                     resp = self.render_content(wb_url, kwargs, request.environ)
                 else:
                     raise


### PR DESCRIPTION
... and lengthen the default WR sleep from 1 to 2, since I still saw some 404s on stage.