### PR TITLE
Don't display nginx version number on WR error pages.

### DIFF
--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -74,7 +74,7 @@ services:
       - webrecorder
 
   nginx:
-    image: nginx:1.13-alpine
+    image: harvardlil/nginx:0.02
     depends_on:
       - app
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
       - webrecorder
 
   nginx:
-    image: harvardlil/nginx:0.01
+    image: harvardlil/nginx:0.02
     depends_on:
       - app
     volumes:

--- a/services/docker/webrecorder/nginx/Dockerfile
+++ b/services/docker/webrecorder/nginx/Dockerfile
@@ -1,5 +1,0 @@
-FROM nginx:1.13-alpine
-
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY webrec.conf /etc/nginx/webrec.conf
-COPY 502.html /usr/share/nginx/html/502.html

--- a/services/docker/webrecorder/nginx/nginx.conf
+++ b/services/docker/webrecorder/nginx/nginx.conf
@@ -17,7 +17,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
-    # server_tokens off;
+    server_tokens off;
 
     # server_names_hash_bucket_size 64;
     # server_name_in_redirect off;
@@ -131,6 +131,11 @@ http {
         # location = /502.html {
         #    root /usr/share/nginx/html;
         # }
+
+        error_page 404 /404.html;
+        location = /404.html {
+            root /usr/share/nginx/html;
+        }
     }
 
     # Local WARC Serve


### PR DESCRIPTION
To realize this change in production, a bunch of repos are involved.

1) I updated our nginx image [here](https://github.com/harvard-lil/webrecorder/pull/11), and have already pushed the built image to Docker Hub. 

2) In this PR, I update dev Perma to use the new image, and changed the dev nginx config to use the new error pages, and, for good measure, to hide the version number in the `Server` header sent by nginx.

3) Made a pair of PRs that I -think- do the same for stage/prod config:
https://github.com/harvard-lil/saltstack/pull/6
https://github.com/harvard-lil/saltstack/pull/7

With that deployed, https://wr.perma-archives.org:8443/ajsdflasdh and the stage equivalent should no longer report the page is served by nginx, or report its version number.

Note: in prod, we never exposed the version number via the `Server` header, because that is rewritten by Cloudflare:
![image](https://user-images.githubusercontent.com/11020492/95388688-afbbde00-08c0-11eb-939b-cb97c9740494.png)
