### PR TITLE
Update Chrome

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       context: .
       dockerfile: ./perma_web/Dockerfile
       args:
-        chrome-layer-cache-buster: 68645b79-86c0-4835-bd2e-c7cf5d70d23d
-    image: perma3:0.123
+        chrome-layer-cache-buster: a7e9520f-2f1d-4ac6-a1b2-b7d84a00cca3
+    image: perma3:0.124
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -612,7 +612,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []


### PR DESCRIPTION
This updates Chrome from 96.0.4664.93 to 96.0.4664.110:

https://chromereleases.googleblog.com/2021/12/stable-channel-update-for-desktop_13.html