### PR TITLE
Restrict cookie-handling to login/logout routes.

### DIFF
--- a/perma_web/perma/middleware.py
+++ b/perma_web/perma/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.http import Http404
+from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -13,14 +14,16 @@ class AdminAuthMiddleware(MiddlewareMixin):
 
 
 def bypass_cache_middleware(get_response):
+    LOGIN_ROUTE = reverse('user_management_limited_login')
+    LOGOUT_ROUTE = reverse('logout')
 
     def middleware(request):
         response = get_response(request)
-        if request.user.is_authenticated:
-            response.set_cookie(settings.CACHE_BYPASS_COOKIE_NAME, 'True')
-        else:
-            response.delete_cookie(settings.CACHE_BYPASS_COOKIE_NAME)
-
+        if request.path.startswith(LOGIN_ROUTE) or request.path.startswith(LOGOUT_ROUTE):
+            if request.user.is_authenticated:
+                response.set_cookie(settings.CACHE_BYPASS_COOKIE_NAME, 'True')
+            else:
+                response.delete_cookie(settings.CACHE_BYPASS_COOKIE_NAME)
         return response
 
     return middleware


### PR DESCRIPTION
This is a followup on https://github.com/harvard-lil/perma/pull/2767

"if there is a cookie in the response, then Cloudflare does not cache the resource." https://support.cloudflare.com/hc/en-us/articles/200172516.

The former version of this middleware redundantly handled cookies on every request... so nothing (except static assets) ever got cached (observed during testing on stage).

This PR restricts cookie-handling to the login and logout routes.... which should be sufficient.