### PR TITLE
Enforce size limit in threads too.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -78,7 +78,7 @@ def celery_task_failure_email(**kwargs):
     """
     Celery 4.0 onward has no method to send emails on failed tasks
     so this event handler is intended to replace it. It reports truly failed
-    tasks, just as those terminated after CELERY_TASK_TIME_LIMIT.
+    tasks, such as those terminated after CELERY_TASK_TIME_LIMIT.
     From https://github.com/celery/celery/issues/3389
     """
 


### PR DESCRIPTION
Fixes https://github.com/harvard-lil/perma/issues/2775

Without the sleep in the size monitoring thread, captures were CPU-intensive enough to make my fan run; the sleep of 0.2s seems sufficient, but, if load on the workers is too high, we can make this sleep longer.