### PR TITLE
Don't verify SSL certs.

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -59,12 +59,18 @@ class Sec1TLSAdapter(requests.adapters.HTTPAdapter):
         """Create and initialize the urllib3 PoolManager."""
         ctx = ssl.create_default_context()
         ctx.set_ciphers('DEFAULT@SECLEVEL=1')
+
+        # for whatever reason, required for verify=False
+        ctx.check_hostname = False
         self.poolmanager = poolmanager.PoolManager(
                 num_pools=connections,
                 maxsize=maxsize,
                 block=block,
                 ssl_version=ssl.PROTOCOL_TLS,
                 ssl_context=ctx)
+
+    def cert_verify(self, conn, url, verify, cert):
+        super().cert_verify(conn, url, False, cert)
 
 ### celery helpers ###
 


### PR DESCRIPTION
In https://github.com/harvard-lil/perma/pull/2875, I removed `verify=False` from link validation, because it was throwing an error when used with our bug-fixing custom SSL adapter, and I didn't think it mattered.

Turns out it does matter: at least one user has found a site that can be archived with `verify=False` that cannot be archived otherwise.

It sounds like `requests` is doing some [soul-searching about how cert verification should be handled](https://github.com/psf/requests/issues/2966).

In the meantime, this PR re-introduces `verify=False`, but does so at a deeper level than before, so that we don't verify certs during link validation OR during the capture process. That requires setting `ctx.check_hostname = False`, because otherwise we get:
```
    super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.
```
And no, I don't understand any of this, so there could be even more problems, but I still think this moves us in the desired direction....

Could I be very wrong? Yes.

Coming soon: I should add special logging of SSL-related problems, so I can troubleshoot without waiting for user reports.