### PR TITLE
Update Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       context: .
       dockerfile: ./perma_web/Dockerfile
       args:
-        chrome-layer-cache-buster: e7e1764b-1f75-490d-8705-b8ca3581c953
-    image: perma3:0.101
+        chrome-layer-cache-buster: 85392367-e81a-4048-b193-6a7a19dcf522
+    image: perma3:0.102
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -610,7 +610,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []


### PR DESCRIPTION
This updates Chrome from 90.0.4430.212 to 91.0.4472.77:

https://chromereleases.googleblog.com/2021/05/stable-channel-update-for-desktop_25.html