### PR TITLE
Make usage consistent, minor copyediting

### DIFF
--- a/perma_web/perma/templates/email/unactivated_user_reset_email.txt
+++ b/perma_web/perma/templates/email/unactivated_user_reset_email.txt
@@ -1,6 +1,6 @@
 TITLE: Password reset for Perma.cc
 
-You're receiving this e-mail because you requested a password reset for your user account at Perma.cc
+You're receiving this email because you requested a password reset for your user account at Perma.cc
 
 Please go to the following page and choose a new password:
 {{ activation_route }}

--- a/perma_web/perma/templates/registration/not_active.html
+++ b/perma_web/perma/templates/registration/not_active.html
@@ -7,7 +7,7 @@
     <div class="col-xs-12">
       <h1 class="page-title">Account not activated</h1>
       <p class="page-dek">Your Perma.cc account has not yet been activated.</p>
-      <p class="page-dek">Check your e-mail: you should have received a welcome e-mail with an activation link. Need another copy?</p>
+      <p class="page-dek">Check your email: you should have received a welcome message with an activation link. Need another copy?</p>
       <form action="" method="post">
         {% csrf_token %}
         <input type="submit" value="Resend activation email" name="resend" class="btn">

--- a/perma_web/perma/templates/registration/password_reset_done.html
+++ b/perma_web/perma/templates/registration/password_reset_done.html
@@ -4,8 +4,8 @@
 <div class="container cont-fixed">
   <div class="row">
     <div class="col-sm-12">
-      <h1 class="page-title">Check your e-mail</h1>
-      <p class="page-dek">We’ve e-mailed you instructions for resetting your password. You should be receiving it shortly.</p>
+      <h1 class="page-title">Check your email</h1>
+      <p class="page-dek">We’ve emailed you instructions for resetting your password. You should be receiving it shortly.</p>
     </div>
   </div>
 </div>

--- a/perma_web/perma/templates/registration/password_reset_email.html
+++ b/perma_web/perma/templates/registration/password_reset_email.html
@@ -1,4 +1,4 @@
-You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}
+You're receiving this email because you requested a password reset for your user account at {{ site_name }}
 
 Please go to the following page and choose a new password:
 {% block reset_link %}

--- a/perma_web/perma/templates/registration/password_reset_form.html
+++ b/perma_web/perma/templates/registration/password_reset_form.html
@@ -5,12 +5,12 @@
   <div class="row">
     <div class="col-sm-12">
       <h1 class="page-title">Password Reset</h1>
-      <p class="page-dek">Forgotten your password? Enter your e-mail address below, and we’ll e-mail instructions for setting a new one.</p>
+      <p class="page-dek">Forgotten your password? Enter your email address below, and we’ll send instructions for setting a new one.</p>
       <form method="post" class="embedded-form form-inline">
         {% csrf_token %}
         <fieldset class="col-sm-6">
           <div class="form-group{% if form.email.errors %} _error{% endif %}">
-            <label for="id_email">E-mail address</label>
+            <label for="id_email">Email address</label>
             {{ form.email }}
             {% if form.email.errors %}<span class="field-error">{{ form.email.errors }}</span>{% endif %}
           </div>

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1290,7 +1290,7 @@ def not_active(request):
         target_user = get_object_or_404(LinkUser, email=email)
         email_new_user(request, target_user)
 
-        messages.add_message(request, messages.INFO, 'Check your e-mail for activation instructions.')
+        messages.add_message(request, messages.INFO, 'Check your email for activation instructions.')
         return HttpResponseRedirect(reverse('user_management_limited_login'))
     else:
         context = {}


### PR DESCRIPTION
This changes all uses of "e-mail" to "email" in templates. Both are correct, but Wikipedia uses the latter [in its article](https://en.wikipedia.org/wiki/Email), and [the Grammarist says](https://grammarist.com/style/e-mail-email/)

> A few editorially conservative publications still prefer e-mail to email, but most of the English-speaking world has adopted the unhyphenated form. 