### PR TITLE
Optionally scan user uploads

### DIFF
--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -16,6 +16,18 @@ services:
     network_mode: "host"
 
   #
+  # Upload scanning
+  #
+  filecheck:
+    image: registry.lil.tools/harvardlil/perma-filecheck:0.7
+    environment:
+      - UVICORN_PORT=8888
+    ports:
+      - "127.0.0.1:8888:8888"
+    networks:
+      - default
+
+  #
   # Webrecorder
   #
   app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
   # Upload scanning
   #
   filecheck:
-    image: perma-filecheck:0.6
+    image: registry.lil.tools/harvardlil/perma-filecheck:0.7
     environment:
       - UVICORN_PORT=8888
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,18 @@ services:
       - perma_payments
 
   #
+  # Upload scanning
+  #
+  filecheck:
+    image: perma-filecheck:0.6
+    environment:
+      - UVICORN_PORT=8888
+    ports:
+      - "127.0.0.1:8888:8888"
+    networks:
+      - default
+
+  #
   # Webrecorder
   #
   app:

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -217,7 +217,7 @@ class CustomerModel(models.Model):
                     })
                 }
             )
-            assert r.ok
+            assert r.ok, r.status_code
         except (requests.RequestException, AssertionError) as e:
             msg = "Communication with Perma-Payments failed: {}".format(str(e))
             logger.error(msg)
@@ -257,7 +257,7 @@ class CustomerModel(models.Model):
                     })
                 }
             )
-            assert r.ok
+            assert r.ok, r.status_code
         except (requests.RequestException, AssertionError) as e:
             msg = "Communication with Perma-Payments failed: {}".format(str(e))
             logger.error(msg)
@@ -503,7 +503,7 @@ class CustomerModel(models.Model):
                                 })
                             }
                         )
-                        assert r.ok
+                        assert r.ok, r.status_code
                     except (requests.RequestException, AssertionError) as e:
                         msg = "Communication with Perma-Payments failed: {}".format(str(e))
                         logger.error(msg)

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -721,3 +721,5 @@ SERVICE_WORKER_URL = 'https://unpkg.com/replaywebpage@1.0.2/sw.js'
 
 ENABLE_BONUS_LINKS = False
 
+SCAN_UPLOADS = False
+SCAN_URL = ''

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -92,5 +92,6 @@ PERMA_PAYMENTS_ENCRYPTION_KEYS = {
 
 
 # Upload scanning
+SCAN_UPLOADS = True
 SCAN_URL = 'http://filecheck:8888/scan/'
 

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -89,3 +89,8 @@ PERMA_PAYMENTS_ENCRYPTION_KEYS = {
     'perma_public_key': "+Y3Kni4Pm+5kWFJgsBL28TyKcgciQdPofRsTwUKaVSE=",
     'perma_payments_public_key': "FhfWRc3QmLzG9SY+QwvTNMT9vcACNzpcMyvNSxKg0jA="
 }
+
+
+# Upload scanning
+SCAN_URL = 'http://filecheck:8888/scan/'
+

--- a/perma_web/perma/settings/deployments/settings_travis.py
+++ b/perma_web/perma/settings/deployments/settings_travis.py
@@ -6,3 +6,5 @@ from .deployments.settings_testing import *
 DATABASES['default']['HOST'] = '127.0.0.1'
 DATABASES['default']['USER'] = 'root'
 DATABASES['default']['PASSWORD'] = ''
+
+SCAN_URL = 'http://localhost:8888/scan/'


### PR DESCRIPTION
Set `SCAN_UPLOADS = True` and `SCAN_URL = 'http://our-scanning-service/scan/'` to enable. During form validation, uploaded files will be passed to the service. If the service is unavailable, validation will fail but users will be told to try again. If the service rejects the file, Perma will log some info (level WARNING, user ID and reason for rejection), but the user will just be told that file "validation failed."