### PR TITLE
New monitor

### DIFF
--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -349,14 +349,31 @@ def upload_all_to_internet_archive():
     for link in links:
         upload_to_internet_archive(link.guid)
 
+
 @task
 def count_pending_ia_links():
+    """
+    For use in monitoring the size of the queue.
+    """
     from perma.models import Link
 
     count = Link.objects.visible_to_ia().filter(
         internet_archive_upload_status__in=['not_started', 'failed', 'upload_or_reupload_required', 'deleted']
     ).count()
     print(count)
+
+
+@task
+def count_links_without_cached_playback_status():
+    """
+    For use in monitoring the size of the queue.
+    """
+    from perma.models import Link
+
+    count = Link.objects.permanent().filter(cached_can_play_back__isnull=True).count()
+    print(count)
+
+
 
 @task
 def regenerate_urlkeys(urlkey_prefix='file'):


### PR DESCRIPTION
If celery beat stops beating, then neither IA tasks nor background tasks will complete. 

Since the count of links we intend to upload to IA (currently monitored) depends on the count of permanent links with `cached_can_play_back=True`... that monitor won't sound an alert if the task responsible for setting `cached_can_play_back` isn't running. So, we should monitor whether links with `cached_can_play_back__isnull=True` are piling up as well.