### PR TITLE
Update Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       dockerfile: ./perma_web/Dockerfile
-    image: perma3:0.64
+    image: perma3:0.65
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -579,7 +579,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 CAPTURE_BROWSER = 'Chrome'  # formerly 'PhantomJS'; some support for 'Firefox'
 DISABLE_DEV_SHM = False
 # Default user agent is adapted from the PhantomJS default
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
 PROXY_CAPTURES = False


### PR DESCRIPTION
This updates Chrome from 85.0.4183.83 to 85.0.4183.102:

https://chromereleases.googleblog.com/2020/09/stable-channel-update-for-desktop.html