### PR TITLE
See if another second is enough for remaining timeouts.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -491,7 +491,7 @@ WR_PLAYBACK_RETRY_AFTER = 1
 # We're finding that warcs aren't always available for download from S3
 # instantly, immediately after upload. How long do we want to wait for S3
 # to catch up, during first playback, before raising an error?
-WARC_AVAILABLE_TIMEOUT = 9
+WARC_AVAILABLE_TIMEOUT = 10
 
 CHECK_WARC_BEFORE_PLAYBACK = False
 


### PR DESCRIPTION
https://github.com/harvard-lil/perma/pull/2768 improved things, but there's been at least one playback that needed more than 9 seconds. Let's see if another second does the job.