### PR TITLE
Fix CSV download of metadata about links

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -448,11 +448,16 @@ class AuthenticatedLinkListExportView(BaseView):
 
     @load_parent
     def get(self, request, format=None):
+        def report_status(link):
+            if link.has_capture_job() and link.capture_job.status in ['pending', 'in_progress']:
+                return link.capture_job.status
+            return 'success' if link.can_play_back() else 'failure'
+
         queryset = AuthenticatedLinkListView.load_links(request)
         formatted_data = [
             OrderedDict([
                 ('url', link.submitted_url),
-                ('status', 'success' if link.can_play_back() else 'failure'),
+                ('status', report_status(link)),
                 ('error_message', link.capture_job.message if link.has_capture_job() else ''),
                 ('title', link.submitted_title),
                 ('perma_link', f"{request.scheme}://{request.get_host()}/{link.guid}")

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -451,11 +451,11 @@ class AuthenticatedLinkListExportView(BaseView):
         queryset = AuthenticatedLinkListView.load_links(request)
         formatted_data = [
             OrderedDict([
-                ('url', link.capture_job.submitted_url),
-                ('status', "success" if link.capture_job.status == "completed" else "error"),
-                ('error_message', link.capture_job.message),
+                ('url', link.submitted_url),
+                ('status', 'success' if link.can_play_back() else 'failure'),
+                ('error_message', link.capture_job.message if link.has_capture_job() else ''),
                 ('title', link.submitted_title),
-                ('perma_link', "{}://{}/{}".format(request.scheme, request.get_host(), link.guid))
+                ('perma_link', f"{request.scheme}://{request.get_host()}/{link.guid}")
             ])
             for link in queryset
         ]


### PR DESCRIPTION
A while ago, I threw in a feature that lets you download a CSV of metadata about links in a given folder:
![image](https://user-images.githubusercontent.com/11020492/76233250-4f679f80-61fe-11ea-8b11-0d7b71431db2.png)

It's been broken the whole time: it assumed that all links have capture jobs, which is not true. I have long delayed fixing it because I realized correctly populating the `status` field was wicked complicated...... which is no longer true! Now it's easy.

So, I'm finally fixing it.