### PR TITLE
Set a cookie to toggle Cloudflare caching.

### DIFF
--- a/perma_web/perma/middleware.py
+++ b/perma_web/perma/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import Http404
 from django.utils.deprecation import MiddlewareMixin
 
@@ -10,3 +11,16 @@ class AdminAuthMiddleware(MiddlewareMixin):
         if request.path.startswith('/admin/') and not getattr(request.user, 'is_staff', False):
             raise Http404
 
+
+def bypass_cache_middleware(get_response):
+
+    def middleware(request):
+        response = get_response(request)
+        if request.user.is_authenticated:
+            response.set_cookie(settings.CACHE_BYPASS_COOKIE_NAME, 'True')
+        else:
+            response.delete_cookie(settings.CACHE_BYPASS_COOKIE_NAME)
+
+        return response
+
+    return middleware

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -108,6 +108,7 @@ MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'perma.middleware.bypass_cache_middleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'perma.middleware.AdminAuthMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
@@ -260,17 +261,22 @@ LOGIN_MINUTE_LIMIT = '5000/m'
 LOGIN_HOUR_LIMIT = '10000/h'
 LOGIN_DAY_LIMIT = '50000/d'
 
+#
+# Django cache
+#
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     }
 }
-# Cache-Control max-age settings
 CACHE_MAX_AGES = {
     'single_permalink' : 60 * 60,     # 1hr
     'timegate'     : 0,
     'timemap'      : 60 * 30,         # 30mins
 }
+
+# Remote cache
+CACHE_BYPASS_COOKIE_NAME = 'cloudflare-bypass-cache'
 
 # Dashboard user lists
 MAX_USER_LIST_SIZE = 50


### PR DESCRIPTION
Since we now use the Django session for playback, even for anonymous users, the presence of the Django session cookie is no longer a good indicator of when or when not Cloudflare should use its cache.

This PR sets a new cookie for logged-in users, which I believe will restore the intended caching, coupled with a new page rule. 

Caveat: in Firefox and Chrome, I can see that `response.delete_cookie(settings.CACHE_BYPASS_COOKIE_NAME)` indeed entirely removes the cookie. With the test client, I can see that instead, the value is set to `''`, empty string. So, in real life, this might not work for all browsers... but I think it's as close as we are going to get. Worst case scenario is not very bad: the Cloudflare cache may continue to be bypassed for users who have manually logged out, after they log out (who cares).

Note that this applies only to pages at perma.cc; not at perma-archives.org. I'm interested in tweaking the cookie situation there, too, but that will require a non-trivial customization of Webrecorder.