### PR TITLE
Tweak HTTP headers

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -537,6 +537,12 @@ CAPTURE_BROWSER = 'PhantomJS'  # or 'Chrome' or 'Firefox'
 CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) Safari/538.1"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
+CAPTURE_HEADERS = {
+    "Accept": "*/*",
+    "Accept-Encoding": "*",
+    "Accept-Language": "*",
+    "Connection": "keep-alive"
+}
 
 APPEND_SLASH = False
 


### PR DESCRIPTION
Some websites are evading capture... and after a couple of days investigating, it looks like it's a combination of our IP address, the headers we are sending (or not sending), and the order the headers are specified in. 

We aren't the first people to notice this sort of thing (e.g. https://sansec.io/labs/2017/05/02/http-header-order-is-important/).

After a couple days of experimenting, it looks like the headers and order in this PR are working... for now. Who knows how long that will last... but I'll plan to check on this weekly or so, and if it looks like this is insufficient or if the situation changes, I'll readdress.

Closes https://github.com/harvard-lil/perma/issues/2779