### PR TITLE
Disallow deletion while capture is in progress.

### DIFF
--- a/perma_web/api/tests/test_current_user_resource.py
+++ b/perma_web/api/tests/test_current_user_resource.py
@@ -22,7 +22,7 @@ class CurrentUserResourceTestCase(ApiResourceTestCase):
         self.successful_get(self.detail_url, user=self.org_user, fields=self.fields)
 
     def test_get_archives_json(self):
-        self.successful_get(self.detail_url + 'archives/', user=self.org_user, count=13)
+        self.successful_get(self.detail_url + 'archives/', user=self.org_user, count=14)
         self.successful_get(self.detail_url + 'archives/', user=self.regular_user, count=14)
 
     def test_get_folders_json(self):

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -119,7 +119,7 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
     #######
 
     def test_get_list_json(self):
-        self.successful_get(self.public_list_url, count=8)
+        self.successful_get(self.public_list_url, count=9)
 
     def test_get_detail_json(self):
         self.successful_get(self.public_link_detail_url, fields=self.logged_out_fields)

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -500,6 +500,9 @@ class AuthenticatedLinkDetailView(BaseView):
             uploaded_file = request.data.get('file')
             if uploaded_file:
 
+                if link.capture_job.status ==  'in_progress' :
+                    raise_general_validation_error("Capture in progress: please wait until complete before uploading a replacement.")
+
                 # delete related captures, delete warc (rename), mark capture job as superseded
                 link.delete_related_captures()
                 link.safe_delete_warc()
@@ -540,6 +543,9 @@ class AuthenticatedLinkDetailView(BaseView):
 
         if not request.user.can_delete(link):
             raise PermissionDenied()
+
+        if link.capture_job.status ==  'in_progress' :
+            raise_general_validation_error("Capture in progress: please wait until complete before deleting.")
 
         link.delete_related_captures()
         link.cached_can_play_back = False

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -500,7 +500,7 @@ class AuthenticatedLinkDetailView(BaseView):
             uploaded_file = request.data.get('file')
             if uploaded_file:
 
-                if link.capture_job.status ==  'in_progress' :
+                if link.has_capture_job() and link.capture_job.status ==  'in_progress' :
                     raise_general_validation_error("Capture in progress: please wait until complete before uploading a replacement.")
 
                 # delete related captures, delete warc (rename), mark capture job as superseded
@@ -544,7 +544,7 @@ class AuthenticatedLinkDetailView(BaseView):
         if not request.user.can_delete(link):
             raise PermissionDenied()
 
-        if link.capture_job.status ==  'in_progress' :
+        if link.has_capture_job() and link.capture_job.status ==  'in_progress' :
             raise_general_validation_error("Capture in progress: please wait until complete before deleting.")
 
         link.delete_related_captures()

--- a/perma_web/fixtures/archive.json
+++ b/perma_web/fixtures/archive.json
@@ -309,6 +309,22 @@
     }
   },
   {
+    "pk": "ABCD-0010",
+    "model": "perma.link",
+    "fields": {
+      "folders": [
+        27
+      ],
+      "notes": "In Progress",
+      "created_by": 2,
+      "submitted_url": "https://github.com",
+      "submitted_url_surt": "com,github)/",
+      "creation_timestamp": "2016-07-19T20:21:31Z",
+      "archive_timestamp": "2016-07-20T20:21:31Z",
+      "organization": 1
+    }
+  },
+  {
   "fields": {
     "status": "pending",
     "url": "http://dolekemp96.org",
@@ -560,7 +576,7 @@
   "model": "perma.capturejob",
   "pk": 3
   },
-    {
+  {
   "fields": {
     "link": "ABCD-0008",
     "status": "completed",
@@ -579,7 +595,7 @@
   "model": "perma.capturejob",
   "pk": 4
   },
-    {
+  {
   "fields": {
     "link": "ABCD-0009",
     "status": "completed",
@@ -597,5 +613,24 @@
   },
   "model": "perma.capturejob",
   "pk": 5
+  },
+  {
+  "fields": {
+    "link": "ABCD-0010",
+    "status": "in_progress",
+    "message": null,
+    "human": true,
+    "order": 1000.0,
+    "submitted_url": "https://github.com",
+    "created_by": 4,
+    "link_batch": null,
+    "attempt": 1,
+    "step_count": 0.0,
+    "step_description": "Starting capture",
+    "capture_start_time": "2019-03-27T19:03:49Z",
+    "capture_end_time": null
+  },
+  "model": "perma.capturejob",
+  "pk": 6
   }
 ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1342,6 +1342,13 @@ class Link(DeletableModel):
     def delete_related_captures(self):
         Capture.objects.filter(link_id=self.pk).delete()
 
+    def has_capture_job(self):
+        try:
+            self.capture_job
+        except CaptureJob.DoesNotExist:
+            return False
+        return True
+
     def mark_capturejob_superseded(self):
         try:
             job = self.capture_job

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -145,7 +145,7 @@
             <label for="notes" class="tray-detail-title">Notes <span class="label-instruction _verbose"> (only visible to you{% if link.organization%} and your organization{% endif %})</span><span class="save-status"></span></label>
             <input id="notes" name="notes" class="form-control link-notes"  value="{{link.notes}}"/>
           </div>
-          {% if can_delete %}
+          {% if can_delete  and not link.capture_job.status == 'in_progress' %}
             <div class="tray-detail-group temporary-options">
               <form id="archive_upload_form">
                 <label class="tray-detail-title">Upload file<span class="label-asterisk">*</span> <span class="label-instruction _verbose" style="display:block;"> This will replace the existing capture. GIF, JPG, PDF, and PNG up to {{max_size}} MB are allowed.</span></label>


### PR DESCRIPTION
With the new error reporting, we're noticing a variety of peculiar errors go by, all from users deleting a Perma Link while its capture is in progress. Even if the user knows in advance that capture will not produce a satisfactory Perma Link (e.g., they know they are capturing a paywalled resource), we don't want to support a workflow that includes deletion mid-capture: it throws too many spanners in the works. This PR disables deletion and replacement while a link's capture job is `in_progress`. Deletion and replacement are still allowed before capture is started, and after it is completed. 

Users who want a workaround can be  given instructions on how to "upload your own".