### PR TITLE
Update Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       context: .
       dockerfile: ./perma_web/Dockerfile
       args:
-        chrome-layer-cache-buster: 006d813c-8350-4486-9339-9e816bb20183
-    image: perma3:0.109
+        chrome-layer-cache-buster: f51c8c61-4b8d-4aef-93ec-282e99f99e55
+    image: perma3:0.110
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -75,7 +75,7 @@ RUN pip3 install -U pip \
 # Install Chrome
 # technique from https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeChrome/Dockerfile.txt
 ARG chrome-layer-cache-buster
-RUN apt-get update \
+RUN apt-get --allow-releaseinfo-change update \
     && apt-get install -y unzip libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libgbm1 libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxcursor1 libxi6 libxrandr2 libxss1 libxtst6 xdg-utils \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && dpkg -i google-chrome*.deb \

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -612,7 +612,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []

--- a/perma_web/perma/tests/test_cloudflare_cache.py
+++ b/perma_web/perma/tests/test_cloudflare_cache.py
@@ -21,10 +21,14 @@ and commit the updated files.
         ip4 = requests.get('https://www.cloudflare.com/ips-v4').text
 
         with open(os.path.join(settings.CLOUDFLARE_DIR, 'ips-v4')) as ip4_cache:
-            self.assertEqual(ip4, ip4_cache.read(), msg=self.message)
+            self.assertEqual(set(ip4.split()),
+                             set(ip4_cache.read().split()),
+                             msg=self.message)
 
     def test_cloudflare_ip6_cache(self):
         ip6 = requests.get('https://www.cloudflare.com/ips-v6').text
 
         with open(os.path.join(settings.CLOUDFLARE_DIR, 'ips-v6')) as ip6_cache:
-            self.assertEqual(ip6, ip6_cache.read(), msg=self.message)
+            self.assertEqual(set(ip6.split()),
+                             set(ip6_cache.read().split()),
+                             msg=self.message)


### PR DESCRIPTION
This updates Chrome from 92.0.4515.131 to 92.0.4515.159:

https://chromereleases.googleblog.com/2021/08/stable-channel-update-for-desktop.html

The addition of `--allow-releaseinfo-change` to the Dockerfile is due to the [release on August 14](https://www.debian.org/News/2021/20210814) of Debian 11 ("bullseye"). If I didn't have cache locally for all the lines including `apt-get update` above this one, I'd have needed to add it there, as well. I'm not sure whether CI will have cache for those lines, but my guess is no. I will put this PR in, expecting failure, then decide whether to add `--allow-releaseinfo-change` everywhere, or begin to switch from buster to bullseye -- which will need to happen at some point, though probably not within the first week of the release. ;)

The error messages, without allowing release info change, look like `E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'`, btw.