### PR TITLE
Special 404 page for a Link's submitted URL during playback.

### DIFF
--- a/perma_web/perma/templates/archive/archive-error.html
+++ b/perma_web/perma/templates/archive/archive-error.html
@@ -7,16 +7,31 @@
 {% block mainContent %}
 
   <div class="record-message">
-    {% if status == '404 Not Found' %}
+
+    <div id="loading">...loading</div>
+
+    <div id="primary-not-found" style="display:none;">
+      <p class="record-message-primary">We’re sorry, something went wrong.</p>
+      <p class="record-message-secondary">
+        It appears that our software experienced an error while playing back this record. This issue is likely temporary and specific to your browser.
+      </p>
+      <p class="record-message-secondary" style="padding-top: 6px;">
+        We suggest opening this Perma Link in a completely new browser or clearing your cache. If your issue persists please <a href="{% url 'contact' %}?subject=Primary%20URL%20Not%20Found">contact us</a>.
+      </p>
+    </div>
+
+    <div id="secondary-not-found" style="display:none;">
       <p class="record-message-primary">Link not found</p>
       <p class="record-message-secondary">
-        You are probably seeing this page because you clicked a link in one of our records. We don’t capture secondary links,
-        but you could check <a href="http://timetravel.mementoweb.org/list/{{ timestamp }}/{{ err_url }}" target="_top">Time Travel</a> or
-        <a href="{{ err_url }}" target="_top">view the link as it exists on the live site</a>.</p>
-    {% else %}
+        You are probably seeing this page because you clicked a link in one of our records.
+        We don’t capture secondary links, but you can check <a href="http://timetravel.mementoweb.org/list/{{ timestamp }}/{{ err_url }}" target="_top">Time Travel</a> or <a href="{{ err_url }}" target="_top">view the link as it exists on the live site</a>.
+      </p>
+    </div>
+
+    <div id="unavailable" style="display:none;">
       <p class="record-message-primary">Playback Unavailable</p>
       <p class="record-message-secondary">We’re having trouble playing back this record’s Capture View. If this problem persists, please let us know.</p>
-      {% if DEBUG %} 
+      {% if DEBUG %}
         <div>
           Error details (you are seeing this because DEBUG mode is on):<br><br>
 
@@ -32,7 +47,27 @@
           Error message: {{ err_msg }}
         </div>
       {% endif %}
-    {% endif %}
+    </div>
+
+    <script>
+      const status_code = "{{ status_code }}"
+      const err_url = "{{ err_url | escapejs }}";
+      const primary_url_regex = new RegExp(`^${window.name}/?$`);
+      const loading = document.getElementById('loading');
+      let elem;
+      if(status_code == 404){
+        if(primary_url_regex.test(err_url)){
+          elem = document.getElementById('primary-not-found');
+        } else {
+          elem = document.getElementById('secondary-not-found');
+        }
+      } else {
+        elem = document.getElementById('unavailable');
+      }
+      loading.style.display = "none";
+      elem.style.display = "block";
+    </script>
+
   </div>
 
 {% endblock %}

--- a/perma_web/perma/templates/archive/iframe.html
+++ b/perma_web/perma/templates/archive/iframe.html
@@ -35,7 +35,7 @@
           <replay-web-page source="{% url 'serve_warc' guid=link.guid %}"
           url="{{ link.submitted_url }}" view="{{ client_side_playback }}"></replay-web-page>
         {% else %}
-          <iframe class="archive-iframe" src="" {% if capture.use_sandbox %}sandbox="allow-forms allow-scripts allow-top-navigation allow-same-origin" {% endif %}>
+          <iframe name="{{ link.submitted_url }}" class="archive-iframe" src="" {% if capture.use_sandbox %}sandbox="allow-forms allow-scripts allow-top-navigation allow-same-origin" {% endif %}>
           </iframe>
           <script src="{{ protocol}}{{ wr_host }}/static/bundle/wb_frame.js"></script>
           <script>

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -609,6 +609,7 @@ def archive_error(request):
     response = render(request, 'archive/archive-error.html', {
         'err_url': request.GET.get('url'),
         'timestamp': request.GET.get('timestamp'),
+        'status_code': status_code,
         'status': f'{status_code} {responses.get(status_code)}',
         'err_msg': request.GET.get('error'),
     }, status=status_code)


### PR DESCRIPTION
We have received reports about perma links that, when visited by one user, show the "Link Not Found" archive error page, that when visited subsquently or in a different browser are fine. A diagnosis has been elusive. But, in the meantime, we can show a custom error page, when the target/submitted URL of a perma link gets a 404 error from Webrecorder.

![image](https://user-images.githubusercontent.com/11020492/126841214-42df00ba-68d9-428f-ad4e-d0d4aaba08b8.png)

This may display in other situations as well, such as https://github.com/harvard-lil/perma/issues/2845, but I think that's okay: so long as WR returns 404 and not 500 for errors, there's not a lot we can do on this end to serve up nuanced responses for each situation.