### PR TITLE
Remove conflicting os environ celery settings

### DIFF
--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -20,7 +20,6 @@ if use_newrelic:
 
 # env setup
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "perma.settings")
-os.environ.setdefault("CELERY_LOADER", "django")
 
 # these imports may depend on env setup and/or newrelic setup that came earlier
 from werkzeug.middleware.dispatcher import DispatcherMiddleware


### PR DESCRIPTION
After getting the most recent changes in develop, `d fab run:use_ssl=True` was failing.

With some debugging I was able to find that running django with `runserver_plus` was failing while `runserver` was working OK - that led me down a google rabbit hole looking at the new celery/django settings plus django-extensions plus werkzeug and I kept seeing issues/code related to environment settings. That led me to blindly try removing this old command, which seems to be the old way of configuring celery with django.

After removing this line, using `runserver_plus` works again.