### PR TITLE
Force celery to email when tasks fail...

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -318,6 +318,10 @@ LOGGING['loggers'] = {
     'warcprox': {
         'level': 'CRITICAL'
     },
+    'celery.django': {
+        'level': 'ERROR',
+        'handlers': ['console', 'mail_admins', 'file'],
+    },
     # show info for our first-party apps
     **{
         app_name: {'level': 'INFO'}
@@ -396,7 +400,6 @@ else:
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
-CELERY_SEND_TASK_ERROR_EMAILS = True
 # If a task is running longer than five minutes, ask it to shut down
 CELERY_TASK_SOFT_TIME_LIMIT=300
 # If a task is running longer than seven minutes, kill it


### PR DESCRIPTION
...and when exceptions are caught during capture.

For the last long while, we have been receiving emails only when tasks completely fail, as when they are forcibly terminated after the hard time limit. In general, if exceptions occurred during capture, we printed a traceback to the celery log, but were not otherwise notified. 

Beginning with Celery 4.0.0, "Tasks no longer sends error emails." https://docs.celeryproject.org/en/stable/history/whatsnew-4.0.html

This PR registers a signal to email us similarly to before, and adds emails for exceptions caught during capture. If the volume is overwhelming, TBD (though I don't predict it will, and sure hope it won't, be).

It is a little difficult to detect locally whether this will produce duplicate entries in the the django log; I don't believe so, but am not positive.
