### PR TITLE
Display Celery queue lengths on private stats page...

### DIFF
--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -164,6 +164,18 @@
       </div>
     </script>
 
+    <script id="celery_queues-template" type="text/x-handlebars-template">
+      <h3 class="body-ah">Celery queues:</h3>
+      <div class="row">
+        <div class="col-sm-3">Tasks in main queue:</div>
+        <div class="col-sm-9">{{ total_main_queue }}</div>
+      </div>
+      <div class="row">
+        <div class="col-sm-3">Tasks in background queue:</div>
+        <div class="col-sm-9">{{ total_background_queue }}</div>
+      </div>
+    </script>
+
     <script id="celery-template" type="text/x-handlebars-template">
       <h3 class="body-ah">Celery task data:</h3>
       <div class="row">
@@ -173,17 +185,18 @@
             <div>
               <h5>Active jobs:</h5>
               {{#each active}}
-                {{name}}: {{kwargs}}<br/>
+                {{name}}: {{#each args}}{{this}}{{/each}} {{#each kwargs}}{{this}}{{/each}}<br/>
               {{/each}}
             </div>
+            <br>
             <div>
               <h5>Next jobs (not a complete list):</h5>
               {{#each reserved}}
-                {{name}}: {{kwargs}}<br/>
+                {{name}}: {{#each args}}{{this}}{{/each}} {{#each kwargs}}{{this}}{{/each}}<br/>
               {{/each}}
             </div>
-            <div>{{ reserved }}</div>
             <div>
+              <br>
               <h5>Finished task count:</h5>
               {{#each stats.total}}
                 {{@key}}: {{this}}<br/>

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -4,6 +4,7 @@ import itertools
 from datetime import timedelta
 
 from celery.task.control import inspect as celery_inspect
+import redis
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters, sensitive_variables
@@ -185,6 +186,13 @@ def stats(request, stat_type=None):
                     'stats': stats[queue],
                 })
         out = {'queues':queues}
+
+    elif stat_type == "celery_queues":
+        r = redis.from_url(settings.CELERY_BROKER_URL)
+        out = {
+            'total_main_queue': r.llen('celery'),
+            'total_background_queue': r.llen('background'), 
+        }
 
     elif stat_type == "job_queue":
         job_queues = CaptureJob.objects.filter(status='pending').order_by('order', 'pk').select_related('link', 'link__created_by')

--- a/perma_web/static/bundles/admin-stats.js
+++ b/perma_web/static/bundles/admin-stats.js
@@ -24,10 +24,17 @@ webpackJsonp([0],[
 	chain = chain.then(addSection("days"));
 	chain = chain.then(addSection("emails"));
 	chain = chain.then(addSection("job_queue"));
+	chain = chain.then(addSection("celery_queues"));
 	chain = chain.then(addSection("celery"));
 	
 	setInterval(function () {
 	  fillSection("job_queue");
+	}, 2000);
+	setInterval(function () {
+	  fillSection("celery_queues");
+	}, 2000);
+	setInterval(function () {
+	  fillSection("celery");
 	}, 2000);
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(1)))
 

--- a/perma_web/static/js/admin-stats.js
+++ b/perma_web/static/js/admin-stats.js
@@ -16,6 +16,9 @@ var chain = $.when(addSection("random")());
 chain = chain.then(addSection("days"));
 chain = chain.then(addSection("emails"));
 chain = chain.then(addSection("job_queue"));
+chain = chain.then(addSection("celery_queues"));
 chain = chain.then(addSection("celery"));
 
 setInterval(function(){ fillSection("job_queue")}, 2000);
+setInterval(function(){ fillSection("celery_queues")}, 2000);
+setInterval(function(){ fillSection("celery")}, 2000);


### PR DESCRIPTION
... and tweak stats output post celery upgrade, so that it prints args/kwargs correctly, instead of just printing `[object Object]` (which I noticed was happening when the playback status task was running).


![image](https://user-images.githubusercontent.com/11020492/75707802-951be980-5c8d-11ea-93ee-59bdcb85bc0c.png)
