### PR TITLE
Overhaul dev package setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       dockerfile: ./perma_web/Dockerfile
-    image: perma3:0.95
+    image: perma3:0.96
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/Pipfile
+++ b/perma_web/Pipfile
@@ -95,6 +95,8 @@ pytest-xdist = "*"                          # run tests in parallel
 pytest = "*"                                # test runner
 sauceclient = "*"                           # run functional tests in many browsers online
 django-extensions = "*"                     # runserver_plus for SSL
+django-debug-toolbar = "*"                  # see SQL queries, monitor signals, etc.
+ipdb = "*"                                  # improved debugger and interactive shell
 
 [requires]
 python_version = "3.7"

--- a/perma_web/Pipfile.lock
+++ b/perma_web/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d9f6120dbb586a00654d064c690d11869a496827f3308749579f359c6b2bb861"
+            "sha256": "941ed9b6d8df89f4ed434e2b97eb857870bf83a4fc53a49933a911db8bc84c03"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -885,6 +885,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
         },
+        "backcall": {
+            "hashes": [
+                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
+                "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
+            ],
+            "version": "==0.2.0"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35",
@@ -952,6 +959,14 @@
             "index": "pypi",
             "version": "==5.5"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:6f201a6c4dac3d187352661f508b9364ec8091217442c9478f1f83c003a0f060",
+                "sha256:945d84890bb20cc4a2f4a31fc4311c0c473af65ea318617f13a7257c9a58bc98"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==5.0.7"
+        },
         "django": {
             "hashes": [
                 "sha256:2484f115891ab1a0e9ae153602a641fbc15d7894c036d79fb78662c0965d7954",
@@ -966,6 +981,14 @@
             ],
             "index": "pypi",
             "version": "==0.3.0"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:a5ff2a54f24bf88286f9872836081078f4baa843dc3735ee88524e89f8821e33",
+                "sha256:e759e63e3fe2d3110e0e519639c166816368701eab4a47fed75d7de7018467b9"
+            ],
+            "index": "pypi",
+            "version": "==3.2.1"
         },
         "django-extensions": {
             "hashes": [
@@ -1025,6 +1048,36 @@
             ],
             "version": "==1.1.1"
         },
+        "ipdb": {
+            "hashes": [
+                "sha256:178c367a61c1039e44e17c56fcc4a6e7dc11b33561261382d419b6ddb4401810"
+            ],
+            "index": "pypi",
+            "version": "==0.13.7"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:9c900332d4c5a6de534b4befeeb7de44ad0cc42e8327fa41b7685abde58cec74",
+                "sha256:c0ce02dfaa5f854809ab7413c601c4543846d9da81010258ecdab299b542d199"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==7.22.0"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93",
+                "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.18.0"
+        },
         "lupa": {
             "hashes": [
                 "sha256:09d6c45eb3b9407588c5a168e3371b629e75c5822050e9feff393601709bd0d7",
@@ -1080,6 +1133,29 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.9"
         },
+        "parso": {
+            "hashes": [
+                "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
+                "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.8.2"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.8.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
@@ -1087,6 +1163,21 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:bf00f22079f5fadc949f42ae8ff7f05702826a97059ffcc6281036ad40ac6f04",
+                "sha256:e1b4f11b9336a28fa11810bc623c357420f69dfdb6d2dac41ca2c21a55c033bc"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==3.0.18"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35",
+                "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
+            ],
+            "version": "==0.7.0"
         },
         "py": {
             "hashes": [
@@ -1111,6 +1202,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.3.1"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94",
+                "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.8.1"
         },
         "pyparsing": {
             "hashes": [
@@ -1230,6 +1329,14 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
+        "traitlets": {
+            "hashes": [
+                "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396",
+                "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.5"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
@@ -1238,6 +1345,13 @@
             ],
             "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
+            ],
+            "version": "==0.2.5"
         },
         "zipp": {
             "hashes": [

--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -1,3 +1,0 @@
-# handy packages to have in a dev environment
-ipdb
-django-debug-toolbar==3.2.1

--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -6,6 +6,6 @@ pipdeptree                      # show full pip dependency tree with the 'pipdep
 
 # WARNING: The following can break things in weird ways.
 # If you install, be on the lookout for oddities soon after and consider uninstalling.
-django-debug-toolbar==1.11.1     # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
+django-debug-toolbar==3.2.1    # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
 #django-extensions==1.7.8        # if installed, `fab run` will use `python manage.py runserver_plus`
 -e git://github.com/django-extensions/django-extensions.git@26665e26#egg=django-extensions  # switch back post 1.7.8

--- a/perma_web/dev_requirements.txt
+++ b/perma_web/dev_requirements.txt
@@ -1,11 +1,3 @@
 # handy packages to have in a dev environment
 ipdb
-django-nose==1.4.3              # an alternative test runner; enable in settings_testing.py
-pysqlite==2.6.3                 # for use with in memory testing set in settings_testing.py
-pipdeptree                      # show full pip dependency tree with the 'pipdeptree' command line tool
-
-# WARNING: The following can break things in weird ways.
-# If you install, be on the lookout for oddities soon after and consider uninstalling.
-django-debug-toolbar==3.2.1    # if installed, debug-toolbar will be included in INSTALLED_APPS by settings_dev.py
-#django-extensions==1.7.8        # if installed, `fab run` will use `python manage.py runserver_plus`
--e git://github.com/django-extensions/django-extensions.git@26665e26#egg=django-extensions  # switch back post 1.7.8
+django-debug-toolbar==3.2.1

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -14,7 +14,7 @@ from perma.tests.utils import reset_failed_test_files_folder
 
 
 @task(name='run')
-def run_django(port="0.0.0.0:8000", use_ssl=False, cert_file='perma-test.crt', host='perma.test'):
+def run_django(port="0.0.0.0:8000", use_ssl=False, cert_file='perma-test.crt', host='perma.test', debug_toolbar=''):
     """
         Run django test server on open port, so it's accessible outside Docker.
 
@@ -44,46 +44,48 @@ def run_django(port="0.0.0.0:8000", use_ssl=False, cert_file='perma-test.crt', h
 
     proc_list = [subprocess.Popen(command, shell=True, stdout=sys.stdout, stderr=sys.stderr) for command in commands]
 
-    try:
-        if use_ssl:
-            try:
-                # use runserver_plus if installed
-                import django_extensions  # noqa
+    with shell_env(DEBUG_TOOLBAR=debug_toolbar):
 
-                if not settings.SECURE_SSL_REDIRECT:
-                    print("\nError! When using SSL, you must run with settings.SECURE_SSL_REDIRECT = True\n")
-                else:
-                    ## The following comment and line are from the Vagrant era, and may
-                    ## need amendment for Docker.
-                    # use --reloader-type stat because:
-                    #  (1) we have to have watchdog installed for pywb, which causes
-                    # runserver_plus to attempt to use it as the reloader, which depends
-                    # on inotify, but
-                    #  (2) we are using a Vagrant NFS mount, which does not support inotify
-                    # see https://github.com/django-extensions/django-extensions/pull/1041
-                    options = '--threaded --reloader-type stat'
+        try:
+            if use_ssl:
+                try:
+                    # use runserver_plus if installed
+                    import django_extensions  # noqa
 
-                    # create a cert if necessary or supply your own; we assume perma.test
-                    # is in your /etc/hosts
-                    conf_file = "%s.conf" % os.path.splitext(cert_file)[0]
-                    with open(conf_file, "w") as f:
-                        f.write("[dn]\nCN=%s\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:%s\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" % (host, host))
-                    if not os.path.exists(cert_file):
-                        local("openssl req -x509 -out %s -keyout %s -newkey rsa:2048 -nodes -sha256 -subj '/CN=%s' -extensions EXT -config %s" % (cert_file, "%s.key" % os.path.splitext(cert_file)[0], host, conf_file))
-                    options += ' --cert-file %s' % cert_file
+                    if not settings.SECURE_SSL_REDIRECT:
+                        print("\nError! When using SSL, you must run with settings.SECURE_SSL_REDIRECT = True\n")
+                    else:
+                        ## The following comment and line are from the Vagrant era, and may
+                        ## need amendment for Docker.
+                        # use --reloader-type stat because:
+                        #  (1) we have to have watchdog installed for pywb, which causes
+                        # runserver_plus to attempt to use it as the reloader, which depends
+                        # on inotify, but
+                        #  (2) we are using a Vagrant NFS mount, which does not support inotify
+                        # see https://github.com/django-extensions/django-extensions/pull/1041
+                        options = '--threaded --reloader-type stat'
 
-                    local("python manage.py runserver_plus %s %s" % (port, options))
-            except ImportError:
-                print("\nWarning! We can't serve via SSL, as django-extensions is not\n" +
-                      "installed. You may wish to run `pipenv install --dev`.\n")
-        else:
-            if settings.SECURE_SSL_REDIRECT:
-                print("\nError! When *not* using SSL, you must run with settings.SECURE_SSL_REDIRECT = False\n")
+                        # create a cert if necessary or supply your own; we assume perma.test
+                        # is in your /etc/hosts
+                        conf_file = "%s.conf" % os.path.splitext(cert_file)[0]
+                        with open(conf_file, "w") as f:
+                            f.write("[dn]\nCN=%s\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:%s\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" % (host, host))
+                        if not os.path.exists(cert_file):
+                            local("openssl req -x509 -out %s -keyout %s -newkey rsa:2048 -nodes -sha256 -subj '/CN=%s' -extensions EXT -config %s" % (cert_file, "%s.key" % os.path.splitext(cert_file)[0], host, conf_file))
+                        options += ' --cert-file %s' % cert_file
+
+                        local("python manage.py runserver_plus %s %s" % (port, options))
+                except ImportError:
+                    print("\nWarning! We can't serve via SSL, as django-extensions is not\n" +
+                          "installed. You may wish to run `pipenv install --dev`.\n")
             else:
-                local("python manage.py runserver %s" % port)
-    finally:
-        for proc in proc_list:
-            os.kill(proc.pid, signal.SIGKILL)
+                if settings.SECURE_SSL_REDIRECT:
+                    print("\nError! When *not* using SSL, you must run with settings.SECURE_SSL_REDIRECT = False\n")
+                else:
+                    local("python manage.py runserver %s" % port)
+        finally:
+            for proc in proc_list:
+                os.kill(proc.pid, signal.SIGKILL)
 
 
 _default_tests = "functional_tests perma api lockss"

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -38,7 +38,7 @@ CELERY_RESULT_BACKEND = None
 ### optional dev packages ###
 
 # django-debug-toolbar
-try:
+if os.environ.get('DEBUG_TOOLBAR'):
     import debug_toolbar  # noqa
     INSTALLED_APPS += (
         'debug_toolbar',
@@ -47,9 +47,6 @@ try:
         'SHOW_TOOLBAR_CALLBACK': 'perma.utils.show_debug_toolbar'  # we have to override this check because the default depends on IP address, which doesn't work inside Vagrant
     }
     MIDDLEWARE = ('debug_toolbar.middleware.DebugToolbarMiddleware',) + MIDDLEWARE
-
-except ImportError:
-    pass
 
 # django_extensions
 try:

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -46,6 +46,8 @@ try:
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': 'perma.utils.show_debug_toolbar'  # we have to override this check because the default depends on IP address, which doesn't work inside Vagrant
     }
+    MIDDLEWARE = ('debug_toolbar.middleware.DebugToolbarMiddleware',) + MIDDLEWARE
+
 except ImportError:
     pass
 

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
@@ -187,6 +187,13 @@ if settings.OFFER_CLIENT_SIDE_PLAYBACK:
 # debug-only serving of media assets
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    try:
+        import debug_toolbar
+        urlpatterns = [
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        ] + urlpatterns
+    except ImportError:
+        pass
 
 # views that only load when running our tests:
 if settings.TESTING:

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
@@ -184,16 +186,15 @@ if settings.OFFER_CLIENT_SIDE_PLAYBACK:
         url(r'^(?P<guid>[^\./]+)\.warc$', common.serve_warc, name='serve_warc'),
     ]
 
-# debug-only serving of media assets
 if settings.DEBUG:
+    # debug-only serving of media assets
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    try:
-        import debug_toolbar
+    # django toolbar
+    if os.environ.get('DEBUG_TOOLBAR'):
+        import debug_toolbar  # noqa
         urlpatterns = [
             url(r'^__debug__/', include(debug_toolbar.urls)),
         ] + urlpatterns
-    except ImportError:
-        pass
 
 # views that only load when running our tests:
 if settings.TESTING:


### PR DESCRIPTION
Removes the obsolete dev_requirements.txt and instead adds ipdb (and thus ipython) and django-debug-toolbar to the dev packages installed by pipenv. 

To run with the toolbar in dev: `fab run:debug_toolbar=True`

I've never used ipython or ipdb; let's try it.