### PR TITLE
Try adding queue

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -180,12 +180,15 @@ def stats(request, stat_type=None):
         queues = []
         if active is not None:
             for queue in sorted(active.keys()):
-                queues.append({
-                    'name': queue,
-                    'active': active[queue],
-                    'reserved': reserved[queue],
-                    'stats': stats[queue],
-                })
+                try:
+                    queues.append({
+                        'name': queue,
+                        'active': active[queue],
+                        'reserved': reserved[queue],
+                        'stats': stats[queue],
+                    })
+                except KeyError:
+                    pass
         out = {'queues':queues}
 
     elif stat_type == "celery_queues":


### PR DESCRIPTION
On the admin stats page, this wraps the appending of celery queues in a try-except, since occasionally `reserved` or `stats` does not include `queue`. It is an effort to reduce noise in error reporting.