### PR TITLE
Re-order lines, to potentially avoid closed-file error on certain tiers.

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -500,9 +500,9 @@ def preserve_perma_warc(guid, timestamp, destination, warc_size):
         yield out
     finally:
         out.flush()
+        warc_size.append(out.tell())
         out.seek(0)
         default_storage.store_file(out, destination, overwrite=True)
-        warc_size.append(out.tell())
         out.close()
 
 def write_perma_warc_header(out_file, guid, timestamp):


### PR DESCRIPTION
I can't explain why `out.tell()` in the former position is throwing `I/O operation on closed file` on stage but not locally or in CI, but it is! So, try this instead.