### PR TITLE
Require upper, lower, and number for newly-set passwords.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -159,6 +159,3 @@ else:
 
 ENABLE_SPONSORED_USERS = True
 ENABLE_BONUS_LINKS = True
-
-# don't check password quality locally, since it's annoying
-AUTH_PASSWORD_VALIDATORS = []

--- a/perma_web/perma/tests/test_utils.py
+++ b/perma_web/perma/tests/test_utils.py
@@ -82,11 +82,9 @@ class UtilsTestCase(TestCase):
         upper = 'A'
         number = '1'
         padding = 'qwertyuio'
-        with self.assertRaises(ValidationError) as e:
+        with self.assertRaises(ValidationError):
             validate_password(padding)
-            import pdb; pdb.set_trace()
         self.assertIsNone(validate_password(lower+upper+number+padding))
-
 
     # communicate with perma payments
 

--- a/perma_web/perma/tests/test_utils.py
+++ b/perma_web/perma/tests/test_utils.py
@@ -3,12 +3,16 @@ import decimal
 from mock import patch, sentinel
 
 from django.conf import settings
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
+
 
 from hypothesis import given
 from hypothesis.extra.django import TestCase
 from hypothesis.strategies import characters, text, integers, booleans, datetimes, dates, decimals, uuids, binary, dictionaries
 from perma.utils import (
+    AlphaNumericValidator,
     InvalidTransmissionException,
     decrypt_from_perma_payments,
     encrypt_for_perma_payments,
@@ -59,6 +63,29 @@ class UtilsTestCase(TestCase):
     def test_get_client_ip(self):
         request = self.factory.get('/some/route', REMOTE_ADDR="1.2.3.4")
         self.assertEqual(get_client_ip(request), "1.2.3.4")
+
+
+    # our custom password validator
+
+    def test_lower_upper_number_required(self):
+        validator = AlphaNumericValidator()
+        lower ='a'
+        upper = 'A'
+        number = '1'
+        for char in (lower, upper, number):
+            with self.assertRaises(ValidationError):
+                validator.validate('a')
+        self.assertIsNone(validator.validate(lower+upper+number))
+
+    def test_custom_validator_in_use(self):
+        lower ='a'
+        upper = 'A'
+        number = '1'
+        padding = 'qwertyuio'
+        with self.assertRaises(ValidationError) as e:
+            validate_password(padding)
+            import pdb; pdb.set_trace()
+        self.assertIsNone(validate_password(lower+upper+number+padding))
 
 
     # communicate with perma payments

--- a/perma_web/perma/tests/test_views_auth.py
+++ b/perma_web/perma/tests/test_views_auth.py
@@ -59,8 +59,8 @@ class AuthViewsTestCase(PermaTestCase):
         self.assertIn('_auth_user_id', self.client.session)
 
         self.client.post(reverse('password_change'),
-            {'old_password':'pass', 'new_password1':'changed-password1',
-            'new_password2':'changed-password1'})
+            {'old_password':'pass', 'new_password1':'Changed-password1',
+            'new_password2':'Changed-password1'})
 
         self.client.logout()
 
@@ -71,5 +71,5 @@ class AuthViewsTestCase(PermaTestCase):
         self.client.logout()
 
         # Try to login with our new password
-        self.client.login(username='test_user@example.com', password='changed-password1')
+        self.client.login(username='test_user@example.com', password='Changed-password1')
         self.assertIn('_auth_user_id', self.client.session)

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -2399,22 +2399,22 @@ class UserManagementViewsTestCase(PermaTestCase):
         response = self.client.get(activation_url, follow=True)
         post_url = response.redirect_chain[0][0]
         self.assertTemplateUsed(response, 'registration/password_reset_confirm.html')
-        response = self.client.post(post_url, {'new_password1': 'anewpass1', 'new_password2': 'anewpass2'}, follow=True)
+        response = self.client.post(post_url, {'new_password1': 'Anewpass1', 'new_password2': 'Anewpass2'}, follow=True)
         self.assertNotContains(response, 'Your password has been set')
         self.assertContains(response, "The two password fields didn&#39;t match")
         # reg confirm - correct
-        response = self.client.post(post_url, {'new_password1': 'anewpass', 'new_password2': 'anewpass'}, follow=True)
+        response = self.client.post(post_url, {'new_password1': 'Anewpass1', 'new_password2': 'Anewpass1'}, follow=True)
         self.assertContains(response, 'Your password has been set')
 
         # Doesn't work twice.
-        response = self.client.post(post_url, {'new_password1': 'anotherpass', 'new_password2': 'anotherpass'}, follow=True)
+        response = self.client.post(post_url, {'new_password1': 'Anotherpass1', 'new_password2': 'Anotherpass1'}, follow=True)
         self.assertContains(response, 'This activation/reset link is invalid')
 
         # the new user is now activated and can log in
         user.refresh_from_db()
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_confirmed)
-        response = self.client.post(reverse('user_management_limited_login'), {'username': new_user_email, 'password': 'anewpass'}, follow=True)
+        response = self.client.post(reverse('user_management_limited_login'), {'username': new_user_email, 'password': 'Anewpass1'}, follow=True)
         self.assertContains(response, 'Enter any URL to preserve it forever')
 
 

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -84,24 +84,27 @@ class AlphaNumericValidator:
 
     @sensitive_variables()
     def validate(self, password, user=None):
-        contains_number = contains_letter = False
+        contains_number = contains_upper = contains_lower = False
         for char in password:
             if not contains_number:
                 if char in string.digits:
                     contains_number = True
-            if not contains_letter:
-                if char in string.ascii_letters:
-                    contains_letter = True
-            if contains_number and contains_letter:
+            if not contains_upper:
+                if char in string.ascii_uppercase:
+                    contains_upper = True
+            if not contains_lower:
+                if char in string.ascii_lowercase:
+                    contains_lower = True
+            if all((contains_number, contains_upper, contains_lower)):
                 break
 
-        if not contains_number or not contains_letter:
-            raise ValidationError("This password does not include at least \
-                                   one letter and at least one number.")
+        if not all((contains_number, contains_upper, contains_lower)):
+            raise ValidationError("This password must include an uppercase letter, \
+                                   a lowercase letter, and a number.")
 
     def get_help_text(self):
-        return "Your password must include at least \
-                one letter and at least one number."
+        return "Your password must include an uppercase letter, \
+                a lowercase letter, and a number."
 
 
 ### list view helpers ###


### PR DESCRIPTION
Existing users can continue using their present passwords; new users will be held to the new standards. 