### PR TITLE
Task to populate warc_size.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -417,6 +417,7 @@ CELERY_TASK_ROUTES = {
     'perma.tasks.sync_subscriptions_from_perma_payments': {'queue': 'background'},
     'perma.tasks.cache_playback_status_for_new_links': {'queue': 'background'},
     'perma.tasks.cache_playback_status': {'queue': 'background'},
+    'perma.tasks.populate_warc_size_fields': {'queue': 'background'},
 }
 
 # Control whether Celery tasks should be run in the background or during a request.


### PR DESCRIPTION
This is a one-time task, to populate the warc_size field for links where we missed it, the first time around. See https://github.com/harvard-lil/perma/issues/2617 and https://github.com/harvard-lil/perma/issues/2172; old links also often lack this metadata.

There are 281,874 links to process. Each should take less than a second. I put this on the background queue; TBD if we are okay waiting. I think, yes.