### PR TITLE
Wait longer for WR upload timeout, to account for large warcs.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -469,7 +469,7 @@ WR_PERMA_PASSWORD = 'Test123Test123'
 # Time (in seconds) to wait for upload to finalize
 # after data fully uploaded to Webreccorder
 # Or, assume error if upload not done after this many seconds
-WR_REPLAY_UPLOAD_TIMEOUT = 20
+WR_REPLAY_UPLOAD_TIMEOUT = 25
 
 # We have WR sessions set to expire after 120s (see wr-custom.yaml).
 # We don't want the cookie to expire mid-upload or mid-playback.


### PR DESCRIPTION
I am investigating how it can be so big (is limiting mechanism broken?), but, we have a 219MB Perma Link created yesterday. The first attempt to play back always fails, due to WR upload timeout. The second (automatic) attempt always works. So, let's increase the WR upload timeout, see if we can avoid the retry, even for our biggest warcs. (Why is upload happening more quickly on the retry?)