### PR TITLE
Fix select lists on Chrome

### DIFF
--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -11242,7 +11242,6 @@ input[type="submit"] {
   font-size: 16px;
   font-family: "Roboto", Helvetica, Arial, "Lucida Grande", sans-serif;
   font-weight: 400;
-  height: 42px;
 }
 
 .form-group select:focus {

--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -7757,6 +7757,10 @@ body {
   position: relative;
 }
 
+select {
+  overflow: auto;
+}
+
 cite,
 em,
 i {

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3003,7 +3003,6 @@ input[type="submit"] {
     font-size: 16px;
     font-family: $font-hed-alt;
     font-weight: 400;
-    height: 42px;
     &:focus {
       border-color: $color-blue;
       box-shadow: none;

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -153,6 +153,11 @@ body {
   position: relative;
 }
 
+// as of 5/5/2020, overflow: visible on Chrome causes select options to overflow the input as a long list, rather than resizing the widget appropriately
+select {
+  overflow: auto;
+}
+
 cite,
 em,
 i {


### PR DESCRIPTION
A user reported a badly-behaved select list:
![image](https://user-images.githubusercontent.com/11020492/81109025-77663d00-8ee7-11ea-9c81-40f8badc4b0f.png)

Turns out to be specific to Chrome (though I did not test on platforms other than Mac): `overflow: visible` totally messes up `select` elements. I do not recall this being true in the past; might be a relatively recent development.

This PR sets a standard overflow on select elements, as a workaround, and makes the input taller (which has been bugging me).