### PR TITLE
See if two more seconds is enough for remaining timeouts.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -485,7 +485,7 @@ WR_PLAYBACK_RETRY_AFTER = 1
 # We're finding that warcs aren't always available for download from S3
 # instantly, immediately after upload. How long do we want to wait for S3
 # to catch up, during first playback, before raising an error?
-WARC_AVAILABLE_TIMEOUT = 7
+WARC_AVAILABLE_TIMEOUT = 9
 
 CHECK_WARC_BEFORE_PLAYBACK = False
 


### PR DESCRIPTION
https://github.com/harvard-lil/perma/pull/2761 appears to be working; this happens noticeably less frequently. But, it's still happening occasionally. Let's see if another 2 seconds does the job. 
