### PR TITLE
Get warc_size from tempfile, not from default storage.

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -3,7 +3,6 @@ import csv
 import django_filters
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
-from django.core.files.storage import default_storage
 from django.http import Http404, HttpResponse
 from mptt.exceptions import InvalidMove
 from rest_framework import status

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -409,8 +409,6 @@ class AuthenticatedLinkListView(BaseView):
             uploaded_file = request.data.get('file')
             if uploaded_file:
                 link.write_uploaded_file(uploaded_file)
-                link.warc_size = default_storage.size(link.warc_storage_file())
-                link.save()
 
             # handle submitted url
             else:
@@ -510,8 +508,6 @@ class AuthenticatedLinkDetailView(BaseView):
 
                 # write new warc and capture
                 link.write_uploaded_file(uploaded_file, cache_break=True)
-                link.warc_size = default_storage.size(link.warc_storage_file())
-                link.save()
 
                 # delete the link from Webrecorder and
                 # clear the user's Webrecorder session, if any,

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1385,9 +1385,12 @@ class Link(DeletableModel):
                           user_upload='True',
                           content_type=mime_type,
                           url=warc_url)
-        with preserve_perma_warc(self.guid, self.creation_timestamp, self.warc_storage_file()) as warc:
+        warc_size = []  # pass a mutable container to the context manager, so that it can populate it with the size of the finished warc
+        with preserve_perma_warc(self.guid, self.creation_timestamp, self.warc_storage_file(), warc_size) as warc:
             uploaded_file.file.seek(0)
             write_resource_record_from_asset(uploaded_file.file.read(), warc_url, mime_type, warc)
+        self.warc_size = warc_size[0]
+        self.save(update_fields=['warc_size'])
         capture.save()
 
     def safe_delete_warc(self):

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -805,10 +805,13 @@ def save_warc(warcprox_controller, capture_job, link, content_type, screenshot, 
 
     # update the db to indicate we succeeded
     safe_save_fields(
+        link,
+        warc_size=warc_size[0]
+    )
+    safe_save_fields(
         link.primary_capture,
         status='success',
-        content_type=content_type,
-        warc_size = warc_size[0]
+        content_type=content_type
     )
     if screenshot:
         safe_save_fields(

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -794,8 +794,9 @@ def save_warc(warcprox_controller, capture_job, link, content_type, screenshot, 
         warcprox_controller.options.directory,
         "{}.warc.gz".format(warcprox_controller.options.warc_filename)
     )
+    warc_size = []  # pass a mutable container to the context manager, so that it can populate it with the size of the finished warc
     with open(recorded_warc_path, 'rb') as recorded_warc_records, \
-         preserve_perma_warc(link.guid, link.creation_timestamp, link.warc_storage_file()) as perma_warc:
+         preserve_perma_warc(link.guid, link.creation_timestamp, link.warc_storage_file(), warc_size) as perma_warc:
         # screenshot first, per Perma custom
         if screenshot:
             write_resource_record_from_asset(screenshot, link.screenshot_capture.url, link.screenshot_capture.content_type, perma_warc)
@@ -807,6 +808,7 @@ def save_warc(warcprox_controller, capture_job, link, content_type, screenshot, 
         link.primary_capture,
         status='success',
         content_type=content_type,
+        warc_size = warc_size[0]
     )
     if screenshot:
         safe_save_fields(
@@ -814,10 +816,6 @@ def save_warc(warcprox_controller, capture_job, link, content_type, screenshot, 
             status='success'
         )
     save_favicons(link, successful_favicon_urls)
-    safe_save_fields(
-        link,
-        warc_size=default_storage.size(link.warc_storage_file())
-    )
     capture_job.mark_completed()
 
 

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -488,7 +488,7 @@ def decrypt_from_perma_payments(ciphertext, encoder=encoding.Base64Encoder):
 #
 
 @contextmanager
-def preserve_perma_warc(guid, timestamp, destination):
+def preserve_perma_warc(guid, timestamp, destination, warc_size):
     """
     Context manager for opening a perma warc, ready to receive warc records.
     Safely closes and saves the file to storage when context is exited.
@@ -502,6 +502,7 @@ def preserve_perma_warc(guid, timestamp, destination):
         out.flush()
         out.seek(0)
         default_storage.store_file(out, destination, overwrite=True)
+        warc_size.append(out.tell())
         out.close()
 
 def write_perma_warc_header(out_file, guid, timestamp):


### PR DESCRIPTION
We have observed that S3 is not always ready to report the size of uploaded warcs, immediately after upload. As a result, some capture jobs are failing unnecessarily. See https://github.com/harvard-lil/perma/issues/2172 for some discussion, and other various discussions of warc_size.

This PR switches our strategy, getting the size of the warc from our local tempfile, rather than inquiring from S3/the storage backend used by default_storage.