### PR TITLE
Add a trap for bots on the signup forms.

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -124,6 +124,11 @@ class UserForm(forms.ModelForm):
         model = LinkUser
         fields = ["first_name", "last_name", "email", "telephone"]
 
+    def add_prefix(self, field_name):
+        # rename the email field in the HTML to foil bots that are spamming us
+        field_name = "e-address" if field_name == "email" else field_name
+        return super().add_prefix(field_name)
+
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -118,9 +118,11 @@ class UserForm(forms.ModelForm):
     """
     User add/edit form.
     """
+    telephone = forms.CharField(label="Do not fill out this box", required=False)  # field to fool bots
+
     class Meta:
         model = LinkUser
-        fields = ["first_name", "last_name", "email"]
+        fields = ["first_name", "last_name", "email", "telephone"]
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request", None)

--- a/perma_web/perma/templates/user_management/settings-profile.html
+++ b/perma_web/perma/templates/user_management/settings-profile.html
@@ -10,7 +10,7 @@
       <div class="alert alert-success alert-block">{% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}</div>
     {% endfor %}
   {% endif %}
-  <form method="post" action="">
+  <form class="change-user" method="post" action="">
     {% csrf_token %}
     {% include "includes/fieldset.html" with form_classes="fg-100" %}
     <button type="submit" class="btn">Save changes</button>

--- a/perma_web/perma/templates/user_management/user_add_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_confirm.html
@@ -10,7 +10,7 @@
     <p>{{ error_message }}</p>
   {% else %}
 
-    <form method="post">
+    <form class="add-user" method="post">
       {% csrf_token %}
       {% include "includes/fieldset.html" %}
       <button type="submit" class="btn">Add user</button>

--- a/perma_web/perma/templates/user_management/user_add_to_admin_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_to_admin_confirm.html
@@ -10,7 +10,7 @@
     <p><b>NOTE: any existing organization or registrar affiliation will be removed.</b></p>
   {% endif %}
 
-  <form method="post">
+  <form class="add-user" method="post">
     {% csrf_token %}
     {% include "includes/fieldset.html" %}
     {% if object.id %}

--- a/perma_web/perma/templates/user_management/user_add_to_organization_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_to_organization_confirm.html
@@ -14,7 +14,7 @@
       <p>{{ user_email }} already has an account.  Would you like to add them to an organization?</p>
     {% endif %}
 
-    <form method="post">
+    <form class="add-user" method="post">
       {% csrf_token %}
       {% include "includes/fieldset.html" %}
       {% if object.id %}

--- a/perma_web/perma/templates/user_management/user_add_to_registrar_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_to_registrar_confirm.html
@@ -27,7 +27,7 @@
       {% endif %}
     {% endif %}
 
-    <form method="post">
+    <form class="add-user" method="post">
       {% csrf_token %}
       {% include "includes/fieldset.html" %}
       {% if object.id %}

--- a/perma_web/perma/templates/user_management/user_add_to_sponsoring_registrar_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_to_sponsoring_registrar_confirm.html
@@ -14,7 +14,7 @@
       <p>{{ user_email }} already has an account.  Would you like to {% if request.user.is_registrar_user %}sponsor them{% else %}add a sponsorship{% endif %}?</p>
     {% endif %}
 
-    <form method="post">
+    <form class="add-user" method="post">
       {% csrf_token %}
       {% include "includes/fieldset.html" %}
       <button type="submit" class="btn">{% if request.user.is_registrar_user %}Sponsor{% else %}Add sponsorship{% endif %}</button>

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -551,7 +551,7 @@ class UserManagementViewsTestCase(PermaTestCase):
             # create user
             email += '1'
             self.submit_form('user_management_' + view_name + '_add_user',
-                           data=dict(list(base_user.items()) + list(form_extras.items()) + [['a-email', email]]),
+                           data=dict(list(base_user.items()) + list(form_extras.items()) + [['a-e-address', email]]),
                            success_url=reverse('user_management_manage_' + view_name),
                            success_query=LinkUser.objects.filter(email=email))
             new_user = LinkUser.objects.get(email=email)
@@ -583,7 +583,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-organizations': self.organization.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          success_url=reverse('user_management_manage_organization_user'),
                          success_query=LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -596,7 +596,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-organizations': self.organization.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          success_url=reverse('user_management_manage_organization_user'),
                          success_query=LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -609,7 +609,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-organizations': self.organization.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          success_url=reverse('user_management_manage_organization_user'),
                          success_query=LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -621,7 +621,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-organizations': self.unrelated_organization.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          error_keys=['organizations'])
         self.assertFalse(LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -633,7 +633,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-organizations': self.unrelated_organization.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          error_keys=['organizations'])
         self.assertFalse(LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -822,7 +822,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                           data={'a-sponsoring_registrars': self.registrar.pk,
                                 'a-first_name': 'First',
                                 'a-last_name': 'Last',
-                                'a-email': address},
+                                'a-e-address': address},
                           query_params={'email': address},
                           success_url=reverse('user_management_manage_sponsored_user'))
 
@@ -839,7 +839,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                                      data={'a-sponsoring_registrars': self.registrar.pk,
                                            'a-first_name': 'First',
                                            'a-last_name': 'Last',
-                                           'a-email': address},
+                                           'a-e-address': address},
                                      query_params={'email': address}).content
         self.assertIn(bytes("Select a valid choice. That choice is not one of the available choices", 'utf-8'), response)
 
@@ -850,7 +850,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-sponsoring_registrars': self.registrar.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': address},
+                               'a-e-address': address},
                          query_params={'email': address},
                          success_url=reverse('user_management_manage_sponsored_user'),
                          success_query=LinkUser.objects.filter(email=address,
@@ -860,7 +860,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                                      data={'a-sponsoring_registrars': self.registrar.pk,
                                            'a-first_name': 'First',
                                            'a-last_name': 'Last',
-                                           'a-email': address},
+                                           'a-e-address': address},
                                      query_params={'email': address}).content
         self.assertIn(bytes("{} is already sponsored by your registrar.".format(address), 'utf-8'), response)
 
@@ -870,7 +870,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-sponsoring_registrars': self.unrelated_registrar.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          error_keys=['sponsoring_registrars'])
         self.assertFalse(LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -974,7 +974,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                           data={'a-registrar': self.registrar.pk,
                                 'a-first_name': 'First',
                                 'a-last_name': 'Last',
-                                'a-email': address},
+                                'a-e-address': address},
                           query_params={'email': address},
                           success_url=reverse('user_management_manage_registrar_user'),
                           success_query=LinkUser.objects.filter(email=address,
@@ -987,7 +987,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-registrar': self.registrar.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': address},
+                               'a-e-address': address},
                          query_params={'email': address},
                          success_url=reverse('user_management_manage_registrar_user'),
                          success_query=LinkUser.objects.filter(email=address,
@@ -997,7 +997,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                                      data={'a-registrar': self.registrar.pk,
                                            'a-first_name': 'First',
                                            'a-last_name': 'Last',
-                                           'a-email': address},
+                                           'a-e-address': address},
                                      query_params={'email': address}).content
         self.assertIn(bytes("{} is already a registrar user for your registrar.".format(address), 'utf-8'), response)
 
@@ -1007,7 +1007,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={'a-registrar': self.unrelated_registrar.pk,
                                'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          error_keys=['registrar'])
         self.assertFalse(LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -1103,7 +1103,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form('user_management_admin_user_add_user',
                          data={'a-first_name': 'First',
                                'a-last_name': 'Last',
-                               'a-email': 'doesnotexist@example.com'},
+                               'a-e-address': 'doesnotexist@example.com'},
                          query_params={'email': 'doesnotexist@example.com'},
                          success_url=reverse('user_management_manage_admin_user'),
                          success_query=LinkUser.objects.filter(email='doesnotexist@example.com',
@@ -1143,7 +1143,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          data={
                              'a-first_name': 'Newfirst',
                              'a-last_name': 'Newlast',
-                             'a-email': 'test_admin_user@example.com'
+                             'a-e-address': 'test_admin_user@example.com'
                          },
                          success_url=reverse('user_management_settings_profile'),
                          success_query=LinkUser.objects.filter(first_name='Newfirst'))
@@ -1775,7 +1775,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.assertEqual(website_label.text, "Library website")
 
     def check_lib_user_labels(self, soup):
-        email_label = soup.find('label', {'for': 'id_a-email'})
+        email_label = soup.find('label', {'for': 'id_a-e-address'})
         self.assertEqual(email_label.text, "Your email")
 
     def check_lib_email(self, message, new_lib, user):
@@ -1824,7 +1824,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                                     u'b-website': new_lib['website'],
                                     u'b-name': new_lib['name'],
                                     u'b-address': new_lib['address'],
-                                    u'a-email': new_lib_user['email'],
+                                    u'a-e-address': new_lib_user['email'],
                                     u'a-first_name': new_lib_user['first'],
                                     u'a-last_name': new_lib_user['last'],
                                     u'csrfmiddlewaretoken': u'11YY3S2DgOw2DHoWVEbBArnBMdEA2svu' }
@@ -1878,7 +1878,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                           data = { u'b-email': new_lib['email'],
                                    u'b-website': new_lib['website'],
                                    u'b-name': new_lib['name'],
-                                   u'a-email': new_lib_user['email'] },
+                                   u'a-e-address': new_lib_user['email'] },
                           success_url=reverse('register_library_instructions'))
         expected_emails_sent += 2
         self.assertEqual(len(mail.outbox), expected_emails_sent)
@@ -1892,7 +1892,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                           data = { u'b-email': new_lib['email'],
                                    u'b-website': new_lib['website'],
                                    u'b-name': new_lib['name'],
-                                   u'a-email': new_lib_user['email'],
+                                   u'a-e-address': new_lib_user['email'],
                                    u'a-first_name': new_lib_user['first'],
                                    u'a-last_name': new_lib_user['last']},
                           success_url=reverse('register_library_instructions'))
@@ -1921,7 +1921,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                           data = { u'b-email': new_lib['email'],
                                    u'b-website': new_lib['website'],
                                    u'b-name': new_lib['name'],
-                                   u'a-email': new_lib_user['email'],
+                                   u'a-e-address': new_lib_user['email'],
                                    u'a-first_name': new_lib_user['first'],
                                    u'a-last_name': new_lib_user['last'],
                                    u'a-telephone': "I'm a bot."},
@@ -1958,7 +1958,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         data = {u'b-email': new_lib['email'],
                 u'b-website': new_lib['website'],
                 u'b-name': new_lib['name'],
-                u'a-email': existing_lib_user['email']}
+                u'a-e-address': existing_lib_user['email']}
         self.submit_form('libraries',
                           data = data,
                           form_keys = ['registrar_form', 'user_form'],
@@ -2015,7 +2015,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Existing user's email address, no court info
         # (currently succeeds, should probably fail; see issue 1746)
         self.submit_form('sign_up_courts',
-                          data = { 'email': existing_user['email']},
+                          data = { 'e-address': existing_user['email']},
                           success_url = reverse('court_request_response'))
         expected_emails_sent += 1
         self.assertEqual(len(mail.outbox), expected_emails_sent)
@@ -2023,7 +2023,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # Existing user's email address + court info
         self.submit_form('sign_up_courts',
-                          data = { 'email': existing_user['email'],
+                          data = { 'e-address': existing_user['email'],
                                    'requested_account_note': new_court['requested_account_note']},
                           success_url = reverse('court_request_response'))
         expected_emails_sent += 1
@@ -2032,7 +2032,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address, don't create account
         self.submit_form('sign_up_courts',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_court['requested_account_note']},
                           success_url = reverse('court_request_response'))
         expected_emails_sent += 1
@@ -2041,7 +2041,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address, create account
         self.submit_form('sign_up_courts',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_court['requested_account_note'],
                                    'create_account': True },
                           success_url = reverse('register_email_instructions'))
@@ -2056,7 +2056,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # (This succeeds and creates a new account; see issue 1749)
         new_user = self.new_court_user()
         self.submit_form('sign_up_courts',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_court['requested_account_note'],
                                    'create_account': True },
                           user = existing_user['email'],
@@ -2069,7 +2069,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Existing user's email address, not that of the user logged in.
         # (This is odd; see issue 1749)
         self.submit_form('sign_up_courts',
-                          data = { 'email': existing_user['email'],
+                          data = { 'e-address': existing_user['email'],
                                    'requested_account_note': new_court['requested_account_note'],
                                    'create_account': True },
                           user = another_existing_user['email'],
@@ -2082,7 +2082,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         new_court = self.new_court()
         new_user = self.new_court_user()
         self.submit_form('sign_up_courts',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_court['requested_account_note'],
                                    'create_account': True,
                                    'telephone': "I'm a bot." },
@@ -2145,7 +2145,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Existing user's email address, no court info
         # (currently succeeds, should probably fail; see issue 1746)
         self.submit_form('sign_up_firm',
-                         data={'email': existing_user['email']},
+                         data={'e-address': existing_user['email']},
                          success_url=reverse('firm_request_response'))
         expected_emails_sent += 1
         self.assertEqual(len(mail.outbox), expected_emails_sent)
@@ -2153,7 +2153,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # Existing user's email address + firm info
         self.submit_form('sign_up_firm',
-                         data={'email': existing_user['email'],
+                         data={'e-address': existing_user['email'],
                                'requested_account_note': new_firm['requested_account_note']},
                          success_url=reverse('firm_request_response'))
         expected_emails_sent += 1
@@ -2162,7 +2162,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address, don't create account
         self.submit_form('sign_up_firm',
-                         data={'email': new_user['email'],
+                         data={'e-address': new_user['email'],
                                'requested_account_note': new_firm['requested_account_note']},
                          success_url=reverse('firm_request_response'))
         expected_emails_sent += 1
@@ -2171,7 +2171,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address, create account
         self.submit_form('sign_up_firm',
-                         data={'email': new_user['email'],
+                         data={'e-address': new_user['email'],
                                'requested_account_note': new_firm['requested_account_note'],
                                'create_account': True},
                          success_url=reverse('register_email_instructions'))
@@ -2186,7 +2186,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # (This succeeds and creates a new account; see issue 1749)
         new_user = self.new_firm_user()
         self.submit_form('sign_up_firm',
-                         data={'email': new_user['email'],
+                         data={'e-address': new_user['email'],
                                'requested_account_note': new_firm['requested_account_note'],
                                'create_account': True},
                          user=existing_user['email'],
@@ -2199,7 +2199,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Existing user's email address, not that of the user logged in.
         # (This is odd; see issue 1749)
         self.submit_form('sign_up_firm',
-                         data={'email': existing_user['email'],
+                         data={'e-address': existing_user['email'],
                                'requested_account_note': new_firm['requested_account_note'],
                                'create_account': True},
                          user=another_existing_user['email'],
@@ -2212,7 +2212,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         new_firm = self.new_firm()
         new_user = self.new_firm_user()
         self.submit_form('sign_up_firm',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_firm['requested_account_note'],
                                    'create_account': True,
                                    'telephone': "I'm a bot." },
@@ -2263,7 +2263,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address + journal info
         self.submit_form('sign_up_journals',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_journal['requested_account_note']},
                           success_url = reverse('register_email_instructions'))
         expected_emails_sent += 1
@@ -2276,7 +2276,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # (This succeeds and creates a new account; see issue 1749)
         new_user = self.new_journal_user()
         self.submit_form('sign_up_journals',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_journal['requested_account_note']},
                           user = existing_user['email'],
                           success_url = reverse('register_email_instructions'))
@@ -2288,7 +2288,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         new_journal = self.new_journal()
         new_user = self.new_journal_user()
         self.submit_form('sign_up_journals',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_journal['requested_account_note'],
                                    'telephone': "I'm a bot." },
                           success_url = reverse('register_email_instructions'))
@@ -2310,7 +2310,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # If email address already belongs to an account, validation fails
         self.submit_form('sign_up_journals',
-                          data = { 'email': 'test_user@example.com',
+                          data = { 'e-address': 'test_user@example.com',
                                    'requested_account_note': 'Here'},
                           error_keys = ['email'])
         self.assertEqual(len(mail.outbox), 0)
@@ -2327,7 +2327,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # If email address already belongs to an account, validation fails
         self.submit_form('sign_up_journals',
-                          data = { 'email': 'test_user@example.com',
+                          data = { 'e-address': 'test_user@example.com',
                                    'requested_account_note': 'Here'},
                           user = 'test_user@example.com',
                           error_keys = ['email'])
@@ -2355,7 +2355,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address + journal info
         self.submit_form('sign_up_faculty',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_user['requested_account_note']},
                           success_url = reverse('register_email_instructions'))
         expected_emails_sent += 1
@@ -2368,7 +2368,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # (This succeeds and creates a new account; see issue 1749)
         new_user = self.new_faculty_user()
         self.submit_form('sign_up_faculty',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_user['requested_account_note']},
                           user = existing_user['email'],
                           success_url = reverse('register_email_instructions'))
@@ -2379,7 +2379,7 @@ class UserManagementViewsTestCase(PermaTestCase):
     def test_new_faculty_form_honeypot(self):
         new_user = self.new_faculty_user()
         self.submit_form('sign_up_faculty',
-                          data = { 'email': new_user['email'],
+                          data = { 'e-address': new_user['email'],
                                    'requested_account_note': new_user['requested_account_note'],
                                    'telephone': "I'm a bot." },
                           success_url = reverse('register_email_instructions'))
@@ -2401,7 +2401,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # If email address already belongs to an account, validation fails
         self.submit_form('sign_up_faculty',
-                          data = { 'email': 'test_user@example.com',
+                          data = { 'e-address': 'test_user@example.com',
                                    'requested_account_note': 'Here'},
                           error_keys = ['email'])
         self.assertEqual(len(mail.outbox), 0)
@@ -2418,7 +2418,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # If email address already belongs to an account, validation fails
         self.submit_form('sign_up_faculty',
-                          data = { 'email': 'test_user@example.com',
+                          data = { 'e-address': 'test_user@example.com',
                                    'requested_account_note': 'Here'},
                           user = 'test_user@example.com',
                           error_keys = ['email'])
@@ -2437,7 +2437,7 @@ class UserManagementViewsTestCase(PermaTestCase):
     def test_account_creation_views(self):
         # user registration
         new_user_email = "new_email@test.com"
-        self.submit_form('sign_up', {'email': new_user_email, 'first_name': 'Test', 'last_name': 'Test'},
+        self.submit_form('sign_up', {'e-address': new_user_email, 'first_name': 'Test', 'last_name': 'Test'},
                          success_url=reverse('register_email_instructions'),
                          success_query=LinkUser.objects.filter(email=new_user_email))
 
@@ -2480,13 +2480,13 @@ class UserManagementViewsTestCase(PermaTestCase):
 
     def test_signup_with_existing_email_rejected(self):
         self.submit_form('sign_up',
-                         {'email': self.registrar_user.email, 'first_name': 'Test', 'last_name': 'Test'},
+                         {'e-address': self.registrar_user.email, 'first_name': 'Test', 'last_name': 'Test'},
                          error_keys=['email'])
 
     def test_new_user_form_honeypot(self):
         new_user_email = "new_email@test.com"
         self.submit_form('sign_up',
-                          data = { 'email': new_user_email,
+                          data = { 'e-address': new_user_email,
                                    'telephone': "I'm a bot." },
                           success_url = reverse('register_email_instructions'))
         self.assertEqual(len(mail.outbox), 0)

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -51,7 +51,7 @@ from perma.forms import (
     UserFormWithAdmin,
     UserAddAdminForm)
 from perma.models import Registrar, LinkUser, Organization, Link, Capture, CaptureJob, ApiKey, Sponsorship, Folder
-from perma.utils import apply_search_query, apply_pagination, apply_sort_order, get_form_data, ratelimit_ip_key, get_lat_long, user_passes_test_or_403, prep_for_perma_payments, clear_wr_session
+from perma.utils import apply_search_query, apply_pagination, apply_sort_order, get_form_data, ratelimit_ip_key, get_lat_long, user_passes_test_or_403, prep_for_perma_payments, clear_wr_session, get_client_ip
 from perma.email import send_admin_email, send_user_email
 from perma.exceptions import PermaPaymentsCommunicationException
 
@@ -1433,6 +1433,11 @@ def libraries(request):
         else:
             form_is_valid = registrar_form.is_valid()
 
+        # telephone is display: none, so should never be filled out except by spam bots.
+        if user_form and user_form.data.get('a-telephone'):
+            user_ip = get_client_ip(request)
+            logger.info(f"Suppressing invalid signup request from {user_ip}: {user_form.data}")
+            return HttpResponseRedirect(reverse('register_library_instructions'))
         if form_is_valid:
             new_registrar = registrar_form.save()
             email_registrar_request(request, new_registrar)
@@ -1477,6 +1482,11 @@ def sign_up(request):
     """
     if request.method == 'POST':
         form = UserForm(request.POST)
+        # telephone is display: none, so should never be filled out except by spam bots.
+        if form.data.get('telephone'):
+            user_ip = get_client_ip(request)
+            logger.info(f"Suppressing invalid signup request from {user_ip}: {form.data}")
+            return HttpResponseRedirect(reverse('register_email_instructions'))
         if form.is_valid():
             new_user = form.save()
             email_new_user(request, new_user)
@@ -1507,6 +1517,11 @@ def sign_up_courts(request):
             email_court_request(request, target_user)
             return HttpResponseRedirect(reverse('court_request_response'))
 
+        # telephone is display: none, so should never be filled out except by spam bots.
+        if form.data.get('telephone'):
+            user_ip = get_client_ip(request)
+            logger.info(f"Suppressing invalid signup request from {user_ip}: {form.data}")
+            return HttpResponseRedirect(reverse('register_email_instructions'))
         if form.is_valid():
             new_user = form.save(commit=False)
             new_user.requested_account_type = 'court'
@@ -1534,6 +1549,11 @@ def sign_up_faculty(request):
     """
     if request.method == 'POST':
         form = CreateUserFormWithUniversity(request.POST)
+        # telephone is display: none, so should never be filled out except by spam bots.
+        if form.data.get('telephone'):
+            user_ip = get_client_ip(request)
+            logger.info(f"Suppressing invalid signup request from {user_ip}: {form.data}")
+            return HttpResponseRedirect(reverse('register_email_instructions'))
         if form.is_valid():
             new_user = form.save(commit=False)
             new_user.requested_account_type = 'faculty'
@@ -1568,6 +1588,11 @@ def sign_up_firm(request):
             email_firm_request(request, target_user)
             return HttpResponseRedirect(reverse('firm_request_response'))
 
+        # telephone is display: none, so should never be filled out except by spam bots.
+        if form.data.get('telephone'):
+            user_ip = get_client_ip(request)
+            logger.info(f"Suppressing invalid signup request from {user_ip}: {form.data}")
+            return HttpResponseRedirect(reverse('register_email_instructions'))
         if form.is_valid():
             new_user = form.save(commit=False)
             new_user.requested_account_type = 'firm'
@@ -1595,6 +1620,11 @@ def sign_up_journals(request):
     """
     if request.method == 'POST':
         form = CreateUserFormWithUniversity(request.POST)
+        # telephone is display: none, so should never be filled out except by spam bots.
+        if form.data.get('telephone'):
+            user_ip = get_client_ip(request)
+            logger.info(f"Suppressing invalid signup request from {user_ip}: {form.data}")
+            return HttpResponseRedirect(reverse('register_email_instructions'))
         if form.is_valid():
             new_user = form.save(commit=False)
             new_user.requested_account_type = 'journal'

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1417,7 +1417,7 @@ def libraries(request):
         else:
             user_form = UserForm(request.POST, prefix = "a")
             user_form.fields['email'].label = "Your email"
-        user_email = request.POST.get('a-email', None)
+        user_email = request.POST.get('a-e-address', None)
         try:
             target_user = LinkUser.objects.get(email=user_email)
         except LinkUser.DoesNotExist:
@@ -1504,7 +1504,7 @@ def sign_up_courts(request):
     """
     if request.method == 'POST':
         form = CreateUserFormWithCourt(request.POST)
-        submitted_email = request.POST.get('email', None)
+        submitted_email = request.POST.get('e-address', None)
         try:
             target_user = LinkUser.objects.get(email=submitted_email)
         except LinkUser.DoesNotExist:
@@ -1575,7 +1575,7 @@ def sign_up_firm(request):
     """
     if request.method == 'POST':
         form = CreateUserFormWithFirm(request.POST)
-        user_email = request.POST.get('email', None)
+        user_email = request.POST.get('e-address', None)
         try:
             target_user = LinkUser.objects.get(email=user_email)
         except LinkUser.DoesNotExist:
@@ -1703,7 +1703,7 @@ def email_registrar_request(request, pending_registrar):
         email = request.user.email
     except AttributeError:
         # User did not have an account
-        email = request.POST.get('a-email')
+        email = request.POST.get('a-e-address')
 
     send_admin_email(
         "Perma.cc new library registrar account request",

--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -7701,10 +7701,10 @@ button#addlink,
 .contact-form textarea[name="box1"] {
   display: none; }
 
-.signup-learnMore-form label[for="id_telephone"] {
+.signup-learnMore-form label[for="id_telephone"], .signup-learnMore-form label[for="id_a-telephone"] {
   display: none; }
 
-.signup-learnMore-form input[name="telephone"] {
+.signup-learnMore-form input[name="telephone"], .signup-learnMore-form input[name="a-telephone"] {
   display: none; }
 
 .list-user._isPrivate span.ui-private {

--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -7701,10 +7701,10 @@ button#addlink,
 .contact-form textarea[name="box1"] {
   display: none; }
 
-.signup-learnMore-form label[for="id_telephone"], .signup-learnMore-form label[for="id_a-telephone"] {
+.signup-learnMore-form label[for="id_telephone"], .signup-learnMore-form label[for="id_a-telephone"], .add-user label[for="id_telephone"], .add-user label[for="id_a-telephone"], .change-user label[for="id_telephone"], .change-user label[for="id_a-telephone"] {
   display: none; }
 
-.signup-learnMore-form input[name="telephone"], .signup-learnMore-form input[name="a-telephone"] {
+.signup-learnMore-form input[name="telephone"], .signup-learnMore-form input[name="a-telephone"], .add-user input[name="telephone"], .add-user input[name="a-telephone"], .change-user input[name="telephone"], .change-user input[name="a-telephone"] {
   display: none; }
 
 .list-user._isPrivate span.ui-private {

--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -7701,6 +7701,12 @@ button#addlink,
 .contact-form textarea[name="box1"] {
   display: none; }
 
+.signup-learnMore-form label[for="id_telephone"] {
+  display: none; }
+
+.signup-learnMore-form input[name="telephone"] {
+  display: none; }
+
 .list-user._isPrivate span.ui-private {
   overflow: hidden;
   display: inline-block;

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3135,10 +3135,10 @@ button#addlink,
 
 .signup-learnMore-form {
   // hide telephone so it will only be filled by spam bots
-  label[for="id_telephone"] {
+  label[for="id_telephone"], label[for="id_a-telephone"] {
     display: none;
   }
-  input[name="telephone"] {
+  input[name="telephone"], input[name="a-telephone"] {
     display: none;
   }
 }

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3133,6 +3133,16 @@ button#addlink,
   }
 }
 
+.signup-learnMore-form {
+  // hide telephone so it will only be filled by spam bots
+  label[for="id_telephone"] {
+    display: none;
+  }
+  input[name="telephone"] {
+    display: none;
+  }
+}
+
 .list-user {
   &._isPrivate {
     span.ui-private {

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3133,7 +3133,7 @@ button#addlink,
   }
 }
 
-.signup-learnMore-form {
+.signup-learnMore-form, .add-user, .change-user {
   // hide telephone so it will only be filled by spam bots
   label[for="id_telephone"], label[for="id_a-telephone"] {
     display: none;


### PR DESCRIPTION
As with the [contact form](https://github.com/harvard-lil/perma/pull/2703), but with a realistic input `name`, "telephone", as per advice on the internet.