### PR TITLE
Bump image version to get new Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       dockerfile: ./perma_web/Dockerfile
-    image: perma3:0.57
+    image: perma3:0.58
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:


### PR DESCRIPTION
As of this writing, this replaces Chrome 83.0.4103.116 with 84.0.4147.89 -- see https://chromereleases.googleblog.com/2020/07/stable-channel-update-for-desktop.html and https://chromium.googlesource.com/chromium/src/+log/83.0.4103.116..84.0.4147.89?pretty=fuller&n=10000