### PR TITLE
Occasional control characters in old Perma Link urls

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -53,7 +53,7 @@ from perma.email import send_self_email
 from perma.exceptions import PermaPaymentsCommunicationException
 from perma.utils import (run_task, url_in_allowed_ip_range,
     copy_file_data, preserve_perma_warc, write_warc_records_recorded_from_web,
-    write_resource_record_from_asset, protocol)
+    write_resource_record_from_asset, protocol, remove_control_characters)
 from perma import site_scripts
 
 import logging
@@ -1501,13 +1501,14 @@ def upload_to_internet_archive(link_guid):
         logger.info(f"Queued Link {link_guid} no longer eligible for upload.")
         return
 
+    url = remove_control_characters(link.submitted_url)
     metadata = {
         "collection": settings.INTERNET_ARCHIVE_COLLECTION,
         "title": f"{link_guid}: {truncatechars(link.submitted_title, 50)}",
         "mediatype": "web",
-        "description": f"Perma.cc archive of {link.submitted_url} created on {link.creation_timestamp}.",
+        "description": f"Perma.cc archive of {url} created on {link.creation_timestamp}.",
         "contributor": "Perma.cc",
-        "submitted_url": link.submitted_url,
+        "submitted_url": url,
         "perma_url": protocol() + settings.HOST + reverse('single_permalink', args=[link.guid]),
         "external-identifier": f"urn:X-perma:{link_guid}",
     }

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -20,6 +20,7 @@ import surt
 import tempdir
 import tempfile
 from ua_parser import user_agent_parser
+import unicodedata
 from urllib.parse import urlparse
 from warcio.warcwriter import BufferWARCWriter
 from wsgiref.util import FileWrapper
@@ -371,6 +372,9 @@ def memento_data_for_url(request, url, qs=None, hash=None):
         }
     }
 
+
+def remove_control_characters(s):
+    return "".join(ch for ch in s if unicodedata.category(ch)[0]!="C")
 
 ### perma payments
 

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -28,7 +28,7 @@ from ..forms import ContactForm
 from ..utils import (if_anonymous, ratelimit_ip_key, redirect_to_download,
     protocol, stream_warc_if_permissible, set_options_headers,
     timemap_url, timegate_url, memento_url, memento_data_for_url, url_with_qs_and_hash,
-    get_client_ip)
+    get_client_ip, remove_control_characters)
 from ..email import send_admin_email, send_user_email_copy_admins
 
 import logging
@@ -237,6 +237,8 @@ def single_permalink(request, guid):
         response['Memento-Datetime'] = datetime_to_http_date(link.creation_timestamp)
         # impose an arbitrary length-limit on the submitted URL, so that this header doesn't become illegally large
         url = link.submitted_url[:500]
+        # strip control characters from url, if somehow they slipped in prior to https://github.com/harvard-lil/perma/commit/272b3a79d94a795142940281c9444b45c24a05db
+        url = remove_control_characters(url)
         response['Link'] = str(
             LinkHeader([
                 Rel(url, rel='original'),


### PR DESCRIPTION
Somehow or other, before https://github.com/harvard-lil/perma/commit/272b3a79d94a795142940281c9444b45c24a05db, some users were able to submit URLs with control characters in them. 

I can't decide whether we should try to clean this up in the db in some way... 

In the meantime, this strips control chars from two spots that I think are causing problems: the IA upload task, and the memento headers.