### PR TITLE
Add analytics to public-facing pages (except playbacks).

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -522,6 +522,30 @@ SESSION_COOKIE_SECURE = False
 
 API_VERSION = 1
 
+USE_ANALYTICS = False
+USE_ANALYTICS_VIEWS = [
+    'landing',
+    'about',
+    'stats',
+    'copyright_policy',
+    'terms_of_service',
+    'privacy_policy',
+    'return_policy',
+    'contingency_plan',
+    'docs',
+    'docs_perma_link_creation',
+    'docs_libraries',
+    'docs_faq',
+    'docs_accounts',
+    'dev_docs',
+    'sign_up',
+    'sign_up_courts',
+    'sign_up_faculty',
+    'sign_up_journals',
+    'sign_up_firm',
+    'libraries'
+]
+
 TEMPLATE_VISIBLE_SETTINGS = (
     'API_VERSION',
     'SECURE_SSL_REDIRECT',
@@ -529,6 +553,8 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'ENABLE_BATCH_LINKS',
     'PLAYBACK_HOST',
     'HOST',
+    'USE_ANALYTICS',
+    'USE_ANALYTICS_VIEWS'
 )
 
 

--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -121,6 +121,6 @@
     {% block scripts %}{% endblock %}
     {% block templates %}{% endblock %}
   </body>
-
+  {% include 'includes/analytics.html' %}
   {% endwith %}
 </html>

--- a/perma_web/perma/templates/includes/analytics.html
+++ b/perma_web/perma/templates/includes/analytics.html
@@ -1,0 +1,19 @@
+{% if USE_ANALYTICS and request.resolver_match.view_name in USE_ANALYTICS_VIEWS %}
+  {% verbatim %}
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://analytics.lil.tools/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '5']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+  {% endverbatim %}
+{% endif %}


### PR DESCRIPTION
To enable, set `USE_ANALYTICS = True`.

The list of routes can be configured using `USE_ANALYTICS_VIEWS`. List values are the names of the views as found in https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/urls.py