### PR TITLE
Give ajax more time to get going, if capture is proxied

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -568,6 +568,7 @@ DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
 PROXY_CAPTURES = False
 PROXY_ADDRESS = 'localhost:9050'
 DOMAINS_TO_PROXY = []
+PROXY_POST_LOAD_DELAY = 5
 CAPTURE_HEADERS = {
     "Accept": "*/*",
     "Accept-Encoding": "*",

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1371,8 +1371,11 @@ def run_next_capture():
                 for media_url in media_urls - requested_urls:
                     add_thread(thread_list, ProxiedRequestThread(proxy_address, media_url, requested_urls, proxied_responses, capture_user_agent))
 
-        # Wait AFTER_LOAD_TIMEOUT seconds for any requests to finish that are started within the next .5 seconds.
+        # Wait AFTER_LOAD_TIMEOUT seconds for any requests that are started shortly to finish
         inc_progress(capture_job, 1, "Waiting for post-load requests")
+        # everything is slower via the proxy; give it time to catch up
+        if proxy:
+            time.sleep(settings.PROXY_POST_LOAD_DELAY)
         unfinished_proxied_pairs = [pair for pair in proxied_pairs if not pair[1]]
         load_time = time.time()
         with browser_running(browser):


### PR DESCRIPTION
This seems to improve the quality of screenshots. I tested 0-15s; 15s didn't seem noticeably better than 5s; 2s seemed materially worse than 5s.