### PR TITLE
Upgrade warcprox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - default
   web:
     build: ./perma_web
-    image: perma3:0.43
+    image: perma3:0.44
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - default
   web:
     build: ./perma_web
-    image: perma3:0.44
+    image: perma3:0.45
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/Pipfile
+++ b/perma_web/Pipfile
@@ -15,12 +15,12 @@ pytz = "*"                                  # timezone helper
 requests = {version = "==2.20.0", extras = ["security"]}
 urllib3 = "==1.24.2"                        # from requests
 tqdm = "*"                                  # progress bar in dev fab tasks
-Werkzeug = "==0.15.3"
+Werkzeug = "*"
 uwsgitop = "*"                              # uWSGI monitoring
 
 
 # databases
-mysqlclient = "~=1.3.0"
+mysqlclient = "*"
 django-redis = "*"                          # use redis as django's cache backend
 redis = "*"                                 # Needed to bind with Redis.
 
@@ -53,7 +53,7 @@ PyVirtualDisplay = "==0.1.5"                # for capturing with non-headless br
 selenium = "==2.47.3"                       # drive headless browsers. pinned after IOErrors on deployment; unpin and upgrade after assessment, testing
 tempdir = "*"                               # create temp dirs to be deleted at end of function -- handy for archive creation
 ua-parser = "*"                             # user agent parsing to detect mobile browsers during playbacks
-warcio = "==1.7.1"                          # helps us write metadata and inspect our WARCs
+warcio = "*"                                # helps us write metadata and inspect our WARCs
 warcprox = "==2.4b2"
 
 

--- a/perma_web/Pipfile
+++ b/perma_web/Pipfile
@@ -54,7 +54,7 @@ selenium = "==2.47.3"                       # drive headless browsers. pinned af
 tempdir = "*"                               # create temp dirs to be deleted at end of function -- handy for archive creation
 ua-parser = "*"                             # user agent parsing to detect mobile browsers during playbacks
 warcio = "*"                                # helps us write metadata and inspect our WARCs
-warcprox = "==2.4b2"
+warcprox = "*"
 
 
 # alternate storages

--- a/perma_web/Pipfile.lock
+++ b/perma_web/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "34195ad9355bfdda2c244f6567db5b2d3e5b46985c86cafd1ad905e28c93e19c"
+            "sha256": "66adb89279c4245385341c0446cf75cc5bfdea40a649aab09aed7e2fd3184b6e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -94,6 +94,13 @@
                 "sha256:d31d7e0e12fb64d6bd331c6b853750c71423d560cee01a989f607dd45407ef65"
             ],
             "version": "==1.14.16"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:9a52dd97a85f257f4e4127f15818e71a0c7899f121b34591fcc1173ea79a0198",
+                "sha256:b304586d357c43221856be51d73387f93e2a961598a9b6b6670664746f3b6c6c"
+            ],
+            "version": "==4.0.0"
         },
         "celery": {
             "extras": [
@@ -559,6 +566,22 @@
             "index": "pypi",
             "version": "==0.1.5"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6",
+                "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf",
+                "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5",
+                "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e",
+                "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811",
+                "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e",
+                "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d",
+                "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20",
+                "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689",
+                "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994",
+                "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
+            ],
+            "version": "==5.3"
+        },
         "redis": {
             "hashes": [
                 "sha256:0dcfb335921b88a850d461dc255ff4708294943322bd55de6cfd68972490ca1f",
@@ -723,10 +746,10 @@
         },
         "warcprox": {
             "hashes": [
-                "sha256:4a2083e0cf59f7d88ae83bb6f6c7e066ee330d907fb5640a492d9f1f668fc71f"
+                "sha256:8c98dca4c5d38e078e59ad261c66b1aeb407df0745238992da976e1f69e2f6ae"
             ],
             "index": "pypi",
-            "version": "==2.4b2"
+            "version": "==2.4.17"
         },
         "warctools": {
             "hashes": [

--- a/perma_web/Pipfile.lock
+++ b/perma_web/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "904a86cf1ba1ed66eae620ec9cf87bd5a29d56b313caab4f30874828730fafad"
+            "sha256": "34195ad9355bfdda2c244f6567db5b2d3e5b46985c86cafd1ad905e28c93e19c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -82,18 +82,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0b9dc594e16a96ed7c6f37e1563ab3f113f130b3cc79efe8eea43097bf87fccb",
-                "sha256:e48ff93a3b6424c65675e1cbe08f7f3245b0128d1c27115cdcf51d432e9767d6"
+                "sha256:2cb3063d347c0d06f96dcd10d69247d3e3d12eda4b1ed9fdec62ac25c7fee8b6",
+                "sha256:5bffdfc7d3465f053db38a64821fbeb1f8044ffafb71c90587f1c293d334305f"
             ],
             "index": "pypi",
-            "version": "==1.11.15"
+            "version": "==1.11.16"
         },
         "botocore": {
             "hashes": [
-                "sha256:2538065f9f5023eae3607e78fc5d8c595c9173ec02bc92410652078617c44ac1",
-                "sha256:554231b1690c8521e05a41e50184e43d62941fdf9351e658aea894649b879985"
+                "sha256:63dc203046e47573add16c348f00a8e2fe3bb4975323458787e7b2bebeec5923",
+                "sha256:d31d7e0e12fb64d6bd331c6b853750c71423d560cee01a989f607dd45407ef65"
             ],
-            "version": "==1.14.15"
+            "version": "==1.14.16"
         },
         "celery": {
             "extras": [
@@ -422,12 +422,13 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:062d78953acb23066c0387a8f3bd0ecf946626f599145bb7fd201460e8f773e1",
-                "sha256:3981ae9ce545901a36a8b7aed76ed02960a429f75dc53b7ad77fb2f9ab7cd56b",
-                "sha256:b3591a00c0366de71d65108627899710d9cfb00e575c4d211aa8de59b1f130c9"
+                "sha256:4c82187dd6ab3607150fbb1fa5ef4643118f3da122b8ba31c3149ddd9cf0cb39",
+                "sha256:9e6080a7aee4cc6a06b58b59239f20f1d259c1d2fddf68ddeed242d2311c7087",
+                "sha256:f3fdaa9a38752a3b214a6fe79d7cae3653731a53e577821f9187e67cbecb2e16",
+                "sha256:f646f8d17d02be0872291f258cce3813497bc7888cd4712a577fd1e719b2f213"
             ],
             "index": "pypi",
-            "version": "==1.3.14"
+            "version": "==1.4.6"
         },
         "netaddr": {
             "hashes": [
@@ -735,11 +736,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:97660b282aa7e29f94f3fe378e5c7162d7ab9d601a8dbb1cbb2ffc8f0e54607d",
-                "sha256:cfd1281b1748288e59762c0e174d64d8bcb2b70e7c57bc4a1203c8825af24ac3"
+                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
+                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
             ],
             "index": "pypi",
-            "version": "==0.15.3"
+            "version": "==1.0.0"
         },
         "whitenoise": {
             "hashes": [

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -551,6 +551,7 @@ ENABLE_AV_CAPTURE = False
 RESOURCE_LOAD_TIMEOUT = 45 # seconds to wait for at least one resource to load before giving up on capture
 SHUTDOWN_GRACE_PERIOD = 10 # seconds to allow slow threads to finish before we complete the capture job
 MAX_PROXY_THREADS = 100
+MAX_PROXY_QUEUE_SIZE = 500 # this is the default in https://github.com/internetarchive/warcprox/blob/ee6bc151e1758a50f8af2b8f2d9746aa56ec95fb/warcprox/main.py#L192
 
 WEBPACK_LOADER = {
     'DEFAULT': {


### PR DESCRIPTION
Motivation: we've been on a relatively early beta release of 2.4, (2.4b2), and since then, they've released 2.4b3, 2.4b5, 2.4b6, 2.4.9, 2.4.17. Surely we'd benefit from some of the changes therein, even if we haven't been noticing major problems with capture.

Testing: local experiments look fine, and I plan to give it some more exercise there, but we should plan to test this pretty extensively on stage, with a wide range of URLs, comparing stage to prod if capture quality seems suspect or if capture failures occur.

Merging and deploying: this should be merged after https://github.com/harvard-lil/perma/pull/2718 (the diff will update to not include that commit, subsequent to its merge, methinks), and then tested, and then I think the two should be deployed to prod together, without other considerable changes.