### PR TITLE
fix typo on FAQ page

### DIFF
--- a/perma_web/perma/templates/docs/faq.html
+++ b/perma_web/perma/templates/docs/faq.html
@@ -113,7 +113,7 @@ This section of the user guide provides answers to common questions about Perma.
       <h3 class="body-bh">How does prorating work?</h3>
       <div class="faq-answer">
       <h4>Here's an example for new users:</h4>
-       <p class="body-text">If you subscribe on the first day of the month, we charge you $10 since you will an account for the entire coming month. On the first of the next month, you will be rebilled at the $10/mo rate. You will have a full 10 links available.</p>
+       <p class="body-text">If you subscribe on the first day of the month, we charge you $10 since you will have an account for the entire coming month. On the first of the next month, you will be rebilled at the $10/mo rate. You will have a full 10 links available.</p>
        <p class="body-text">If you subscribe halfway through the month, we'll charge you half, or $5, since you would have an account for half the month. You will have a full 10 links available. On the first of the next month, you will be rebilled at the $10/mo rate.</p>
       <h4> Here's an example for current users:</h4>
        <p class="body-text">You have a 10 link, $10/mo account and want to upgrade to a 20 link, $20/mo account. You have already used 3 links, so you have 7 left in your account. If you purchase the upgrade on the first day of the month, the upgrade will cost $10, the full amount, since you will have an upgraded account for the entire coming month. Since your new account limits afford you 10 more links, you will now have 17 links for the rest of the month. On the first of the next month, you will be rebilled at the $20/mo rate, and have a full 20 links available.</p>


### PR DESCRIPTION
added missing word to section explaining personal subscription policies