### PR TITLE
Client-side playback: add screenshot, update

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -682,8 +682,8 @@ ENABLE_SPONSORED_USERS = False
 
 OFFER_CLIENT_SIDE_PLAYBACK = False
 USERS_WITH_CLIENT_SIDE_PLAYBACK = []
-PLAYBACK_UI_JS_URL = 'https://unpkg.com/replaywebpage@1.0.1/ui.js'
-SERVICE_WORKER_URL = 'https://unpkg.com/replaywebpage@1.0.1/sw.js'
+PLAYBACK_UI_JS_URL = 'https://unpkg.com/replaywebpage@1.0.2/ui.js'
+SERVICE_WORKER_URL = 'https://unpkg.com/replaywebpage@1.0.2/sw.js'
 
 ENABLE_BONUS_LINKS = False
 

--- a/perma_web/perma/templates/archive/iframe.html
+++ b/perma_web/perma/templates/archive/iframe.html
@@ -22,7 +22,13 @@
   <div class="capture-wrapper">
     <div class="h_iframe">
       {% if capture.role == 'screenshot' %}
-        <img src="{{ protocol}}{{ wr_prefix }}im_/{{ wr_url }}" style="display:block; margin: 0 auto;" alt="screenshot">
+        {% if client_side_playback %}
+          <script src="{{ PLAYBACK_UI_JS_URL }}"></script>
+          <replay-web-page source="{% url 'serve_warc' guid=link.guid %}"
+          url="file:///{{ link.guid }}/cap.png" view="{{ client_side_playback }}"></replay-web-page>
+        {% else %}
+          <img src="{{ protocol}}{{ wr_prefix }}im_/{{ wr_url }}" style="display:block; margin: 0 auto;" alt="screenshot">
+        {% endif %}
       {% else %}
         {% if client_side_playback %}
           <script src="{{ PLAYBACK_UI_JS_URL }}"></script>


### PR DESCRIPTION
You have to click on the screenshot to see it at normal size; the alt text is the same as the src... but, present!