### PR TITLE
Don't specify BUILDARG in playwright tag

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -54,7 +54,7 @@ Remember to set `SECURE_SSL_REDIRECT = False` when you go back to
 running without SSL. Note also that if you run with SSL against a
 local (non-SSL) webrecorder, playback will fail silently.
 
-### Run all the tests
+### Run the tests
 
 `d fab test`
 
@@ -73,6 +73,16 @@ including a super-convenient keyword-matching option:
 
 See [Testing and Test Coverage](#testing-and-test-coverage) for more
 information about testing Perma.
+
+### Run the playback tests
+
+First, spin up your development instance of Perma:
+
+`d fab run`
+
+Then, in a new terminal window:
+
+`docker-compose exec playwright pipenv run pytest --browser chromium --browser firefox --browser webkit`
 
 ### Update the python dependencies
 
@@ -284,6 +294,8 @@ Python unit tests live in `perma/tests`, `api/tests`, etc.
 Functional tests live in `functional_tests/`.
 
 Javascript tests live in `spec/`.
+
+Playback tests live in `playwright/`.
 
 See the [Common tasks and commands](#common-tasks-and-commands) for the
 common techniques for running the tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     build:
       context: .
       dockerfile: ./playwright/Dockerfile
-    image: perma-playwright:0.00314159
+    image: perma-playwright:0.003141592
     volumes:
       - ./playwright:/playwright:delegated
     environment:

--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,5 +1,4 @@
-ARG BUILDARCH=amd64
-FROM mcr.microsoft.com/playwright:v1.18.1-focal-${BUILDARCH}
+FROM mcr.microsoft.com/playwright:v1.18.1-focal
 
 RUN apt-get update \
     && apt-get install -y python3.8 python3-pip \


### PR DESCRIPTION
Turns out if we just omit it, the correct image is pulled, by platform.