### PR TITLE
Getvalue not available for large tempfiles. 

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -280,10 +280,11 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                     errors['file'] = "File is too large."
 
                 elif settings.SCAN_UPLOADS:
+                    uploaded_file.file.seek(0)
                     try:
                         r = requests.post(
                             settings.SCAN_URL,
-                            files={'file': (uploaded_file.name, uploaded_file.file.getvalue())}
+                            files={'file': (uploaded_file.name, uploaded_file.file.read())}
                         )
                         assert r.ok, r.status_code
                         scan_results = r.json()


### PR DESCRIPTION
Small files are:
```
(Pdb) type(uploaded_file.file)
<class '_io.BytesIO'>
```

Large files are:
```
(Pdb) type(uploaded_file.file)
<class 'tempfile._TemporaryFileWrapper'
```

`read` is available for both. `seek(0)` is evidently necessary; in testing the cursor was not predictably placed otherwise.