### PR TITLE
Use a cache-busting trick to force Chrome update in image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,9 @@ services:
     build:
       context: .
       dockerfile: ./perma_web/Dockerfile
-    image: perma3:0.96
+      args:
+        chrome-layer-cache-buster: 69A623BC-D088-4C12-A232-248BE9B36D20
+    image: perma3:0.97
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -39,22 +39,9 @@ RUN echo "deb http://httpredir.debian.org/debian buster main contrib" > /etc/apt
     && apt-get install -y ttf-mscorefonts-installer \
     && apt-get install -y fonts-roboto
 
-# Install Chrome
-# technique from https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeChrome/Dockerfile.txt
-RUN apt-get update \
-    && apt-get install -y unzip libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libgbm1 libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxcursor1 libxi6 libxrandr2 libxss1 libxtst6 xdg-utils \
-    && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && dpkg -i google-chrome*.deb \
-    && CHROME_MAJOR_VERSION=$(google-chrome --version | sed -E "s/.* ([0-9]+)(\.[0-9]+){3}.*/\1/") \
-    && CHROME_DRIVER_VERSION=$(wget --no-verbose -O - "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION}") \
-    && wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
-    && unzip chromedriver_linux64.zip \
-    && mv chromedriver /usr/bin/chromedriver \
-    && chmod +x /usr/bin/chromedriver
-
 # Install a cert for use by warcprox
 COPY services/warcprox/perma-warcprox-ca.pem /perma/perma_web
-RUN apt-get update && apt-get install libnss3-tools \
+RUN apt-get update && apt-get install -y libnss3-tools \
     && mkdir -p $HOME/.pki/nssdb \
     && certutil -d $HOME/.pki/nssdb -N --empty-password \
     && certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n 'warcprox CA cert' -i perma-warcprox-ca.pem
@@ -84,6 +71,20 @@ RUN pip3 install -U pip \
     && pip install pipenv \
     && pipenv --python 3.7 install --ignore-pipfile --dev \
     && rm Pipfile.lock
+
+# Install Chrome
+# technique from https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeChrome/Dockerfile.txt
+ARG chrome-layer-cache-buster
+RUN apt-get update \
+    && apt-get install -y unzip libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libgbm1 libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxcursor1 libxi6 libxrandr2 libxss1 libxtst6 xdg-utils \
+    && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && dpkg -i google-chrome*.deb \
+    && CHROME_MAJOR_VERSION=$(google-chrome --version | sed -E "s/.* ([0-9]+)(\.[0-9]+){3}.*/\1/") \
+    && CHROME_DRIVER_VERSION=$(wget --no-verbose -O - "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION}") \
+    && wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+    && unzip chromedriver_linux64.zip \
+    && mv chromedriver /usr/bin/chromedriver \
+    && chmod +x /usr/bin/chromedriver
 
 # dev personalizations / try installing packages without rebuilding everything
 RUN apt-get update && apt-get install -y nano

--- a/update_chrome.sh
+++ b/update_chrome.sh
@@ -5,8 +5,9 @@
 # necessary. Rebuilding is somewhat time-consuming, so only run it when you
 # have reason to think there's a new Chrome version.
 
-docker-compose build --no-cache
-docker-compose up -d
+ORIG_CACHE_BUSTER=`grep chrome-layer-cache-buster docker-compose.yml | awk  '{print $2}'`
+perl -pi -e "s/chrome-layer-cache-buster: .*/chrome-layer-cache-buster: $(uuidgen)/" docker-compose.yml
+docker-compose up -d --build
 LATEST=`docker-compose exec -T web pipenv run google-chrome --version | cut -f 3 -d ' '`
 SETTING=`grep CAPTURE_USER_AGENT perma_web/perma/settings/deployments/settings_common.py | sed 's/.*Chrome\/\([^ ]*\)\(.*\)/\1/'`
 if [ "$LATEST" != "$SETTING" ] ; then
@@ -14,5 +15,7 @@ if [ "$LATEST" != "$SETTING" ] ; then
     COUNTER=`grep perma3 docker-compose.yml | cut -f 2 -d '.'`
     let NEWCOUNTER=$COUNTER+1
     perl -pi -e "s/perma3:0.$COUNTER/perma3:0.$NEWCOUNTER/" docker-compose.yml
+else
+    perl -pi -e "s/chrome-layer-cache-buster: .*/chrome-layer-cache-buster: $ORIG_CACHE_BUSTER/" docker-compose.yml
 fi
 docker-compose down


### PR DESCRIPTION
This should significantly reduce the time it takes to run `update_chrome.sh` (once your machine has built perma3:0.97), because you no longer have to build with `--no-cache` to look for updates, and because I'm moving the Chrome installation layer lower in the Dockerfile, since we do Chrome updates more often than python or node package updates. 

This also makes sure that other developers get the update: with the previous setup, the newly-tagged image produced when they pulled the code and ran `docker-compose up` would use their cached chrome layer, if one was present.