### PR TITLE
Fixes for sponsored users

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -123,7 +123,7 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
     #######
 
     def test_get_list_json(self):
-        self.successful_get(self.public_list_url, count=9)
+        self.successful_get(self.public_list_url, count=10)
 
     def test_get_detail_json(self):
         self.successful_get(self.public_link_detail_url, fields=self.logged_out_fields)

--- a/perma_web/fixtures/archive.json
+++ b/perma_web/fixtures/archive.json
@@ -325,6 +325,22 @@
     }
   },
   {
+    "pk": "ABCD-0011",
+    "model": "perma.link",
+    "fields": {
+      "folders": [
+        55
+      ],
+      "notes": "Personal Link for Sponsored User",
+      "created_by": 20,
+      "submitted_url": "https://github.com",
+      "submitted_url_surt": "com,github)/",
+      "creation_timestamp": "2016-07-19T20:21:31Z",
+      "archive_timestamp": "2016-07-20T20:21:31Z",
+      "organization": null
+    }
+  },
+  {
   "fields": {
     "status": "pending",
     "url": "http://dolekemp96.org",

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -901,30 +901,33 @@ class LinkUser(CustomerModel, AbstractBaseUser):
         if unlimited is None:
             unlimited = self.unlimited
 
+        # exclude sponsored links and links associated with an org
+        personal_links = Link.objects.filter(organization_id=None, folders__sponsored_by=None)
+
         if unlimited:
             # UNLIMITED (paid or sponsored)
             link_count = float("-inf")
         elif period == 'once':
             # TRIAL: all non-org links ever
             if self.cached_subscription_started:
-                link_count = Link.objects.filter(creation_timestamp__range=(self.cached_subscription_started, today), created_by_id=self.id, organization_id=None).count()
+                link_count = personal_links.filter(creation_timestamp__range=(self.cached_subscription_started, today), created_by_id=self.id).count()
             else:
-                link_count = Link.objects.filter(created_by_id=self.id, organization_id=None).count()
+                link_count = personal_links.filter(created_by_id=self.id, organization_id=None).count()
         elif period == 'monthly':
             # MONTHLY RECURRING: links this calendar month (or, for new customers, links this month from the moment you started paying us)
             if self.cached_subscription_started and \
                self.cached_subscription_started.year == today.year and \
                self.cached_subscription_started.month == today.month:
-                link_count = Link.objects.filter(creation_timestamp__range=(self.cached_subscription_started, today), created_by_id=self.id, organization_id=None).count()
+                link_count = personal_links.filter(creation_timestamp__range=(self.cached_subscription_started, today), created_by_id=self.id, organization_id=None).count()
             else:
-                link_count = Link.objects.filter(creation_timestamp__year=today.year, creation_timestamp__month__gte=today.month, created_by_id=self.id, organization_id=None).count()
+                link_count = personal_links.filter(creation_timestamp__year=today.year, creation_timestamp__month__gte=today.month, created_by_id=self.id, organization_id=None).count()
         elif period == 'annually':
             # ANNUAL RECURRING
             # if you have a paid subscription, calculate via its expiry date
             if self.cached_paid_through:
-                link_count = Link.objects.filter(creation_timestamp__range=(self.cached_paid_through - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
+                link_count = personal_links.filter(creation_timestamp__range=(self.cached_paid_through - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
             # else, check the last 365 days
-            link_count = Link.objects.filter(creation_timestamp__range=(today - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
+            link_count = personal_links.filter(creation_timestamp__range=(today - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
         else:
             raise NotImplementedError("User's link_limit_period not yet handled.")
         return max(limit - link_count, 0)

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -611,10 +611,14 @@ class Sponsorship(models.Model):
             models.UniqueConstraint(fields=['registrar', 'user'], name='unique_sponsorship'),
         ]
 
+    tracker = FieldTracker()
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         if not self.folders:
             self.user.create_sponsored_folder(self.registrar)
+        if self.tracker.has_changed('status'):
+            self.folders.update(read_only=self.status == 'inactive')
 
     @property
     def folders(self):

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -98,7 +98,7 @@ def noncustomers():
     return [nonpaying_registrar(), nonpaying_user()]
 
 def user_with_links():
-    # a user with 6 links, made at intervals
+    # a user with 6 personal links, made at intervals
     user = LinkUser()
     user.save()
     today = timezone.now()
@@ -1374,6 +1374,20 @@ class ModelsTestCase(PermaTestCase):
         get_subscription.assert_called_once_with(customer)
         is_active.assert_called_once_with(sentinel.subscription)
         links_remaining_in_period.assert_called_once_with(customer, customer.link_limit_period, customer.link_limit)
+
+
+    #
+    # Limk limit for sponsored users
+    #
+
+    def test_sponsored_links_not_counted_against_personal_total(self):
+        sponsored_user = LinkUser.objects.get(email='test_sponsored_user@example.com')
+        self.assertEqual(sponsored_user.get_links_remaining()[0], 10)
+        link = Link(creation_timestamp=timezone.now().replace(day=1), guid="AAAA-AAAA", created_by=sponsored_user)
+        link.save()
+        self.assertEqual(sponsored_user.get_links_remaining()[0], 9)
+        link.move_to_folder_for_user(sponsored_user.sponsorships.first().folders.first(), sponsored_user)
+        self.assertEqual(sponsored_user.get_links_remaining()[0], 10)
 
 
     #

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -1382,12 +1382,12 @@ class ModelsTestCase(PermaTestCase):
 
     def test_sponsored_links_not_counted_against_personal_total(self):
         sponsored_user = LinkUser.objects.get(email='test_sponsored_user@example.com')
-        self.assertEqual(sponsored_user.get_links_remaining()[0], 10)
+        self.assertEqual(sponsored_user.get_links_remaining()[0], 9)
         link = Link(creation_timestamp=timezone.now().replace(day=1), guid="AAAA-AAAA", created_by=sponsored_user)
         link.save()
-        self.assertEqual(sponsored_user.get_links_remaining()[0], 9)
+        self.assertEqual(sponsored_user.get_links_remaining()[0], 8)
         link.move_to_folder_for_user(sponsored_user.sponsorships.first().folders.first(), sponsored_user)
-        self.assertEqual(sponsored_user.get_links_remaining()[0], 10)
+        self.assertEqual(sponsored_user.get_links_remaining()[0], 9)
 
 
     #

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -1998,6 +1998,7 @@ webpackJsonp([1],[
 	                value: childNode.data.folder_id,
 	                text: childNode.text.trim(),
 	                selected: childNode.data.folder_id == current_folder_id,
+	                disabled: childNode.data.is_sponsored_root_folder || childNode.data.read_only,
 	                "data-orgid": childNode.data.organization_id
 	            }).prepend(new Array(depth).join('&nbsp;&nbsp;&nbsp;&nbsp;')));
 	
@@ -2233,6 +2234,7 @@ webpackJsonp([1],[
 	        folder_id: folder.id,
 	        organization_id: folder.organization,
 	        sponsor_id: folder.sponsored_by,
+	        is_sponsored_root_folder: folder.is_sponsored_root_folder,
 	        read_only: folder.read_only
 	      },
 	      "state": { "disabled": folder.is_sponsored_root_folder },

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -2169,7 +2169,22 @@ webpackJsonp([1],[
 	  if (!folderToSelect && current_user.top_level_folders.length == 1) {
 	    folderToSelect = current_user.top_level_folders[0].id;
 	  }
-	  folderTree.select_node(getNodeByFolderID(folderToSelect));
+	  var node = getNodeByFolderID(folderToSelect);
+	  if (!node) {
+	    folderTree.refresh(false, function (state) {
+	      // This empty function let's the node get selected after the refresh,
+	      // necessary when selecting a Sponsored Folder from the dropdown, if
+	      // a Sponsored Folder has not previously been loaded.
+	      //
+	      // I don't understand why this works, and suspect it's brittle.
+	      // https://www.jstree.com/api/#/?q=(&f=refresh()
+	    });
+	    node = getNodeByFolderID(folderToSelect);
+	    node.state.selected = true;
+	  }
+	  if (node) {
+	    folderTree.select_node(node);
+	  }
 	}
 	
 	function setSavedFolder(node) {
@@ -11460,12 +11475,25 @@ webpackJsonp([1],[
 	      organizations[org.id] = org;
 	    });
 	    if ((0, _keys2.default)(organizations).length) {
-	      var template = orgListTemplate({
-	        "orgs": data.objects,
-	        "user_folder": current_user.top_level_folders[0].id,
-	        "links_remaining": links_remaining
-	      });
-	      $organizationDropdown.append(template);
+	      if (current_user.top_level_folders[1].is_sponsored_root_folder) {
+	        APIModule.request("GET", "/folders/" + current_user.top_level_folders[1].id + "/folders/").done(function (sponsored_data) {
+	          var template = orgListTemplate({
+	            "orgs": data.objects,
+	            "user_folder": current_user.top_level_folders[0].id,
+	            "sponsored_folders": sponsored_data.objects,
+	            "links_remaining": links_remaining
+	          });
+	          $organizationDropdown.append(template);
+	        });
+	      } else {
+	        var template = orgListTemplate({
+	          "orgs": data.objects,
+	          "user_folder": current_user.top_level_folders[0].id,
+	          "sponsored_folders": null,
+	          "links_remaining": links_remaining
+	        });
+	        $organizationDropdown.append(template);
+	      }
 	    }
 	  });
 	}
@@ -13833,17 +13861,39 @@ webpackJsonp([1],[
 	},"4":function(container,depth0,helpers,partials,data) {
 	    return "<span class=\"ui-private\">(Private)</span> ";
 	},"6":function(container,depth0,helpers,partials,data) {
-	    return "unlimited";
+	    var stack1;
+	
+	  return "  <li class=\"dropdown-header sponsored\">Sponsored Links</li>\n"
+	    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.sponsored_folders : depth0),{"name":"each","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+	},"7":function(container,depth0,helpers,partials,data) {
+	    var stack1, alias1=container.lambda, alias2=container.escapeExpression;
+	
+	  return "    <li>\n      <a href=\"#\" data-folderid='["
+	    + alias2(alias1((depth0 != null ? depth0.parent : depth0), depth0))
+	    + ","
+	    + alias2(alias1((depth0 != null ? depth0.id : depth0), depth0))
+	    + "]'>\n        "
+	    + alias2(alias1((depth0 != null ? depth0.name : depth0), depth0))
+	    + " "
+	    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.read_only : depth0),{"name":"if","hash":{},"fn":container.program(8, data, 0),"inverse":container.program(10, data, 0),"data":data})) != null ? stack1 : "")
+	    + "\n      </a>\n    </li>\n";
 	},"8":function(container,depth0,helpers,partials,data) {
+	    return "<span class=\"links-remaining\">0</span>";
+	},"10":function(container,depth0,helpers,partials,data) {
+	    return "<span class='links-unlimited sponsored'>unlimited</span>";
+	},"12":function(container,depth0,helpers,partials,data) {
+	    return "unlimited";
+	},"14":function(container,depth0,helpers,partials,data) {
 	    return container.escapeExpression(container.lambda((depth0 != null ? depth0.links_remaining : depth0), depth0));
 	},"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
 	    var stack1, alias1=depth0 != null ? depth0 : {};
 	
 	  return ((stack1 = __default(__webpack_require__(159)).call(alias1,(depth0 != null ? depth0.orgs : depth0),{"name":"eachWithPrevious","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+	    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.sponsored_folders : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
 	    + "<li class=\"personal-links\">\n  <a href=\"#\" data-folderid=\""
 	    + container.escapeExpression(container.lambda((depth0 != null ? depth0.user_folder : depth0), depth0))
 	    + "\">\n    Personal Links <span class=\"links-remaining\">"
-	    + ((stack1 = __default(__webpack_require__(157)).call(alias1,(depth0 != null ? depth0.links_remaining : depth0),"==","Infinity",{"name":"compare","hash":{},"fn":container.program(6, data, 0),"inverse":container.program(8, data, 0),"data":data})) != null ? stack1 : "")
+	    + ((stack1 = __default(__webpack_require__(157)).call(alias1,(depth0 != null ? depth0.links_remaining : depth0),"==","Infinity",{"name":"compare","hash":{},"fn":container.program(12, data, 0),"inverse":container.program(14, data, 0),"data":data})) != null ? stack1 : "")
 	    + "</span>\n  </a>\n</li>\n";
 	},"useData":true});
 

--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -9141,6 +9141,10 @@ button #addlink {
   background-color: #2D76EE;
 }
 
+.links-unlimited.sponsored {
+  background-color: #DD671A;
+}
+
 .dropdown .selector {
   width: 100.3%;
   text-align: left;
@@ -9252,6 +9256,10 @@ button #addlink {
 
 .dropdown .selector-menu .dropdown-header {
   margin-top: 4px;
+}
+
+.dropdown .selector-menu .dropdown-header.sponsored {
+  color: #DD671A;
 }
 
 .dropdown .selector-menu a {

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -122,6 +122,9 @@
   .dropdown-header {
     margin-top: $half;
   }
+  .dropdown-header.sponsored {
+    color: $color-orange;
+  }
 }
 
 /////////////////////////////////////////
@@ -1327,6 +1330,10 @@ button {
   @extend .custom-badge;
   color: white;
   background-color: $color-blue;
+}
+
+.links-unlimited.sponsored {
+  background-color: $color-orange;
 }
 
 @mixin style-ui-after {

--- a/perma_web/static/js/create-link.module.js
+++ b/perma_web/static/js/create-link.module.js
@@ -289,12 +289,25 @@ function populateOrgDropdown(){
     // populate the top-level "organizations" var
     data.objects.map(org => {organizations[org.id] = org});
     if (Object.keys(organizations).length){
-      let template = orgListTemplate({
-        "orgs": data.objects,
-        "user_folder": current_user.top_level_folders[0].id,
-        "links_remaining": links_remaining
-      });
-      $organizationDropdown.append(template);
+      if (current_user.top_level_folders[1].is_sponsored_root_folder){
+        APIModule.request("GET", "/folders/" + current_user.top_level_folders[1].id + "/folders/").done(function(sponsored_data){
+          let template = orgListTemplate({
+            "orgs": data.objects,
+            "user_folder": current_user.top_level_folders[0].id,
+            "sponsored_folders": sponsored_data.objects,
+            "links_remaining": links_remaining
+          });
+          $organizationDropdown.append(template);
+        });
+      } else {
+        let template = orgListTemplate({
+          "orgs": data.objects,
+          "user_folder": current_user.top_level_folders[0].id,
+          "sponsored_folders": null,
+          "links_remaining": links_remaining
+        });
+        $organizationDropdown.append(template);
+    }
     }
   });
 }

--- a/perma_web/static/js/folder-tree.module.js
+++ b/perma_web/static/js/folder-tree.module.js
@@ -194,6 +194,7 @@ function apiFoldersToJsTreeFolders(apiFolders){
         folder_id: folder.id,
         organization_id: folder.organization,
         sponsor_id: folder.sponsored_by,
+        is_sponsored_root_folder: folder.is_sponsored_root_folder,
         read_only: folder.read_only
       },
       "state": {"disabled": folder.is_sponsored_root_folder},

--- a/perma_web/static/js/folder-tree.module.js
+++ b/perma_web/static/js/folder-tree.module.js
@@ -129,7 +129,22 @@ function selectSavedFolder(){
   if(!folderToSelect && current_user.top_level_folders.length == 1){
     folderToSelect = current_user.top_level_folders[0].id;
   }
-  folderTree.select_node(getNodeByFolderID(folderToSelect));
+  let node = getNodeByFolderID(folderToSelect);
+  if (!node){
+    folderTree.refresh(false, function(state){
+      // This empty function let's the node get selected after the refresh,
+      // necessary when selecting a Sponsored Folder from the dropdown, if
+      // a Sponsored Folder has not previously been loaded.
+      //
+      // I don't understand why this works, and suspect it's brittle.
+      // https://www.jstree.com/api/#/?q=(&f=refresh()
+    });
+    node = getNodeByFolderID(folderToSelect);
+    node.state.selected = true;
+  }
+  if (node){
+    folderTree.select_node(node);
+  }
 }
 
 function setSavedFolder (node) {

--- a/perma_web/static/js/hbs/org-list-template.handlebars
+++ b/perma_web/static/js/hbs/org-list-template.handlebars
@@ -8,6 +8,16 @@
     </a>
   </li>
 {{/eachWithPrevious}}
+{{#if sponsored_folders }}
+  <li class="dropdown-header sponsored">Sponsored Links</li>
+  {{# each sponsored_folders}}
+    <li>
+      <a href="#" data-folderid='[{{ parent }},{{ id }}]'>
+        {{ name }} {{# if read_only }}<span class="links-remaining">0</span>{{ else }}<span class='links-unlimited sponsored'>unlimited</span>{{/if}}
+      </a>
+    </li>
+  {{/each }}
+{{/if}}
 <li class="personal-links">
   <a href="#" data-folderid="{{ user_folder }}">
     Personal Links <span class="links-remaining">{{#compare links_remaining "==" 'Infinity' }}unlimited{{ else }}{{ links_remaining }}{{/compare}}</span>

--- a/perma_web/static/js/helpers/folder-selector.helper.js
+++ b/perma_web/static/js/helpers/folder-selector.helper.js
@@ -17,7 +17,8 @@ export function makeFolderSelector($folder_selector, current_folder_id) {
                     value: childNode.data.folder_id,
                     text: childNode.text.trim(),
                     selected: childNode.data.folder_id == current_folder_id,
-                    "data-orgid": childNode.data.organization_id
+                    disabled: childNode.data.is_sponsored_root_folder || childNode.data.read_only,
+                    "data-orgid": childNode.data.organization_id,
                 }).prepend(
                     new Array(depth).join('&nbsp;&nbsp;&nbsp;&nbsp;')
                 )


### PR DESCRIPTION
- sponsored links aren't counted against a user's personal link limit
- you can't move links to the root sponsored folder
- top-level sponsored folders appear in the folder-selection dropdown, for users who get a dropdown
- slightly better handling of sponsored folders in the link batch modal's dropdown, and the dropdown you can use to move a link to a new folder