### PR TITLE
Use the database more efficiently in the Django admin.

### DIFF
--- a/perma_web/perma/templates/admin/input_filter.html
+++ b/perma_web/perma/templates/admin/input_filter.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
+<ul>
+  <li>
+    {% with choices.0 as all_choice %}
+      <form method="GET" action="">
+        {% for k, v in all_choice.query_parts %}
+          <input type="hidden" name="{{ k }}" value="{{ v }}" />
+        {% endfor %}
+        <input  type="text"
+                value="{{ spec.value|default_if_none:'' }}"
+                name="{{ spec.parameter_name }}"/>
+        {% if not all_choice.selected %}
+            <strong><a href="{{ all_choice.query_string }}">x {% trans 'Remove' %}</a></strong>
+        {% endif %}
+      </form>
+    {% endwith %}
+  </li>
+</ul>

--- a/perma_web/perma/templates/admin/perma/linkuser/change_form.html
+++ b/perma_web/perma/templates/admin/perma/linkuser/change_form.html
@@ -5,7 +5,7 @@
   <div class="module aligned">
     <h2>Links</h2>
     <div class="form-row">
-      <a href="{% url 'admin:perma_link_changelist' %}?q={{ original.email | urlencode }}">
+      <a href="{% url 'admin:perma_link_changelist' %}?created_by={{ original.email | urlencode }}">
         View links created by {{ original.email }}
       </a>
     </div>


### PR DESCRIPTION
Part one of a series, aiming to improve performance.

Lots of behind-the-scenes improvements, but this also changes the UI for two admin tables:

1) When viewing a user's organizations, they are displayed as a list of ID numbers, instead of a fancy multi-select widget.
![image](https://user-images.githubusercontent.com/11020492/105752180-f2a7cd00-5f14-11eb-8790-f807dbd8a22c.png)
This... maybe be an unnecessary optimization. Let's readdress if it's not working out.

2) The search field is removed from the links table, and replaced with a series of field-specific filter fields.
![image](https://user-images.githubusercontent.com/11020492/105752310-1d922100-5f15-11eb-95de-713941bf7a5f.png)
All the filters use icontains.