### PR TITLE
Try uploading the right coverage file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             docker-compose exec app python -m webrecorder.admin -c info@perma.cc public Test123Test123 archivist 'Info at Perma.cc'
             docker-compose exec web pipenv run pytest \
               --junitxml=junit/pytest/test-results.xml       `# write test results so they can be displayed by circleci` \
-              --cov --cov-config=setup.cfg --cov-report xml  `# write coverage data to .coverage for upload by codecov` \
+              --cov --cov-config=setup.cfg --cov-report xml  `# write coverage data to coverage.xml for upload by codecov` \
 
       # Upload test details to circleci
       - store_test_results:
@@ -60,4 +60,4 @@ jobs:
 
       # Upload coverage to Codecov using third-party orb
       - codecov/upload:
-          file: perma_web/.coverage
+          file: perma_web/coverage.xml


### PR DESCRIPTION
Circle CI oddly says
```
Coverage XML written to file coverage.xml
```
but then
```
==> Reading reports
    + perma_web/.coverage bytes=53248
==> Appending adjustments
    https://docs.codecov.io/docs/fixing-reports
    -> No adjustments found
==> Gzipping contents
        8.0K	/tmp/codecov.vJFcgl.gz
==> Uploading reports
...
```

so I'm not sure what it thinks it's been uploading.