### PR TITLE
WR: Check for user before attempting to write cdxj during commital.

### DIFF
--- a/services/docker/webrecorder/recording.py
+++ b/services/docker/webrecorder/recording.py
@@ -449,7 +449,10 @@ class Recording(RedisUniqueComponent):
 
             self.redis.publish('close_rec', info_key)
 
-            cdxj_filename, full_cdxj_filename = self.write_cdxj(user, cdxj_key)
+            # BEGIN PERMA CUSTOMIZATION
+            if user:
+                cdxj_filename, full_cdxj_filename = self.write_cdxj(user, cdxj_key)
+            # END PERMA CUSTOMIZATION
 
             all_done = True
 


### PR DESCRIPTION
Follows up on https://github.com/harvard-lil/perma/pull/2950: still handling the case where there is no longer a user record in redis.