### PR TITLE
Replaced links: API download routes

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -55,6 +55,12 @@ class LinkResourceTestMixin():
         self.public_link_download_url = reverse('api:public_archives_download', args=[self.link.pk])
         self.public_link_download_url_for_private_link = reverse('api:public_archives_download', args=[self.unrelated_private_link.pk])
 
+        self.replaced_link_public_download_url = reverse('api:public_archives_download', args=['ABCD-0006'])
+        self.replaced_link_public_download_redirect_target = reverse('api:public_archives_download', args=['3SLN-JHX9'])
+        self.replaced_link_authed_download_url = reverse('api:archives_download', args=['ABCD-0006'])
+        self.replaced_link_authed_download_redirect_target = reverse('api:archives_download', args=['3SLN-JHX9'])
+        self.replaced_link_owner = LinkUser.objects.get(id=4)
+
         self.logged_out_fields = [
             'title',
             'description',
@@ -147,6 +153,17 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
             expected_status_code=403,
             user=self.firm_user
         )
+
+    def test_replaced_link_public_download(self):
+        resp = self.api_client.get(self.replaced_link_public_download_url)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, self.replaced_link_public_download_redirect_target)
+
+    def test_replaced_link_authed_download(self):
+        self.api_client.force_authenticate(user=self.replaced_link_owner)
+        resp = self.api_client.get(self.replaced_link_authed_download_url)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, self.replaced_link_authed_download_redirect_target)
 
     @patch('perma.utils.stream_warc', autospec=True)
     def test_private_download(self, stream):


### PR DESCRIPTION
I did not consider [replaced links](https://github.com/harvard-lil/perma/commit/de6a92521c5988e735435a41103514f7961d377c) when I added API routes for downloading warcs. This PR corrects that oversight.