### PR TITLE
Put internet archive tasks on their own queue.

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -31,7 +31,7 @@ def run_django(port="0.0.0.0:8000", use_ssl=False, cert_file='perma-test.crt', h
     if settings.RUN_TASKS_ASYNC:
         print("Starting background celery process. Warning: this has a documented memory leak, and developing with"
               " RUN_TASKS_ASYNC=False is usually easier unless you're specifically testing a Django-Celery interaction.")
-        commands.append('celery -A perma worker --loglevel=info -Q celery,background -B -n w1@%h')
+        commands.append('celery -A perma worker --loglevel=info -Q celery,background,ia -B -n w1@%h')
 
     # Only run the webpack background process in debug mode -- with debug False, dev server uses static assets,
     # and running webpack just messes up the webpack stats file.

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -409,6 +409,16 @@ CELERY_TASK_TIME_LIMIT = 420
 # this value will be reset in settings.utils.post_processing
 WORKER_COUNT = 2
 
+CELERY_TASK_ROUTES = {
+    'perma.tasks.upload_to_internet_archive': {'queue': 'ia'},
+    'perma.tasks.delete_from_internet_archive': {'queue': 'ia'},
+    'perma.tasks.delete_all_from_internet_archive': {'queue': 'ia'},
+    'perma.tasks.upload_all_to_internet_archive': {'queue': 'ia'},
+    'perma.tasks.sync_subscriptions_from_perma_payments': {'queue': 'background'},
+    'perma.tasks.cache_playback_status_for_new_links': {'queue': 'background'},
+    'perma.tasks.cache_playback_status': {'queue': 'background'},
+}
+
 # Control whether Celery tasks should be run in the background or during a request.
 # This should normally be True, but it's handy to not require rabbitmq and celery sometimes.
 RUN_TASKS_ASYNC = True
@@ -542,17 +552,6 @@ LOCKSS_CONTENT_IPS = ""  # IPs of Perma servers allowed to play back LOCKSS cont
 LOCKSS_CRAWL_INTERVAL = "12h"
 LOCKSS_QUORUM = 3
 LOCKSS_DEBUG_IPS = False
-
-CELERY_TASK_ROUTES = {
-    'perma.tasks.upload_to_internet_archive': {'queue': 'background'},
-    'perma.tasks.delete_from_internet_archive': {'queue': 'background'},
-    'perma.tasks.delete_all_from_internet_archive': {'queue': 'background'},
-    'perma.tasks.upload_all_to_internet_archive': {'queue': 'background'},
-    'perma.tasks.sync_subscriptions_from_perma_payments': {'queue': 'background'},
-    'perma.tasks.cache_playback_status_for_new_links': {'queue': 'background'},
-    'perma.tasks.cache_playback_status': {'queue': 'background'},
-}
-
 
 ENABLE_AV_CAPTURE = False
 RESOURCE_LOAD_TIMEOUT = 45 # seconds to wait for at least one resource to load before giving up on capture

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -14,7 +14,7 @@ MEDIA_ROOT = 'perma/assets/generated/'
 # These will be added to CELERYBEAT_SCHEDULE in settings.utils.post_processing
 CELERY_BEAT_JOB_NAMES = [
     'update-stats',
-    'send-links-to-internet-archives',
+    'send-links-to-internet-archive',
     'send-js-errors',
     'run-next-capture',
     'verify_webrecorder_api_available',

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -33,7 +33,7 @@ def post_process_settings(settings):
             'task': 'perma.tasks.update_stats',
             'schedule': crontab(minute='*'),
         },
-        'send-links-to-internet-archives': {
+        'send-links-to-internet-archive': {
             'task': 'perma.tasks.upload_all_to_internet_archive',
             'schedule': crontab(minute='0', hour='*'),
         },

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1475,7 +1475,7 @@ def upload_all_to_internet_archive(limit=None):
         return
 
     links = Link.objects.visible_to_ia().filter(
-        internet_archive_upload_status__in=['not_started', 'failed', 'upload_or_reupload_required']
+        internet_archive_upload_status__in=['not_started', 'failed', 'upload_or_reupload_required', 'deleted']
     )
     if limit:
         links = links[:limit]

--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -174,6 +174,10 @@
         <div class="col-sm-3">Tasks in background queue:</div>
         <div class="col-sm-9">{{ total_background_queue }}</div>
       </div>
+      <div class="row">
+        <div class="col-sm-3">Tasks in IA queue:</div>
+        <div class="col-sm-9">{{ total_ia_queue }}</div>
+      </div>
     </script>
 
     <script id="celery-template" type="text/x-handlebars-template">

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -191,7 +191,8 @@ def stats(request, stat_type=None):
         r = redis.from_url(settings.CELERY_BROKER_URL)
         out = {
             'total_main_queue': r.llen('celery'),
-            'total_background_queue': r.llen('background'), 
+            'total_background_queue': r.llen('background'),
+            'total_ia_queue': r.llen('ia'),
         }
 
     elif stat_type == "job_queue":


### PR DESCRIPTION
The current Salt config, `CELERY_BEAT_JOB_NAMES.remove('send-links-to-internet-archives')`, will need the final `s` removed.