### PR TITLE
WIP: Run on postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
             docker-compose up -d
             sleep 15
             docker-compose exec web pipenv run flake8 .
-            docker-compose exec web pipenv run fab dev.create_db
             docker-compose exec web pipenv run fab dev.init_db
             docker-compose exec app python -m webrecorder.admin -c info@perma.cc public Test123Test123 archivist 'Info at Perma.cc'
             docker-compose exec web pipenv run pytest \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - redis_data:/data:delegated
   db:
-    image: registry.lil.tools/library/postgres:11.11
+    image: registry.lil.tools/library/postgres:12.8
     environment:
       POSTGRES_PASSWORD: password
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,17 +13,11 @@ services:
     volumes:
       - redis_data:/data:delegated
   db:
-    image: registry.lil.tools/library/mysql:5.6
+    image: registry.lil.tools/library/postgres:11.11
     environment:
-        MYSQL_ROOT_PASSWORD: password
+      POSTGRES_PASSWORD: password
     volumes:
-      # NAMED VOLUMES
-      # If the volume contains a database (a subdirectory named mysql)
-      # when you start the container, it will be left untouched and unaffected
-      # by config environment variables like $MYSQL_ROOT_PASSWORD.
-      - db3_data:/var/lib/mysql:delegated
-      # BIND MOUNTS
-      - ./services/mysql/conf.d:/etc/mysql/conf.d
+      - postgres_data:/var/lib/postgresql/data:delegated
     networks:
       - default
   web:
@@ -32,7 +26,7 @@ services:
       dockerfile: ./perma_web/Dockerfile
       args:
         chrome-layer-cache-buster: 2ef978cc-0afe-4fb1-9239-50d3b77e5ba1
-    image: perma3:0.127
+    image: perma3:0.128
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:
@@ -235,7 +229,7 @@ services:
 
 volumes:
   node_modules:
-  db3_data:
+  postgres_data:
   redis_data:
   pp_db_data:
   wr_warcs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     image: registry.lil.tools/library/postgres:12.8
     environment:
       POSTGRES_PASSWORD: password
+      POSTGRES_DB: perma
+      POSTGRES_USER: perma
     volumes:
       - postgres_data:/var/lib/postgresql/data:delegated
     networks:

--- a/init_perma.sh
+++ b/init_perma.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose exec web pipenv run fab dev.create_db
 docker-compose exec web pipenv run fab dev.init_db

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update \
     && apt-get install -y virtualenv \
     && apt-get install -y git \
     \
-    && apt-get install -y default-mysql-client \
-    && apt-get install -y default-libmysqlclient-dev \
+    && apt-get install -y postgresql-client \
+    && apt-get install -y libpq-dev \
     && apt-get install -y xvfb \
     && apt-get install -y libffi-dev \
     && apt-get install -y libjpeg62-turbo-dev \

--- a/perma_web/Pipfile
+++ b/perma_web/Pipfile
@@ -21,7 +21,7 @@ uwsgitop = "*"                              # uWSGI monitoring
 
 
 # databases
-psycopg2 = ">2.7"
+psycopg2 = ">2.7, <2.9"
 django-redis = "*"                          # use redis as django's cache backend
 redis = "*"                                 # Needed to bind with Redis.
 

--- a/perma_web/Pipfile
+++ b/perma_web/Pipfile
@@ -21,7 +21,7 @@ uwsgitop = "*"                              # uWSGI monitoring
 
 
 # databases
-mysqlclient = "*"
+psycopg2 = ">2.7"
 django-redis = "*"                          # use redis as django's cache backend
 redis = "*"                                 # Needed to bind with Redis.
 

--- a/perma_web/Pipfile.lock
+++ b/perma_web/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f63972079ea1afb5cad63481385dc721ab8ddc3fd99d902b790a18871d789574"
+            "sha256": "77985768f8614a42b62e10e71e158693d0e843072580921fe85f82b5182732bb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -63,19 +63,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1def3b3b0414915e20a543ea5f0f6dfb8fdab20819d5a7c2ce107937668d1085",
-                "sha256:9364b6310891e4ce478d8379ce114de3ede46e53beb1012cda07121e969ced5a"
+                "sha256:42dd9fcb9e033ab19c9dfaeaba745ef9d2db6efe4e9f1e1f547b3e3e0b1f4a82",
+                "sha256:e0247a901ba3b7ec51f232921764b7ad14f458ed91038a71df9da732e12bbbe1"
             ],
             "index": "pypi",
-            "version": "==1.20.27"
+            "version": "==1.20.35"
         },
         "botocore": {
             "hashes": [
-                "sha256:8dca8fb66c47b8be9a5c9d29cc4dcf0a4d28289df8cbe1a6d3df431c1f2400d6",
-                "sha256:fac6515997a7e86216a280ae57f6a80b3560ed5fb157c84e87a9341936773437"
+                "sha256:4cbd668a28e489c8d1909f621684f070309b3ae990667094b344e6ea72337795",
+                "sha256:5be6ba6c5ea71c256da8a5023bf9c278847c4b90fdb40f2c4c3bdb21ca11ff28"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.27"
+            "version": "==1.23.35"
         },
         "cachetools": {
             "hashes": [
@@ -167,11 +167,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
-                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
+                "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd",
+                "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.9"
+            "version": "==2.0.10"
         },
         "contextlib2": {
             "hashes": [
@@ -358,10 +358,10 @@
         },
         "easyprocess": {
             "hashes": [
-                "sha256:fb948daac01f64c1e49750752711253614846c6fc7e5692a718a7408f2ffb984",
-                "sha256:fca26794d3ced044d0471bd4ed767d5c287391d8a1c5e9d106fc59478b732543"
+                "sha256:a2a8de2a408e260d0fe7e2936b506b5d655bce7a8d2d19e668860d0a1c4e81b6",
+                "sha256:a454c27b6997134960f8efe8cc4667b33aa5b5382703cdf23c1784f38f1f436b"
             ],
-            "version": "==0.3"
+            "version": "==1.0"
         },
         "fabric3": {
             "hashes": [
@@ -391,7 +391,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_version >= '3'",
             "version": "==3.3"
         },
         "importlib-metadata": {
@@ -553,10 +553,10 @@
         },
         "paramiko": {
             "hashes": [
-                "sha256:a1fdded3b55f61d23389e4fe52d9ae428960ac958d2edf50373faa5d8926edd0",
-                "sha256:db5d3f19607941b1c90233588d60213c874392c4961c6297037da989c24f8070"
+                "sha256:04097dbd96871691cdb34c13db1883066b8a13a0df2afd4cb0a92221f51c2603",
+                "sha256:944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b"
             ],
-            "version": "==2.9.1"
+            "version": "==2.9.2"
         },
         "pillow": {
             "hashes": [
@@ -627,27 +627,19 @@
         },
         "pynacl": {
             "hashes": [
-                "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4",
-                "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4",
-                "sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574",
-                "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d",
-                "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634",
-                "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25",
-                "sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f",
-                "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505",
-                "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122",
-                "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7",
-                "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420",
-                "sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f",
-                "sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96",
-                "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6",
-                "sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6",
-                "sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514",
-                "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff",
-                "sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80"
+                "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858",
+                "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d",
+                "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93",
+                "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1",
+                "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92",
+                "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff",
+                "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba",
+                "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394",
+                "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b",
+                "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"
             ],
             "index": "pypi",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "pyopenssl": {
             "hashes": [
@@ -758,11 +750,11 @@
                 "security"
             ],
             "hashes": [
-                "sha256:8e5643905bf20a308e25e4c1dd379117c09000bf8a82ebccc462cfb1b34a16b5",
-                "sha256:f71a09d7feba4a6b64ffd8e9d9bc60f9bf7d7e19fd0e04362acb1cfc2e3d98df"
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
             ],
             "index": "pypi",
-            "version": "==2.27.0"
+            "version": "==2.27.1"
         },
         "requests-file": {
             "hashes": [
@@ -810,11 +802,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5c89b1a14a67ac5f0956f1cb0aeb7d1d3f4c8ba4e4e1ab7bf1af4933f9a2f0fe",
-                "sha256:675fcebecb43c32eb930481abf907619137547f4336206e4d673180242e1a278"
+                "sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe",
+                "sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==60.2.0"
+            "version": "==60.5.0"
         },
         "six": {
             "hashes": [
@@ -899,11 +891,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.7"
+            "version": "==1.26.8"
         },
         "uwsgitop": {
             "hashes": [
@@ -1118,11 +1110,11 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374",
-                "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"
+                "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
+                "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
         },
         "deprecated": {
             "hashes": [
@@ -1192,11 +1184,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:3cae408a92917fe288b0932eb3bb758f1585bf8b6e1d4ca4a666a2835c707db3",
-                "sha256:5002ce1f27fd94b53b0046ac7d20dab17fd74ebc6c90d401979588eadc46f84e"
+                "sha256:b51d1cbfd5c5d38b59435f695a1ff790c5fa7600baa59eba202a7bf8498d9043",
+                "sha256:ce3961fff61e7353d022608788cbc9876c293d2468749eeba27511adc9565131"
             ],
             "index": "pypi",
-            "version": "==6.34.1"
+            "version": "==6.35.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -1222,11 +1214,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:cb6aef731bf708a7727ab6cde8df87f0281b1427d41e65d62d4b68934fa54e97",
-                "sha256:fc60ef843e0863dd4e24ab2bb5698f071031332801ecf8d1aeb4fb622056545c"
+                "sha256:346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3",
+                "sha256:4c4234cdcc6b8f87c5b5c7af9899aa696ac5cfcf0e9f6d0688018bbee5c73bce"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.30.1"
+            "version": "==7.31.0"
         },
         "jedi": {
             "hashes": [
@@ -1380,11 +1372,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:59b895e326f0fb0d733fd28c6839bd18ad0687ba20efc26d4277fd1d30b971f4",
-                "sha256:9135c1af61eec0f650cd1ea1ed8ce298e54d56bcd8cc2ef46edd7702c171337c"
+                "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65",
+                "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.11.1"
+            "version": "==2.11.2"
         },
         "pyparsing": {
             "hashes": [
@@ -1467,11 +1459,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5c89b1a14a67ac5f0956f1cb0aeb7d1d3f4c8ba4e4e1ab7bf1af4933f9a2f0fe",
-                "sha256:675fcebecb43c32eb930481abf907619137547f4336206e4d673180242e1a278"
+                "sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe",
+                "sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==60.2.0"
+            "version": "==60.5.0"
         },
         "six": {
             "hashes": [

--- a/perma_web/Pipfile.lock
+++ b/perma_web/Pipfile.lock
@@ -527,17 +527,6 @@
             ],
             "version": "==0.6.21"
         },
-        "mysqlclient": {
-            "hashes": [
-                "sha256:02c8826e6add9b20f4cb12dcf016485f7b1d6e30356a1204d05431867a1b3947",
-                "sha256:2c8410f54492a3d2488a6a53e2d85b7e016751a1e7d116e7aea9c763f59f5e8c",
-                "sha256:973235686f1b720536d417bf0a0d39b4ab3d5086b2b6ad5e6752393428c02b12",
-                "sha256:b62d23c11c516cedb887377c8807628c1c65d57593b57853186a6ee18b0c6a5b",
-                "sha256:e6279263d5a9feca3e0edbc2b2a52c057375bf301d47da2089c075ff76331d14"
-            ],
-            "index": "pypi",
-            "version": "==2.1.0"
-        },
         "netaddr": {
             "hashes": [
                 "sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac",
@@ -606,6 +595,27 @@
             ],
             "index": "pypi",
             "version": "==9.0.0"
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:00195b5f6832dbf2876b8bf77f12bdce648224c89c880719c745b90515233301",
+                "sha256:068115e13c70dc5982dfc00c5d70437fe37c014c808acce119b5448361c03725",
+                "sha256:26e7fd115a6db75267b325de0fba089b911a4a12ebd3d0b5e7acb7028bc46821",
+                "sha256:2c93d4d16933fea5bbacbe1aaf8fa8c1348740b2e50b3735d1b0bf8154cbf0f3",
+                "sha256:56007a226b8e95aa980ada7abdea6b40b75ce62a433bd27cec7a8178d57f4051",
+                "sha256:56fee7f818d032f802b8eed81ef0c1232b8b42390df189cab9cfa87573fe52c5",
+                "sha256:6a3d9efb6f36f1fe6aa8dbb5af55e067db802502c55a9defa47c5a1dad41df84",
+                "sha256:a49833abfdede8985ba3f3ec641f771cca215479f41523e99dace96d5b8cce2a",
+                "sha256:ad2fe8a37be669082e61fb001c185ffb58867fdbb3e7a6b0b0d2ffe232353a3e",
+                "sha256:b8cae8b2f022efa1f011cc753adb9cbadfa5a184431d09b273fb49b4167561ad",
+                "sha256:d160744652e81c80627a909a0e808f3c6653a40af435744de037e3172cf277f5",
+                "sha256:d5062ae50b222da28253059880a871dc87e099c25cb68acf613d9d227413d6f7",
+                "sha256:f22ea9b67aea4f4a1718300908a2fb62b3e4276cf00bd829a97ab5894af42ea3",
+                "sha256:f974c96fca34ae9e4f49839ba6b78addf0346777b46c4da27a7bf54f48d3057d",
+                "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"
+            ],
+            "index": "pypi",
+            "version": "==2.8.6"
         },
         "pycparser": {
             "hashes": [

--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from perma.models import LinkUser, Folder, CaptureJob, Capture, Link, Organization, LinkBatch
 from perma.utils import ip_in_allowed_ip_range
 
-from .utils import get_mime_type, mime_type_lookup, url_is_invalid_unicode, reverse_api_view
+from .utils import get_mime_type, mime_type_lookup, reverse_api_view
 
 import logging
 logger = logging.getLogger(__name__)
@@ -204,10 +204,6 @@ class AuthenticatedLinkSerializer(LinkSerializer):
         url = url.strip()
         if url and url[:4] != 'http':
             url = 'http://' + url
-
-        # Somehow it's possible for some control characters to get to the server
-        if url_is_invalid_unicode(url):
-            raise serializers.ValidationError({'url': "Unicode error while processing URL."})
         return url
 
     def validate(self, data):

--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -224,7 +224,7 @@ class LinkAuthorizationTestCase(LinkAuthorizationMixin, ApiResourceTestCase):
         # Make sure it's listed in the folder
         obj = self.successful_get("{0}/{1}".format(self.list_url, link.pk), user=user)
         data = self.successful_get(archives_url, user=user)
-        self.assertIn(obj, data['objects'])
+        self.assertIn(obj['guid'], [obj['guid'] for obj in data['objects']])
 
     def rejected_link_move(self, user, link, folder, expected_status_code=401):
         folder_url = "{0}/folders/{1}".format(self.url_base, folder.pk)

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -170,14 +170,9 @@ def logs(log_dir=os.path.join(settings.PROJECT_ROOT, '../services/logs/')):
 
 
 @task
-def create_db(host='db', user='root', password='password'):
-    local(f"mysql -h {host} -u{user} -p{password} -e 'create database perma character set utf8;'")
-
-
-@task
 def init_db():
     """
-        Run syncdb, apply migrations, and import fixtures for new dev database.
+        Apply migrations and import fixtures for new dev database.
     """
     local("python manage.py migrate")
     local("python manage.py loaddata fixtures/sites.json fixtures/users.json fixtures/folders.json")

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -159,7 +159,7 @@ class FasterAdminPaginator(Paginator):
     @cached_property
     def count(self):
         cursor = connection.cursor()
-        cursor.execute(f"SELECT table_rows FROM information_schema.tables WHERE table_name = '{self.object_list.query.model._meta.db_table}'")
+        cursor.execute(f"SELECT reltuples AS estimate FROM pg_class WHERE relname = '{self.object_list.query.model._meta.db_table}';")
         estimate = int(cursor.fetchone()[0])
         if estimate > 10000:
             self.estimated_count = True

--- a/perma_web/perma/apps.py
+++ b/perma_web/perma/apps.py
@@ -12,21 +12,3 @@ class PermaConfig(AppConfig):
     def ready(self):
         # register our signals
         from . import signals  # noqa
-
-        # check timezone config
-        from django.db import connection
-        cursor = connection.cursor()
-        cursor.execute("SELECT CONVERT_TZ('2004-01-01 12:00:00','UTC','UTC')")
-        if cursor.fetchone()[0] is None:
-            print("""
-Mysql does not have the UTC time zone configured! Some date queries will not work.
-Please run the following as the mysql root user on the database named `mysql`:
-
-    INSERT INTO time_zone (Use_leap_seconds) VALUES ('N');
-    SET @time_zone_id= LAST_INSERT_ID();
-    INSERT INTO time_zone_name (Name, Time_zone_id) VALUES ('UTC', @time_zone_id);
-    INSERT INTO time_zone_transition_type (Time_zone_id, Transition_type_id, Offset, Is_DST, Abbreviation) VALUES
-     (@time_zone_id, 0, 0, 0, 'UTC');
-""")
-
-

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -10,22 +10,14 @@ SERVICES_DIR = os.path.abspath(os.path.join(PROJECT_ROOT, '../services'))
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'perma',                      # Or path to database file if using sqlite3.
-        'USER': 'perma',
-        'PASSWORD': 'perma',
-        'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '3306',                      # Set to empty string for default.
-        'OPTIONS': {
-            "init_command": "SET default_storage_engine=INNODB; SET NAMES 'utf8';",
-            "charset": "utf8",
-        }
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'PASSWORD': 'password',
+        'HOST': 'db',
+        'PORT': 5432,
     },
 }
-if os.environ.get('DOCKERIZED'):
-    DATABASES['default']['USER'] = 'root'
-    DATABASES['default']['PASSWORD'] = 'password'
-    DATABASES['default']['HOST'] = 'db'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -11,8 +11,8 @@ SERVICES_DIR = os.path.abspath(os.path.join(PROJECT_ROOT, '../services'))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'postgres',
+        'NAME': 'perma',
+        'USER': 'perma',
         'PASSWORD': 'password',
         'HOST': 'db',
         'PORT': 5432,

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -882,7 +882,7 @@ def clean_up_failed_captures():
     """
     # use database time with a custom where clause to ensure consistent time across workers
     for capture_job in CaptureJob.objects.filter(status='in_progress').select_related('link').extra(
-            where=[f"capture_start_time < now() - INTERVAL {settings.CELERY_TASK_TIME_LIMIT} second"]
+        where=[f"capture_start_time < now() - make_interval(secs => {settings.CELERY_TASK_TIME_LIMIT})"]
     ):
         capture_job.mark_failed("Timed out.")
         capture_job.link.captures.filter(status='pending').update(status='failed')

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -132,7 +132,9 @@ def stats(request, stat_type=None):
         out = {
             'users_by_domain': list(LinkUser.objects
                 .filter(is_confirmed=True)
-                .annotate(domain=RawSQL("SUBSTRING_INDEX(email, '.', -1)",[]))
+                # Postgres doesn't presently let you extract the last element of a split cleanly:
+                # technique from https://www.postgresql-archive.org/split-part-for-the-last-element-td6159483.html
+                .annotate(domain=RawSQL("reverse(split_part(reverse(lower(email)), '.', 1))", []))
                 .values('domain')
                 .annotate(count=Count('domain'))
                 .order_by('-count')


### PR DESCRIPTION
## Motivation
Everything else at LIL runs on postgres, and it would be really nice to not have this one outlier, so that expertise we gain and utils we make/discover on one project can be used by all of them.... not "all of them except Perma".... Postgres also has some really nice features, like server-side cursors, that I think we could benefit from. But, most immediately.... early this year, we uncovered some queries that brought the DB to its knees because of the query analyzer choosing a poor strategy. We worked around by tweaking our use of the ORM to force subqueries, etc., but got to wondering what the queries would look like on the most recent MySQL or postgres...

This summer, we will have to upgrade to a more recent MySQL anyway, so I decided to dig in and see what moving to postgres instead would look like.

## Adventures with `dumpdata` (abandoned)
Jack suggested, "switching DBs in django can potentially be really easy by freeriding on dumpdata/loaddata," and pointed to https://stackoverflow.com/a/30129025/307769.

I gave that a try on my laptop using a dump of the prod data, and Ben also gave it a try on his high-powered desktop.

It turns out we probably just have too much data to make that approach feasible. 

### RAM

Even on Ben's high-powered desktop, the dumping process eventually started consuming so much RAM that the kernel killed the process. This turns out to be due to the way JSON serialization is handled. In Django 3.2, they added the ability to dump to JSONL instead, to solve exactly this problem. I'm not ready to upgrade our whole app to 3.2 at this point, but I was able to get it to the point where the dumpdata command could be run. And sure enough, that does fix the RAM problem: the dump can proceed to the end. 

If we went in this direction, the dumping and loading would have to take place on otherwise incompletely functional, specially-crafted Perma running 3.2, with the associated handful of changes to the codebase. Doable, but more than a little weird.

### Speed

The dumping process is slow. 

I did a bunch of experimentation locally, to see if I could identify what was slowest, and/or reduce the problem to steps that could run in parallel, and/or speed up the process. (Note for future self: if you experiment with this again, make sure you dump the data file to a Docker volume, not to a directory mounted on the host, and make sure your installation of Docker has lots of space left by deleting unneeded images and volumes beforehand. Otherwise, this will bork and/or be much much slower and resource intensive.)

Discoveries:

- you can use 3.2's gzip compression without a significant effect on timing or performance

- running with `--natural-foreign` is, for models with a large number of rows, impossibly slow and resource intensive. With `natural-foreign`, Django produces output like `"created_by": ["user@example.edu"]` instead of "created_by": [1]. Now, is that just because, again, I'm missing the right kind of index? I think it's just because joining huge tables is expensive. My attempt to export the capturejob model with natural keys as per the StackOverflow post was clearly taking too long: only 8.6M of output after 19m48.283s, so I stopped it. Without natural keys, I dumped the whole model (105M of output) in 8m42.494s. so if go in this direction, we're going to have to make sure we can set primary keys during the load step.... or go through some heinous "old pk vs new pk" mapping step.

- i was able to export most of the models this way without running into trouble. interestingly, the time to export was -not- 100% due to the size of the table or number of rows: the number and of relationships mattered hugely, especially many-to-many relationships. i was never able to export Link satisfactorily. it used a ton of resources and took hours. This invocation: `time pipenv run ./manage.py dumpdata perma.Link --all --format jsonl --output /tmp/experiment/link.jsonl.gz --verbosity 1` took 101m49.119s. If I commented out the folder m2m field in the model, it took 22m43.915s. Is that just because, again, I'm missing an index or something? Maybe. The tags m2m field doesn't seem to add any measurable time... but then again, there aren't really many tags or tagged links, where are there are lots and lots of folders.

If there were a good way to just have it dump each TABLE, separately, and not worry about any relationships or anything, that might help.... but there isn't. For instance, you can't get it to serialize the m2m tables by themselves. 

I thought about looking at the dump- and loaddata code, and seeing what it might take to change that.... but then decided I'd like to explore other approaches instead. Even if optimized, this approach would seem to take many hours, probably a full day or more of downtime after all is said and done, and there were unresolved mysteries about foreign keys.... so I wanted to see if there was a better approach. 

## Adventures with `pgloader`, part 1

I somehow ran across [pgloader](https://github.com/dimitri/pgloader), a program that you wire up to MySQL and Postgres at the same time. 
> Its main advantage over just using COPY or \copy, and over using a Foreign Data Wrapper, is its transaction behaviour, where pgloader will keep a separate file of rejected data, but continue trying to copy good data in your database.

### Process

Since my local dev environment runs in Docker, I added a new container from the `dimitri/pgloader` image, and then manually `apt-get update && apt-get install -y default-mysql-client postgresql-client` inside the running container. (It would have been better to make a Dockerfile and use `FROM`, but I didn't bother...). If we go with this approach in real life, I don't think we want to get Docker involved: I think having another layer of resource limits etc. between us and the running process is probably too confusing: if it's too slow we can run on a bigger box without having to worry about Docker config.... I think? But, we'll just want to make sure we install, then, the same version that's used in the experiments.

I first ran with `pgloader mysql://root:password@db/perma postgresql://postgres:password@postgres/postgres`, but it exploded into LDB (Lisp debugger) with a gruesome `Heap, exhausted, game over.` In relevant Github issues, the maintainer suggested limiting the number of rows handled at a time; I tried `--with "prefetch rows = 1000"`, picking 1000 for no particular reason... and that seemed to do the job. Next, I filled up all the space my computer permits Docker to use, and while misdiagnosing that, also ran with `--with "prefetch rows = 1000" --with "batch size = 5MB" --with "batch rows = 1000" `, which I -think- is also what I eventually ran successfully with... but in any case, we'll want to see how we can tune those to affect performance. I think we can also increase parallelization... TODO!

I believe that I saw no error messages or warning on the successful run other than:
```
2021-05-27T21:27:09.179000Z WARNING PostgreSQL warning: identifier "idx_16507_perma_historicallinku_pending_registrar_id_7c33fc376c6bccd5_uniq" will be truncated to "idx_16507_perma_historicallinku_pending_registrar_id_7c33fc376c"
2021-05-27T21:27:09.217000Z WARNING PostgreSQL warning: identifier "idx_16507_perma_historicallinkuser_sponsored_root_folder_id_a83fef7e" will be truncated to "idx_16507_perma_historicallinkuser_sponsored_root_folder_id_a83"
2021-05-27T21:31:28.942000Z WARNING PostgreSQL warning: identifier "idx_16492_perma_folder_sponsored_by_id_0328a0ef_fk_perma_registrar_id" will be truncated to "idx_16492_perma_folder_sponsored_by_id_0328a0ef_fk_perma_regist"
2021-05-27T21:32:30.072000Z WARNING PostgreSQL warning: identifier "idx_16483_perma_capturejob_created_by_id_28ab42a6_fk_perma_linkuser_id" will be truncated to "idx_16483_perma_capturejob_created_by_id_28ab42a6_fk_perma_link"
2021-05-27T21:32:30.086000Z WARNING PostgreSQL warning: identifier "idx_16483_perma_capturejob_link_batch_id_376ac3f7_fk_perma_linkbatch_id" will be truncated to "idx_16483_perma_capturejob_link_batch_id_376ac3f7_fk_perma_link"
2021-05-27T21:33:56.824000Z WARNING PostgreSQL warning: identifier "idx_16546_perma_linkuser_pending_registrar_id_78efd14c078d4f4b_uniq" will be truncated to "idx_16546_perma_linkuser_pending_registrar_id_78efd14c078d4f4b_"
2021-05-27T21:33:57.575000Z WARNING PostgreSQL warning: identifier "idx_16501_perma_generic_content_type_id_7808e6af_fk_django_content_type_id" will be truncated to "idx_16501_perma_generic_content_type_id_7808e6af_fk_django_cont"
2021-05-27T21:33:57.594000Z WARNING PostgreSQL warning: identifier "idx_16501_perma_genericstringtaggeditem_tag_id_859dfb15_fk_taggit_tag_id" will be truncated to "idx_16501_perma_genericstringtaggeditem_tag_id_859dfb15_fk_tagg"
2021-05-27T21:33:58.093000Z WARNING PostgreSQL warning: identifier "idx_16540_perma_linkbatch_created_by_id_f5908521_fk_perma_linkuser_id" will be truncated to "idx_16540_perma_linkbatch_created_by_id_f5908521_fk_perma_linku"
2021-05-27T21:33:58.152000Z WARNING PostgreSQL warning: identifier "idx_16540_perma_linkbatch_target_folder_id_8b403a0c_fk_perma_folder_id" will be truncated to "idx_16540_perma_linkbatch_target_folder_id_8b403a0c_fk_perma_fo"
2021-05-27T21:33:58.207000Z WARNING PostgreSQL warning: identifier "idx_16615_taggit_taggeditem_content_type_id_object_id_tag_id_4bb97a8e_uniq" will be truncated to "idx_16615_taggit_taggeditem_content_type_id_object_id_tag_id_4b"
2021-05-27T21:33:58.400000Z WARNING PostgreSQL warning: identifier "idx_16588_perma_sponsorship_user_id_a83fd48c_fk_perma_linkuser_id" will be truncated to "idx_16588_perma_sponsorship_user_id_a83fd48c_fk_perma_linkuser_"
2021-05-27T21:33:58.426000Z WARNING PostgreSQL warning: identifier "idx_16588_perma_sponsorship_created_by_id_837d3014_fk_perma_linkuser_id" will be truncated to "idx_16588_perma_sponsorship_created_by_id_837d3014_fk_perma_lin"
2021-05-27T21:34:08.588000Z WARNING PostgreSQL warning: identifier "perma__organization_id_35ecbcbadca23b5b_fk_perma_organization_id" will be truncated to "perma__organization_id_35ecbcbadca23b5b_fk_perma_organization_i"
2021-05-27T21:34:09.769000Z WARNING PostgreSQL warning: identifier "perma_l_organization_id_22f7770040eab4d_fk_perma_organization_id" will be truncated to "perma_l_organization_id_22f7770040eab4d_fk_perma_organization_i"
2021-05-27T21:34:10.593000Z WARNING PostgreSQL warning: identifier "perm_pending_registrar_id_78efd14c078d4f4b_fk_perma_registrar_id" will be truncated to "perm_pending_registrar_id_78efd14c078d4f4b_fk_perma_registrar_i"
2021-05-27T21:34:10.697000Z WARNING PostgreSQL warning: identifier "perma_link_folders_folder_id_3990585c41a8789e_fk_perma_folder_id" will be truncated to "perma_link_folders_folder_id_3990585c41a8789e_fk_perma_folder_i"
2021-05-27T21:34:14.203000Z WARNING PostgreSQL warning: identifier "perma_organi_registrar_id_7fbd00eaad6de725_fk_perma_registrar_id" will be truncated to "perma_organi_registrar_id_7fbd00eaad6de725_fk_perma_registrar_i"
```

That's good to know. Django needs to know the names of indices verbatim, so some work to do here. TODO.

It went SO much faster, completing the job in the time it took `dumpdata` to dump one largish model:
```
2021-05-27T21:34:14.243000Z LOG report summary reset
                         table name     errors       rows      bytes      total time
-----------------------------------  ---------  ---------  ---------  --------------
                    fetch meta data          0        179                     0.301s
                     Create Schemas          0          0                     0.006s
                   Create SQL Types          0          0                     0.006s
                      Create tables          0         64                     0.209s
                     Set Table OIDs          0         32                     0.005s
-----------------------------------  ---------  ---------  ---------  --------------
                perma.perma_capture          0    5735284   638.5 MB       2m23.338s
     perma.perma_historicallinkuser          0    2954323   749.8 MB       2m42.889s
               perma.django_session          0    2954916   958.2 MB       3m11.896s
            perma.perma_minutestats          0    2269812    76.9 MB       1m15.246s
           perma.perma_link_folders          0    2271629    51.0 MB        1m8.101s
    perma.perma_historicalregistrar          0    1954051   509.1 MB       1m44.439s
                   perma.perma_link          0    2263858   830.9 MB       2m18.016s
 perma.perma_historicalorganization          0    1790965   185.5 MB        1m6.690s
             perma.perma_capturejob          0    2033839   360.6 MB       1m25.883s
                 perma.perma_folder          0      95643     8.5 MB          5.976s
 perma.perma_linkuser_organizations          0      19825   302.7 kB          1.248s
               perma.axes_accesslog          0      17502     5.3 MB          2.638s
             perma.django_admin_log          0       3597   307.7 kB          1.229s
              perma.perma_registrar          0        684   147.7 kB          0.415s
              perma.perma_weekstats          0        343    18.9 kB          0.597s
              perma.auth_permission          0        162     7.1 kB          1.185s
          perma.django_content_type          0         44     0.9 kB          1.268s
                   perma.taggit_tag          0         23     0.6 kB          1.368s
                perma.lockss_mirror          0          4     0.4 kB          1.521s
           perma.axes_accessattempt          0          1     0.5 kB          1.746s
          perma.perma_uncaughterror          0     819810   929.4 MB       1m23.780s
               perma.perma_linkuser          0      55265    11.1 MB          3.032s
perma.perma_genericstringtaggeditem          0      18374   348.0 kB          1.199s
              perma.perma_linkbatch          0      16603   716.9 kB          0.550s
           perma.perma_organization          0       2247   151.8 kB          0.189s
                 perma.perma_apikey          0        630    43.4 kB          0.073s
            perma.taggit_taggeditem          0        197     2.1 kB          0.048s
            perma.django_migrations          0        102     5.3 kB          0.148s
            perma.perma_sponsorship          0         35     2.7 kB          0.154s
                   perma.auth_group          0          4     0.1 kB          0.125s
       perma.auth_group_permissions          0          0                     0.088s
                  perma.django_site          0          1     0.0 kB          0.094s
-----------------------------------  ---------  ---------  ---------  --------------
            COPY Threads Completion          0          4                 11m55.322s
                     Create Indexes          0        115                 12m40.515s
             Index Build Completion          0        115                     1.266s
                    Reset Sequences          0         30                     0.127s
                       Primary Keys          0         32                     0.068s
                Create Foreign Keys          0         32                    14.314s
                    Create Triggers          0          0                     0.002s
                    Set Search Path          0          1                     0.005s
                   Install Comments          0          0                     0.000s
-----------------------------------  ---------  ---------  ---------  --------------
                  Total import time          ?   25279773     5.2 GB      24m51.619s
```
So, this is clearly the way we want to go.

## Get Perma working with postgres

A few small changes were necessary to get Perma working with that new, populated database.
- install the postgres adapter and dev package instead of the equivalent mysql ones, and update the python packages
- remove some mysql-specific checks about timezones before app startup, which I assume is okay because no other LIL projects have them
- find the places where we are hard-coding SQL instead of using the ORM, and translate them from MySQL-flavored SQL to postgres-flavored SQL.
- fix a [test that expected a Link's capture objects to return in a particular order](https://github.com/harvard-lil/perma/pull/2933/files#diff-c707b555b92894f8aa21df4e3968a1609e61db9b247f7fe35eff76840b61b10f), which doesn't matter

- and finally.... an interesting fix. We have had code that checks for the presence of control characters in URLs for a long while, after we learned that we had some and had trouble with that somewhere down the line, a story mostly lost to history. (I think the trouble might have been w/ IA upload for the links in question? or in making memento headers? not sure, and can't find details). but since then, we have started storing the target URL in the CaptureJob table too, since we now make CaptureJobs for invalid submissions too. that means that table could have the bad chars. our test against bad chars broke because postgress refused the character when creating the CaptureJob object, rather than... whatever MySQL does. so, I moved the check from Link validation to the CaptureJob creation code.

That's fine, but I think that means I should carefully examine the contents of the URL field in both DBs, and see what happened during the port.

## How confident am I that this worked?

I was still logged in, with Perma talking to the postgres DB: pretty darn cool. That's pretty good evidence that foreign key relationships are intact.

I clicked around a little, made a couple captures, looked at a couple playbacks, and they seemed fine. I didn't do anything thorough or systematic.

Tests are all passing, locally and on CircleCI and on TravisCI, run against a fresh DB.

## Adventures with `pgloader`, part 2

See https://github.com/rebeccacremona/perma/compare/to-postgres...rebeccacremona:pgloader?expand=1

Let's have Django create the tables from our new squashed migration, along with any indices and constraints it wants, and then just load the data in. I think that means everything but the migration table.

### Casting

#### Integers

All 30 Django-produced `id` fields emit a casting warning:

```
+-------------------------------+-------------+-----------+-------------------+
| TABLE_NAME                    | COLUMN_NAME | DATA_TYPE | NUMERIC_PRECISION |
+-------------------------------+-------------+-----------+-------------------+
| auth_group                    | id          | int       |                10 |
| auth_group_permissions        | id          | int       |                10 |
| auth_permission               | id          | int       |                10 |
| axes_accessattempt            | id          | int       |                10 |
| axes_accesslog                | id          | int       |                10 |
| django_admin_log              | id          | int       |                10 |
| django_content_type           | id          | int       |                10 |
| django_migrations             | id          | int       |                10 |
| django_site                   | id          | int       |                10 |
| lockss_mirror                 | id          | int       |                10 |
| perma_apikey                  | id          | int       |                10 |
| perma_capture                 | id          | int       |                10 |
| perma_capturejob              | id          | int       |                10 |
| perma_folder                  | id          | int       |                10 |
| perma_genericstringtaggeditem | id          | int       |                10 |
| perma_historicallinkuser      | id          | int       |                10 |
| perma_historicalorganization  | id          | int       |                10 |
| perma_historicalregistrar     | id          | int       |                10 |
| perma_linkbatch               | id          | int       |                10 |
| perma_linkuser                | id          | int       |                10 |
| perma_linkuser_organizations  | id          | int       |                10 |
| perma_link_folders            | id          | int       |                10 |
| perma_minutestats             | id          | int       |                10 |
| perma_organization            | id          | int       |                10 |
| perma_registrar               | id          | int       |                10 |
| perma_sponsorship             | id          | int       |                10 |
| perma_uncaughterror           | id          | int       |                10 |
| perma_weekstats               | id          | int       |                10 |
| taggit_tag                    | id          | int       |                10 |
| taggit_taggeditem             | id          | int       |                10 |
+-------------------------------+-------------+-----------+-------------------+
30 rows in set (0.00 sec)

2022-01-07T23:37:59.644000Z WARNING Source column "perma"."auth_group"."id" is casted to type "bigserial" which is not the same as "integer", the type of current target database column "perma"."auth_group"."id".
...
```
All 49 int foreign keys produce a similar warning:

```
+-------------------------------+--------------------------+-----------+-------------------+
| TABLE_NAME                    | COLUMN_NAME              | DATA_TYPE | NUMERIC_PRECISION |
+-------------------------------+--------------------------+-----------+-------------------+
| auth_group_permissions        | group_id                 | int       |                10 |
| auth_group_permissions        | permission_id            | int       |                10 |
| auth_permission               | content_type_id          | int       |                10 |
| django_admin_log              | user_id                  | int       |                10 |
| django_admin_log              | content_type_id          | int       |                10 |
| perma_apikey                  | user_id                  | int       |                10 |
| perma_capturejob              | link_batch_id            | int       |                10 |
| perma_capturejob              | created_by_id            | int       |                10 |
| perma_folder                  | sponsored_by_id          | int       |                10 |
| perma_folder                  | organization_id          | int       |                10 |
| perma_folder                  | owned_by_id              | int       |                10 |
| perma_folder                  | tree_id                  | int       |                10 |
| perma_folder                  | created_by_id            | int       |                10 |
| perma_folder                  | parent_id                | int       |                10 |
| perma_genericstringtaggeditem | content_type_id          | int       |                10 |
| perma_genericstringtaggeditem | tag_id                   | int       |                10 |
| perma_historicallinkuser      | sponsored_root_folder_id | int       |                10 |
| perma_historicallinkuser      | root_folder_id           | int       |                10 |
| perma_historicallinkuser      | registrar_id             | int       |                10 |
| perma_historicallinkuser      | history_user_id          | int       |                10 |
| perma_historicallinkuser      | history_id               | int       |                10 |
| perma_historicallinkuser      | pending_registrar_id     | int       |                10 |
| perma_historicalorganization  | shared_folder_id         | int       |                10 |
| perma_historicalorganization  | registrar_id             | int       |                10 |
| perma_historicalorganization  | history_user_id          | int       |                10 |
| perma_historicalorganization  | history_id               | int       |                10 |
| perma_historicalregistrar     | history_id               | int       |                10 |
| perma_historicalregistrar     | history_user_id          | int       |                10 |
| perma_link                    | organization_id          | int       |                10 |
| perma_link                    | created_by_id            | int       |                10 |
| perma_linkbatch               | created_by_id            | int       |                10 |
| perma_linkbatch               | target_folder_id         | int       |                10 |
| perma_linkuser                | sponsored_root_folder_id | int       |                10 |
| perma_linkuser                | pending_registrar_id     | int       |                10 |
| perma_linkuser                | root_folder_id           | int       |                10 |
| perma_linkuser                | registrar_id             | int       |                10 |
| perma_linkuser_organizations  | linkuser_id              | int       |                10 |
| perma_linkuser_organizations  | organization_id          | int       |                10 |
| perma_link_folders            | folder_id                | int       |                10 |
| perma_organization            | registrar_id             | int       |                10 |
| perma_organization            | shared_folder_id         | int       |                10 |
| perma_sponsorship             | user_id                  | int       |                10 |
| perma_sponsorship             | registrar_id             | int       |                10 |
| perma_sponsorship             | created_by_id            | int       |                10 |
| perma_uncaughterror           | resolved_by_user_id      | int       |                10 |
| perma_uncaughterror           | user_id                  | int       |                10 |
| taggit_taggeditem             | object_id                | int       |                10 |
| taggit_taggeditem             | content_type_id          | int       |                10 |
| taggit_taggeditem             | tag_id                   | int       |                10 |
+-------------------------------+--------------------------+-----------+-------------------+
49 rows in set (0.01 sec)

2022-01-07T23:37:59.645000Z WARNING Source column "perma"."auth_group_permissions"."group_id" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."auth_group_permissions"."group_id".
...
```

There are 28 other integers in the database:
```
2022-01-07T23:37:59.649000Z WARNING Source column "perma"."axes_accessattempt"."failures_since_start" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."axes_accessattempt"."failures_since_start".
2022-01-07T23:37:59.651000Z WARNING Source column "perma"."lockss_mirror"."peer_port" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."lockss_mirror"."peer_port".
2022-01-07T23:37:59.655000Z WARNING Source column "perma"."perma_folder"."lft" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_folder"."lft".
2022-01-07T23:37:59.655000Z WARNING Source column "perma"."perma_folder"."rght" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_folder"."rght".
2022-01-07T23:37:59.656000Z WARNING Source column "perma"."perma_folder"."level" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_folder"."level".
2022-01-07T23:37:59.660000Z WARNING Source column "perma"."perma_historicallinkuser"."link_count" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicallinkuser"."link_count".
2022-01-07T23:37:59.660000Z WARNING Source column "perma"."perma_historicallinkuser"."link_limit" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicallinkuser"."link_limit".
2022-01-07T23:37:59.661000Z WARNING Source column "perma"."perma_historicallinkuser"."bonus_links" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicallinkuser"."bonus_links".
2022-01-07T23:37:59.662000Z WARNING Source column "perma"."perma_historicalorganization"."link_count" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicalorganization"."link_count".
2022-01-07T23:37:59.664000Z WARNING Source column "perma"."perma_historicalregistrar"."bonus_links" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicalregistrar"."bonus_links".
2022-01-07T23:37:59.664000Z WARNING Source column "perma"."perma_historicalregistrar"."link_count" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicalregistrar"."link_count".
2022-01-07T23:37:59.664000Z WARNING Source column "perma"."perma_historicalregistrar"."link_limit" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_historicalregistrar"."link_limit".
2022-01-07T23:37:59.665000Z WARNING Source column "perma"."perma_link"."warc_size" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_link"."warc_size".
2022-01-07T23:37:59.667000Z WARNING Source column "perma"."perma_linkuser"."link_count" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_linkuser"."link_count".
2022-01-07T23:37:59.667000Z WARNING Source column "perma"."perma_linkuser"."link_limit" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_linkuser"."link_limit".
2022-01-07T23:37:59.668000Z WARNING Source column "perma"."perma_linkuser"."bonus_links" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_linkuser"."bonus_links".
2022-01-07T23:37:59.670000Z WARNING Source column "perma"."perma_minutestats"."links_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_minutestats"."links_sum".
2022-01-07T23:37:59.671000Z WARNING Source column "perma"."perma_minutestats"."organizations_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_minutestats"."organizations_sum".
2022-01-07T23:37:59.671000Z WARNING Source column "perma"."perma_minutestats"."registrars_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_minutestats"."registrars_sum".
2022-01-07T23:37:59.671000Z WARNING Source column "perma"."perma_minutestats"."users_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_minutestats"."users_sum".
2022-01-07T23:37:59.672000Z WARNING Source column "perma"."perma_organization"."link_count" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_organization"."link_count".
2022-01-07T23:37:59.673000Z WARNING Source column "perma"."perma_registrar"."bonus_links" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_registrar"."bonus_links".
2022-01-07T23:37:59.673000Z WARNING Source column "perma"."perma_registrar"."link_count" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_registrar"."link_count".
2022-01-07T23:37:59.673000Z WARNING Source column "perma"."perma_registrar"."link_limit" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_registrar"."link_limit".
2022-01-07T23:37:59.675000Z WARNING Source column "perma"."perma_weekstats"."links_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_weekstats"."links_sum".
2022-01-07T23:37:59.675000Z WARNING Source column "perma"."perma_weekstats"."organizations_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_weekstats"."organizations_sum".
2022-01-07T23:37:59.675000Z WARNING Source column "perma"."perma_weekstats"."users_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_weekstats"."users_sum".
2022-01-07T23:37:59.676000Z WARNING Source column "perma"."perma_weekstats"."registrars_sum" is casted to type "bigint" which is not the same as "integer", the type of current target database column "perma"."perma_weekstats"."registrars_sum".
```

With no intervention, these all ended up in postgres as:
```
|        data_type         | numeric_precision 
+--------------------------+-------------------
| integer                  |                32
```

That seems fine; I'll try adding a rule that just says to cast all mysq `int` to postgres `integer`. ("bigserial should be used if you anticipate the use of more than 2^31 (2,147,483,648) identifiers over the lifetime of the table."

#### Integer vs serial

I wonder why the primary keys aren't `serial` type?

The docs say we would expect it to be `serial` https://docs.djangoproject.com/en/2.2/ref/databases/#manually-specifying-values-of-auto-incrementing-primary-keys. So does the source: https://github.com/django/django/blob/2.2.26/django/db/backends/postgresql/base.py#L69

Auto fields are `integer` here, and perma payments, and capstone, so clearly this is fine. I can see that all the necesary sequences are there: 
```
                            List of relations
 Schema |                    Name                     |   Type   | Owner 
--------+---------------------------------------------+----------+-------
 public | auth_group_id_seq                           | sequence | perma
 public | auth_group_permissions_id_seq               | sequence | perma
 public | auth_permission_id_seq                      | sequence | perma
 public | axes_accessattempt_id_seq                   | sequence | perma
 public | axes_accesslog_id_seq                       | sequence | perma
 public | django_admin_log_id_seq                     | sequence | perma
 public | django_content_type_id_seq                  | sequence | perma
 public | django_migrations_id_seq                    | sequence | perma
 public | django_site_id_seq                          | sequence | perma
 public | lockss_mirror_id_seq                        | sequence | perma
 public | perma_apikey_id_seq                         | sequence | perma
 public | perma_capture_id_seq                        | sequence | perma
 public | perma_capturejob_id_seq                     | sequence | perma
 public | perma_folder_id_seq                         | sequence | perma
 public | perma_genericstringtaggeditem_id_seq        | sequence | perma
 public | perma_historicallink_history_id_seq         | sequence | perma
 public | perma_historicallinkuser_history_id_seq     | sequence | perma
 public | perma_historicalorganization_history_id_seq | sequence | perma
 public | perma_historicalregistrar_history_id_seq    | sequence | perma
 public | perma_link_folders_id_seq                   | sequence | perma
 public | perma_linkbatch_id_seq                      | sequence | perma
 public | perma_linkuser_id_seq                       | sequence | perma
 public | perma_linkuser_organizations_id_seq         | sequence | perma
 public | perma_minutestats_id_seq                    | sequence | perma
 public | perma_organization_id_seq                   | sequence | perma
 public | perma_registrar_id_seq                      | sequence | perma
 public | perma_sponsorship_id_seq                    | sequence | perma
 public | perma_uncaughterror_id_seq                  | sequence | perma
 public | perma_weekstats_id_seq                      | sequence | perma
 public | taggit_tag_id_seq                           | sequence | perma
 public | taggit_taggeditem_id_seq                    | sequence | perma
(31 rows)
```
(extra row = for historical link table, which I dropped from mysql locally during earlier explorations)

The output of `./manage.py sqlmigrate perma 0001_squashed_0068_auto_20210525_1643` says things like:
```
CREATE TABLE "perma_registrar" ("id" serial NOT NULL PRIMARY KEY...
```

If I run `CREATE TABLE "perma_test" ("id" serial NOT NULL PRIMARY KEY);` manually in psql and then check that column's data type..... it's `integer`!! So okay, whatever, this is clearly fine.

I'll just extra make sure we are resetting the sequences, after loading all this data in. (It's the default, but I'm putting that arg in just for good measure.)

#### IP addresses

There are two IP addresses
```
2022-01-07T23:37:59.648000Z WARNING Source column "perma"."axes_accessattempt"."ip_address" is casted to type "char" which is not the same as "inet", the type of current target database column "perma"."axes_accessattempt"."ip_address".
2022-01-07T23:37:59.649000Z WARNING Source column "perma"."axes_accesslog"."ip_address" is casted to type "char" which is not the same as "inet", the type of current target database column "perma"."axes_accesslog"."ip_address".
```

#### Internal Django flag
```
2022-01-07T23:37:59.650000Z WARNING Source column "perma"."django_admin_log"."action_flag" is casted to type "integer" which is not the same as "smallint", the type of current target database column "perma"."django_admin_log"."action_flag".
```


### Warnings about absent constraints

At the beginning of the migration, I see 42 rows of warnings like, "WARNING PostgreSQL warning: constraint "auth_group_permissions_group_id_b120cbf9_fk_auth_group_id" of relation "auth_group_permissions" does not exist, skipping."

I'm not really sure what it's saying, but I can't see that there is a problem.

A freshly migrated postgres db popped up by Django DOES have those constraints:

```
perma=# SELECT con.*
perma-#        FROM pg_catalog.pg_constraint con
perma-#             INNER JOIN pg_catalog.pg_class rel
perma-#                        ON rel.oid = con.conrelid
perma-#             INNER JOIN pg_catalog.pg_namespace nsp
perma-#                        ON nsp.oid = connamespace
perma-#        WHERE nsp.nspname = 'public'
perma-#              AND rel.relname = 'auth_group_permissions';

  oid  |                           conname                           | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | conexclop | conbin 
-------+-------------------------------------------------------------+--------------+---------+---------------+-------------+--------------+----------+----------+----------+-------------+-----------+-------------+-------------+---------------+------------+-------------+--------------+--------+---------+-----------+-----------+-----------+-----------+--------
 16958 | auth_group_permissions_pkey                                 |         2200 | p       | f             | f           | t            |    16953 |        0 |    16957 |           0 |         0 |             |             |               | t          |           0 | t            | {1}    |         |           |           |           |           | 
 16968 | auth_group_permissions_group_id_b120cbf9_fk_auth_group_id   |         2200 | f       | t             | t           | t            |    16953 |        0 |    16947 |           0 |     16943 | a           | a           | s             | t          |           0 | t            | {2}    | {1}     | {96}      | {96}      | {96}      |           | 
 16973 | auth_group_permissio_permission_id_84c5c92e_fk_auth_perm    |         2200 | f       | t             | t           | t            |    16953 |        0 |    16939 |           0 |     16935 | a           | a           | s             | t          |           0 | t            | {3}    | {1}     | {96}      | {96}      | {96}      |           | 
 16979 | auth_group_permissions_group_id_permission_id_0cd325b0_uniq |         2200 | u       | f             | f           | t            |    16953 |        0 |    16978 |           0 |         0 |             |             |               | t          |           0 | t            | {2,3}  |         |           |           |           |           | 
(4 rows)

-------+--------------------------------------------------------+--------------+---------+---------------+-------------+--------------+----------+----------+----------+-------------+-----------+-------------+-------------+---------------+------------+-------------+--------------+--------+---------+-----------+-----------+-----------+-----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 16915 | django_admin_log_action_flag_check                     |         2200 | c       | f             | f           | t            |    16911 |        0 |        0 |           0 |         0 |             |             |               | t          |           0 | f            | {5}    |         |           |           |           |           | {OPEXPR :opno 542 :opfuncid 168 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 5 :vartype 21 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 5 :location 215} {CONST :consttype 23 :consttypmod -1 :constcollid 0 :constlen 4 :constbyval true :constisnull false :location 232 :constvalue 4 [ 0 0 0 0 0 0 0 0 ]}) :location 229}
 16920 | django_admin_log_pkey                                  |         2200 | p       | f             | f           | t            |    16911 |        0 |    16919 |           0 |         0 |             |             |               | t          |           0 | t            | {1}    |         |           |           |           |           | 
 16921 | django_admin_log_content_type_id_c4bce8eb_fk_django_co |         2200 | f       | t             | t           | t            |    16911 |        0 |    16402 |           0 |     16398 | a           | a           | s             | t          |           0 | t            | {7}    | {1}     | {96}      | {96}      | {96}      |           | 
 16926 | django_admin_log_user_id_c564eba6_fk_perma_linkuser_id |         2200 | f       | t             | t           | t            |    16911 |        0 |    16472 |           0 |     16464 | a           | a           | s             | t          |           0 | t            | {8}    | {1}     | {96}      | {96}      | {96}      |           | 
(4 rows)
```

And, after the data is migrated, I can see that the constraints mentioned in the warnings ARE created and present in the final postgres db.
```
perma=# SELECT con.*
perma-#        FROM pg_catalog.pg_constraint con
perma-#             INNER JOIN pg_catalog.pg_class rel
perma-#                        ON rel.oid = con.conrelid
perma-#             INNER JOIN pg_catalog.pg_namespace nsp
perma-#                        ON nsp.oid = connamespace
perma-#        WHERE nsp.nspname = 'public'
perma-#              AND rel.relname = 'auth_group_permissions';

  oid  |                           conname                           | connamespace | contype | condeferrable | condeferred | convalidated | conrelid | contypid | conindid | conparentid | confrelid | confupdtype | confdeltype | confmatchtype | conislocal | coninhcount | connoinherit | conkey | confkey | conpfeqop | conppeqop | conffeqop | conexclop | conbin 
-------+-------------------------------------------------------------+--------------+---------+---------------+-------------+--------------+----------+----------+----------+-------------+-----------+-------------+-------------+---------------+------------+-------------+--------------+--------+---------+-----------+-----------+-----------+-----------+--------
 16958 | auth_group_permissions_pkey                                 |         2200 | p       | f             | f           | t            |    16953 |        0 |    16957 |           0 |         0 |             |             |               | t          |           0 | t            | {1}    |         |           |           |           |           | 
 16979 | auth_group_permissions_group_id_permission_id_0cd325b0_uniq |         2200 | u       | f             | f           | t            |    16953 |        0 |    16978 |           0 |         0 |             |             |               | t          |           0 | t            | {2,3}  |         |           |           |           |           | 
 18111 | auth_group_permissions_group_id_b120cbf9_fk_auth_group_id   |         2200 | f       | t             | t           | t            |    16953 |        0 |    16947 |           0 |     16943 | a           | a           | s             | t          |           0 | t            | {2}    | {1}     | {96}      | {96}      | {96}      |           | 
 18116 | auth_group_permissio_permission_id_84c5c92e_fk_auth_perm    |         2200 | f       | t             | t           | t            |    16953 |        0 |    16939 |           0 |     16935 | a           | a           | s             | t          |           0 | t            | {3}    | {1}     | {96}      | {96}      | {96}      |           | 
(4 rows)


2022-01-10T17:26:21.622000Z NOTICE ALTER TABLE "perma"."auth_group_permissions" DROP CONSTRAINT IF EXISTS "auth_group_permissio_permission_id_84c5c92e_fk_auth_perm" CASCADE;
2022-01-10T17:26:21.622000Z WARNING PostgreSQL warning: constraint "auth_group_permissio_permission_id_84c5c92e_fk_auth_perm" of relation "auth_group_permissions" does not exist, skipping
...
2022-01-10T17:39:17.057000Z NOTICE ALTER TABLE "perma"."auth_group_permissions" ADD CONSTRAINT "auth_group_permissio_permission_id_84c5c92e_fk_auth_perm" FOREIGN KEY (permission_id) REFERENCES auth_permission(id) DEFERRABLE INITIALLY DEFERRED


perma=# SELECT con.*
perma-#        FROM pg_catalog.pg_constraint con
perma-#             INNER JOIN pg_catalog.pg_class rel
perma-#                        ON rel.oid = con.conrelid
perma-#             INNER JOIN pg_catalog.pg_namespace nsp
perma-#                        ON nsp.oid = connamespace
perma-#        WHERE nsp.nspname = 'public'
perma-#              AND rel.relname = 'django_admin_log';

-------+--------------------------------------------------------+--------------+---------+---------------+-------------+--------------+----------+----------+----------+-------------+-----------+-------------+-------------+---------------+------------+-------------+--------------+--------+---------+-----------+-----------+-----------+-----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 16915 | django_admin_log_action_flag_check                     |         2200 | c       | f             | f           | t            |    16911 |        0 |        0 |           0 |         0 |             |             |               | t          |           0 | f            | {5}    |         |           |           |           |           | {OPEXPR :opno 542 :opfuncid 168 :opresulttype 16 :opretset false :opcollid 0 :inputcollid 0 :args ({VAR :varno 1 :varattno 5 :vartype 21 :vartypmod -1 :varcollid 0 :varlevelsup 0 :varnoold 1 :varoattno 5 :location 215} {CONST :consttype 23 :consttypmod -1 :constcollid 0 :constlen 4 :constbyval true :constisnull false :location 232 :constvalue 4 [ 0 0 0 0 0 0 0 0 ]}) :location 229}
 16920 | django_admin_log_pkey                                  |         2200 | p       | f             | f           | t            |    16911 |        0 |    16919 |           0 |         0 |             |             |               | t          |           0 | t            | {1}    |         |           |           |           |           | 
 18126 | django_admin_log_content_type_id_c4bce8eb_fk_django_co |         2200 | f       | t             | t           | t            |    16911 |        0 |    16402 |           0 |     16398 | a           | a           | s             | t          |           0 | t            | {7}    | {1}     | {96}      | {96}      | {96}      |           | 
 18131 | django_admin_log_user_id_c564eba6_fk_perma_linkuser_id |         2200 | f       | t             | t           | t            |    16911 |        0 |    16472 |           0 |     16464 | a           | a           | s             | t          |           0 | t            | {8}    | {1}     | {96}      | {96}      | {96}      |           | 
(4 rows)

2022-01-10T17:26:21.625000Z NOTICE ALTER TABLE "perma"."django_admin_log" DROP CONSTRAINT IF EXISTS "django_admin_log_content_type_id_c4bce8eb_fk_django_co" CASCADE;
2022-01-10T17:26:21.625000Z WARNING PostgreSQL warning: constraint "django_admin_log_content_type_id_c4bce8eb_fk_django_co" of relation "django_admin_log" does not exist, skipping
...
2022-01-10T17:39:17.065000Z NOTICE ALTER TABLE "perma"."django_admin_log" ADD CONSTRAINT "django_admin_log_content_type_id_c4bce8eb_fk_django_co" FOREIGN KEY (content_type_id) REFERENCES django_content_type(id) DEFERRABLE INITIALLY DEFERRED
```

I only spot checked two, but have no reason to believe anything is different with the others.

FWIW, the constraints on those tables in the MySQL:
```
mysql> select COLUMN_NAME, CONSTRAINT_NAME, REFERENCED_COLUMN_NAME, REFERENCED_TABLE_NAME
    -> from information_schema.KEY_COLUMN_USAGE
    -> where TABLE_NAME = 'auth_group_permissions';
+---------------+--------------------------------+------------------------+-----------------------+
| COLUMN_NAME   | CONSTRAINT_NAME                | REFERENCED_COLUMN_NAME | REFERENCED_TABLE_NAME |
+---------------+--------------------------------+------------------------+-----------------------+
| id            | PRIMARY                        | NULL                   | NULL                  |
| group_id      | group_id                       | NULL                   | NULL                  |
| permission_id | group_id                       | NULL                   | NULL                  |
| group_id      | group_id_refs_id_f4b32aac      | id                     | auth_group            |
| permission_id | permission_id_refs_id_6ba0f519 | id                     | auth_permission       |
+---------------+--------------------------------+------------------------+-----------------------+
5 rows in set (0.02 sec)

mysql> select COLUMN_NAME, CONSTRAINT_NAME, REFERENCED_COLUMN_NAME, REFERENCED_TABLE_NAME
    -> from information_schema.KEY_COLUMN_USAGE
    -> where TABLE_NAME = 'django_admin_log';
+-----------------+----------------------------------+------------------------+-----------------------+
| COLUMN_NAME     | CONSTRAINT_NAME                  | REFERENCED_COLUMN_NAME | REFERENCED_TABLE_NAME |
+-----------------+----------------------------------+------------------------+-----------------------+
| id              | PRIMARY                          | NULL                   | NULL                  |
| content_type_id | content_type_id_refs_id_93d2d1f8 | id                     | django_content_type   |
+-----------------+----------------------------------+------------------------+-----------------------+
2 rows in set (0.01 sec)
```
🤷‍♀️ I don't see anything to worry about here or to further follow up on.

### Errors

The two errors are both because Key (history_user_id)=(7918) is not present in table "perma_linkuser".` That's true on prod too. There could be others like that with the historical link data, whose data I do not have locally.

The absence of those constraints is not a big deal. I'll make a ticket to address (or not) after the fact: we can delete the rows and add in the constraints manually, or can just fuhgeddaboudit.

### Control characters

Here are some links to be careful with:
```
mysql> SELECT guid, submitted_url FROM perma_link WHERE submitted_url RLIKE '[[:cntrl:]]+';
---------------------------------------------------------------------------------------------+
| guid      | submitted_url                                                                                                                                                                                                                       |
+-----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 2WCG-8BZL | http://www.smithsonianmag.com/arts-culture/how-americas-leading-science-fictionauthors- are-shaping-your-future-180951169/?page2                                                                                                   |
| E8NE-2H8W | http://www.vice.com/read/the-kill-list-by-frederick-forsyth-gtmo- library-985                                                                                                                                                       |
| FZP9-KYEF | http://digitalcommons.law.yale.edu/cgi/viewcontent.cgi?article3053&contextfss_papers                                                                                                                                              |
| M87M-XXZR | https://ecommons.cornell.edu/bitstream/handle/1813/13836/Savitsky,%20Douglas.pdf;jsessionid3F37C6 EF090FEE53E1244B81852FC6E8?sequence1                                                                                            |
| UVZ8-9D3Y | http://www.brown.edu/conference/congress-and-history/sites/brown.edu.conference.congress-and-history/files/uploads/binder_    spindel_june_2011.pdf                                                                                   |
| W7JM-R7KG | http://www.scotusblog.com/2016/06/opinion-analysis-victory-for-the-categorical-approach-in-immigration-and-federal-criminal-sentencing-but-for-how-long/. •   http://crimmigration.com/2016/07/06/reviewing-united-states-v-mathis/ |
| ZY7G-88FB | http://www.electionstudies.org/studypages/2008_2009panel/anes2008_2009panel_User  Guide_AdvanceRelease.pdf                                                                                                                          |
+-----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
7 rows in set (9.06 sec)


perma=# SELECT guid, submitted_url FROM perma_link WHERE submitted_url ~ '[[:cntrl:]]+';
   guid    |                                                                                                             submitted_url                                                                                                             
-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 KHC3-9TUT | http://www.who.org/violence-injury\u0097
 FZP9-KYEF | http://digitalcommons.law.yale.edu/cgi/viewcontent.cgi?article\x023053&context\x02fss_papers
 2MS4-KP2T | http://www.who.org/violence-injury\u0097
 2WCG-8BZL | http://www.smithsonianmag.com/arts-culture/how-americas-leading-science-fictionauthors- are-shaping-your-future-180951169/?page\x022
 3P47-BTXZ | http://www.who.org/violence-injury\u0097
 E8NE-2H8W | http://www.vice.com/read/the-kill-list-by-frederick-forsyth-gtmo-       library-985
 HW84-SVPC | http://www.who.org/violence-injury\u0097
 V9N6-X7X5 | http://www.who.org/violence-injury\u0097
 M87M-XXZR | https://ecommons.cornell.edu/bitstream/handle/1813/13836/Savitsky,%20Douglas.pdf;jsessionid\x023F37C6 EF090FEE53E1244B81852FC6E8?sequence\x021
 UVZ8-9D3Y | http://www.brown.edu/conference/congress-and-history/sites/brown.edu.conference.congress-and-history/files/uploads/binder_      spindel_june_2011.pdf
 WXC8-ZMSD | http://www.who.org/violence-injury\u0097
 W7JM-R7KG | http://www.scotusblog.com/2016/06/opinion-analysis-victory-for-the-categorical-approach-in-immigration-and-federal-criminal-sentencing-but-for-how-long/. •     http://crimmigration.com/2016/07/06/reviewing-united-states-v-mathis/
 ZY7G-88FB | http://www.electionstudies.org/studypages/2008_2009panel/anes2008_2009panel_User        Guide_AdvanceRelease.pdf
(13 rows)

```
The ones identified by mysql are included in postgres' longer list.

On prod today:
```
   guid    | playback
-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 KHC3-9TUT | link not found, screenshot works 
 FZP9-KYEF | succeeds (pretty 404)
 2MS4-KP2T | link not found, screenshot works
 2WCG-8BZL | succeeds (pretty 404)
 3P47-BTXZ | link not found, screenshot works
 E8NE-2H8W | link not found, screenshot works
 HW84-SVPC | link not found, screenshot works
 V9N6-X7X5 | link not found, screenshot works
 M87M-XXZR | works
 UVZ8-9D3Y | deleted
 WXC8-ZMSD | link not found, screenshot works
 W7JM-R7KG | deleted
 ZY7G-88FB | deleted
```
I can check again post migration to see if anything about them changes.