### PR TITLE
Bump image version to get new Chrome at Circle CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       dockerfile: ./perma_web/Dockerfile
-    image: perma3:0.58
+    image: perma3:0.59
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:


### PR DESCRIPTION
This upgrades Chrome from 84.0.4147.89 to 84.0.4147.105 at Circle CI. To get this upgrade locally, I had to run 
```
docker-compose down
docker system prune --all
docker-compose up -d
```
which seems heavy-handed; I did not find the `--no-cache` option mentioned in https://github.com/harvard-lil/perma/pull/2822#issuecomment-664456351