### PR TITLE
Hopefully fix image on Twitter cards

### DIFF
--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -17,13 +17,13 @@
     <meta name="twitter:site" content="@permacc">
     <meta name="twitter:title" content="Websites change. Perma Links don't.">
     <meta name="twitter:description" content="Perma.cc helps scholars, journals, courts, and others create permanent records of the web sources they cite.">
-    <meta name="twitter:image" content="{{ base_url }}{{ STATIC_URL }}img/create-step-4.png">
+    <meta name="twitter:image" content="{{ base_url }}{{ STATIC_URL }}img/create-step-4.png?cache-buster=1">
 
     <meta property="og:title" content="Websites change. Perma Links don't.">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Perma">
     <meta property="og:url" content="{{ base_url }}">
-    <meta property="og:image" content="{{ base_url }}{{ STATIC_URL }}img/sharing/blue_logo.png">
+    <meta property="og:image" content="{{ base_url }}{{ STATIC_URL }}img/sharing/blue_logo.png?cache-buster=1">
 
     {% block meta %}{% endblock %}
     <link href="{{ STATIC_URL }}img/favicon.ico" rel="shortcut icon" type="image/x-icon">

--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -17,13 +17,13 @@
     <meta name="twitter:site" content="@permacc">
     <meta name="twitter:title" content="Websites change. Perma Links don't.">
     <meta name="twitter:description" content="Perma.cc helps scholars, journals, courts, and others create permanent records of the web sources they cite.">
-    <meta name="twitter:image" content="{{ base_url }}{{ STATIC_URL }}img/create-step-4.png?cache-buster=1">
+    <meta name="twitter:image" content="{{ base_url }}{{ STATIC_URL }}img/create-step-4.png?cache-buster=10">
 
     <meta property="og:title" content="Websites change. Perma Links don't.">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Perma">
     <meta property="og:url" content="{{ base_url }}">
-    <meta property="og:image" content="{{ base_url }}{{ STATIC_URL }}img/sharing/blue_logo.png?cache-buster=1">
+    <meta property="og:image" content="{{ base_url }}{{ STATIC_URL }}img/sharing/blue_logo.png?cache-buster=10">
 
     {% block meta %}{% endblock %}
     <link href="{{ STATIC_URL }}img/favicon.ico" rel="shortcut icon" type="image/x-icon">

--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -17,13 +17,13 @@
     <meta name="twitter:site" content="@permacc">
     <meta name="twitter:title" content="Websites change. Perma Links don't.">
     <meta name="twitter:description" content="Perma.cc helps scholars, journals, courts, and others create permanent records of the web sources they cite.">
-    <meta name="twitter:image" content="{{ request.get_host }}{{ STATIC_URL }}img/create-step-4.png">
+    <meta name="twitter:image" content="{{ base_url }}{{ STATIC_URL }}img/create-step-4.png">
 
     <meta property="og:title" content="Websites change. Perma Links don't.">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Perma">
-    <meta property="og:url" content="{{ request.get_host }}">
-    <meta property="og:image" content="{{ request.get_host }}{{ STATIC_URL }}img/sharing/blue_logo.png">
+    <meta property="og:url" content="{{ base_url }}">
+    <meta property="og:image" content="{{ base_url }}{{ STATIC_URL }}img/sharing/blue_logo.png">
 
     {% block meta %}{% endblock %}
     <link href="{{ STATIC_URL }}img/favicon.ico" rel="shortcut icon" type="image/x-icon">


### PR DESCRIPTION
This is presently my only guess for why the Twitter cards for the home page, about, etc. are not displaying the intended image.

Twitter caches card info once a week, so even if this works, we shouldn't expect already-posted Tweets' cards to update any time soon. We should, however, be able to see a fresh card by making a bitly link and Tweeting about that.

If this works, we can talk about whether we want to allow Twitterbot to access playback pages as well. Either a) they didn't initially respect robots.txt for this activity, or b) we didn't notice we broke this in https://github.com/harvard-lil/perma/commit/7ea2b5d8f5f333a18caf50d3d4cea5763ad15f0f#diff-079d9f44880048d8baeeee35385e87378256a2072c951e6a6a6b4f443953f01d, about a year after https://github.com/harvard-lil/perma/commit/c21ab341621cb002a49304f384fd729d3443f9a2