### PR TITLE
Update Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       context: .
       dockerfile: ./perma_web/Dockerfile
       args:
-        chrome-layer-cache-buster: 11c7f734-9174-4f26-9e1b-3b49eb0e5f73
-    image: perma3:0.120
+        chrome-layer-cache-buster: 9af4d93c-23f9-4cb1-99c4-b9af89f94668
+    image: perma3:0.121
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -612,7 +612,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []


### PR DESCRIPTION
This is another major version update of Chrome, from 95.0.4638.69 to 96.0.4664.45:

https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html