### PR TITLE
Add config for domains to use a user-agent with the word "bot" in it.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -46,7 +46,7 @@ from .utils import (tz_datetime,
     pp_date_from_post,
     first_day_of_next_month, today_next_year, preserve_perma_warc,
     write_resource_record_from_asset, get_wr_session_cookie,
-    clear_wr_session, query_wr_api)
+    clear_wr_session, query_wr_api, user_agent_for_domain)
 
 
 logger = logging.getLogger(__name__)
@@ -1399,7 +1399,7 @@ class Link(DeletableModel):
                 request = requests.Request(
                     'GET',
                     self.ascii_safe_url,
-                    headers={'User-Agent': settings.CAPTURE_USER_AGENT, **settings.CAPTURE_HEADERS}
+                    headers={'User-Agent': user_agent_for_domain(self.url_details.netloc), **settings.CAPTURE_HEADERS}
                 )
                 response = s.send(
                     request.prepare(),

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -581,7 +581,9 @@ DISABLE_DEV_SHM = False
 # Default user agent is adapted from the PhantomJS default
 CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
+PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
+DOMAINS_REQUIRING_BOT_USER_AGENT = []
 PROXY_CAPTURES = False
 PROXY_ADDRESS = 'localhost:9050'
 DOMAINS_TO_PROXY = []

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -54,7 +54,8 @@ from perma.email import send_self_email
 from perma.exceptions import PermaPaymentsCommunicationException
 from perma.utils import (run_task, url_in_allowed_ip_range,
     copy_file_data, preserve_perma_warc, write_warc_records_recorded_from_web,
-    write_resource_record_from_asset, protocol, remove_control_characters)
+    write_resource_record_from_asset, protocol, remove_control_characters,
+    user_agent_for_domain)
 from perma import site_scripts
 
 import logging
@@ -956,9 +957,7 @@ def run_next_capture():
         stop = False
         proxy = False
 
-        capture_user_agent = settings.CAPTURE_USER_AGENT
-        if any(domain in link.url_details.netloc for domain in settings.DOMAINS_REQUIRING_UNIQUE_USER_AGENT):
-            capture_user_agent = capture_user_agent + " " + settings.PERMA_USER_AGENT_SUFFIX
+        capture_user_agent = user_agent_for_domain(link.url_details.netloc)
         print("Using user-agent: %s" % capture_user_agent)
 
         if settings.PROXY_CAPTURES and any(domain in link.url_details.netloc for domain in settings.DOMAINS_TO_PROXY):

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -300,6 +300,13 @@ def parse_user_agent(user_agent_str):
     # {'brand': None, 'model': None, 'family': 'Other'}
     return user_agent_parser.ParseUserAgent(user_agent_str)
 
+def user_agent_for_domain(target_domain):
+    capture_user_agent = settings.CAPTURE_USER_AGENT
+    if any(domain in target_domain for domain in settings.DOMAINS_REQUIRING_UNIQUE_USER_AGENT):
+        capture_user_agent = capture_user_agent + f" {settings.PERMA_USER_AGENT_SUFFIX}"
+    if any(domain in target_domain for domain in settings.DOMAINS_REQUIRING_BOT_USER_AGENT):
+        capture_user_agent = capture_user_agent + f" {settings.PERMABOT_USER_AGENT_SUFFIX}"
+    return capture_user_agent
 
 ### pdf handling on mobile ###
 


### PR DESCRIPTION
Some domains' bot-detection software is evidently configured to admit people who admit to being bots. Let's maintain such a list, expecting it to change over time.