### PR TITLE
Don't error out if the page appears sizeless.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -761,7 +761,12 @@ def get_page_size(browser):
             # URLError: the headless browser has gone away for some reason.
             root_element = None
     if root_element:
-        return root_element.size
+        try:
+            return root_element.size
+        except WebDriverException:
+            # If there is no "body" element, a WebDriverException is thrown.
+            # Skip the screenshot in that case: nothing to see
+            pass
 
 def page_pixels_in_allowed_range(page_size):
     return page_size and page_size['width'] * page_size['height'] < settings.MAX_IMAGE_SIZE


### PR DESCRIPTION
https://github.com/harvard-lil/perma/pull/2780 let us start capturing a new set of pages... many of which reliably throw the below error during screenshot capture:

```
WebDriverException
Message: {"errorMessage":"null is not an object (evaluating 'a.clientWidth')","request":{"headers":{"Accept":"application/json","Accept-Encoding":"identity","Connection":"close","Content-Type":"application/json;charset=UTF-8","Host":"127.0.0.1:35805","User-Agent":"Python-urllib/3.7"},"httpVersion":"1.1","method":"GET","url":"/size","urlParsed":{"anchor":"","query":"","file":"size","directory":"/","path":"/size","relative":"/size","port":"","host":"","password":"","user":"","userInfo":"","authority":"","protocol":"","source":"/size","queryKey":{},"chunks":["size"]},"urlOriginal":"/session/e9e5b500-882e-11ea-91de-5bfa89c70bb8/element/:wdc:1587954572465/size"}}
Screenshot: available via screen
```
It turns out that, for whatever reason, at this point, phantom is no longer successfully rendering the page: the body is gone:
```
(Pdb) elements = browser.find_elements_by_css_selector('*')
(Pdb) for element in elements: print(element.tag_name)
html
head
script
script
```
That's a shame, and I'm not sure what to make of it! Clearly it was rendering it okay for a while, otherwise we wouldn't be getting nice captures. But, there doesn't seem to be anything I can do about it. If we do take a screenshot here, it is indeed blank.... though tall... 

This PR tweaks the code to return a `page_size` of `None`, so the screenshot is gracefully skipped.
