### PR TITLE
Warc not found

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1435,12 +1435,13 @@ class Link(DeletableModel):
         if job and not job.superseded and job.status != 'completed':
             successful_metadata = False
 
-        # I assert that the presence of a warc in default_storage means a Link
-        # can be played back. If there is a disconnect between our metadata and
-        # the contents of default_storage... something is wrong and needs fixing.
-        has_warc = default_storage.exists(self.warc_storage_file())
-        if successful_metadata != has_warc:
-            logger.error(f"Conflicting metadata about {self.guid}: has_warc={has_warc}, successful_metadata={successful_metadata}")
+        if settings.CHECK_WARC_BEFORE_PLAYBACK:
+            # I assert that the presence of a warc in default_storage means a Link
+            # can be played back. If there is a disconnect between our metadata and
+            # the contents of default_storage... something is wrong and needs fixing.
+            has_warc = default_storage.exists(self.warc_storage_file())
+            if successful_metadata != has_warc:
+                logger.error(f"Conflicting metadata about {self.guid}: has_warc={has_warc}, successful_metadata={successful_metadata}")
 
         # Trust our records (the metadata) more than has_warc
         return successful_metadata

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -487,6 +487,8 @@ WR_PLAYBACK_RETRY_AFTER = 1
 # to catch up, during first playback, before raising an error?
 WARC_AVAILABLE_TIMEOUT = 7
 
+CHECK_WARC_BEFORE_PLAYBACK = False
+
 # Disable SameSite protection (https://www.owasp.org/index.php/SameSite)
 # So that we can set iframe cookies properly, when we receive the redirect from Webrecorder
 # https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -482,6 +482,11 @@ WR_COOKIE_PERMITTED_AGE = 60
 # Seconds to wait before retrying a failed WR playback.
 WR_PLAYBACK_RETRY_AFTER = 1
 
+# We're finding that warcs aren't always available for download from S3
+# instantly, immediately after upload. How long do we want to wait for S3
+# to catch up, during first playback, before raising an error?
+WARC_AVAILABLE_TIMEOUT = 7
+
 # Disable SameSite protection (https://www.owasp.org/index.php/SameSite)
 # So that we can set iframe cookies properly, when we receive the redirect from Webrecorder
 # https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE

--- a/perma_web/perma/templates/archive/playback-delayed.html
+++ b/perma_web/perma/templates/archive/playback-delayed.html
@@ -1,0 +1,12 @@
+{# called from pywb when a requested asset doesn't exist in the warc #}
+{% extends "archive/single-link.html" %}
+
+{% block styles %}
+{% endblock %}
+
+{% block mainContent %}
+  <div class="record-message" style="padding-top: 15px;">
+    <p class="record-message-primary">Playback Delayed</p>
+    <p class="record-message-secondary">We apologize, the playback of your Perma Link is delayed. Please try again in a couple of seconds. If this problem persists, please let us know.</p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
A few times a day, we observe a spurious "not found" for a warc during playback, resulting in a 500 Internal Server Error on the Perma side, visible to the user. The first attempt to play back gets a 404 from S3, as does the retry 2 seconds later.... but every time, without fail, when we follow up, the link plays back fine...

Here's my only theory: these are all from newly-created links, and S3 hasn't fully replicated across it's servers yet. From https://aws.amazon.com/premiumsupport/knowledge-center/404-error-nosuchkey-s3/
> Amazon S3 might return the "NoSuchKey" error if the object was recently uploaded. When you upload an object, Amazon S3 replicates your data across multiple servers, so the newly uploaded object might not be found until after the object is completely replicated across the multiple servers. Amazon S3 provides eventual consistency for read-after-write if a GET or HEAD object call is made before the object upload. To avoid the "NoSuchKey" error for a newly uploaded object, wait a few seconds after the PUT request, and then you can make the first attempt to access the object.

So, this PR adds special handling for newly-created links, waiting for S3 to return 200 for up to `settings.WARC_AVAILABLE_TIMEOUT` seconds before attempting to initialize playback. I have it set to 7 seconds for now. We know that 2 seconds is not long enough, otherwise, the existing playback retry code would cover it.

Fingers crossed!