### PR TITLE
Double timeout; 5s too short for stage.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1705,7 +1705,7 @@ def verify_webrecorder_api_available():
     """
     r = requests.get(
         f'{settings.WR_API}.yml',
-        timeout=5,
+        timeout=10,
         allow_redirects=False
     )
     r.raise_for_status()

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1704,12 +1704,12 @@ def verify_webrecorder_api_available():
     Necessary because the api should not be exposed to the public internet.
     """
     r = requests.get(
-        f'{settings.WR_API}.yml',
+        f'{settings.WR_API}.json',
         timeout=10,
         allow_redirects=False
     )
     r.raise_for_status()
-    assert "description: Webrecorder API" in r.text
+    assert "Webrecorder API" in r.text
 
 
 @shared_task()


### PR DESCRIPTION
As far as I can tell, everything is fine... but this task fails sometimes. Looks to be that this route is just slow to load, sometimes. Which, maybe means it's not the best for monitoring, since that suggests it's expensive.... but while I think about an alternative, this might quiet all those spurious error emails from stage.