### PR TITLE
Limit maximum size of IA uploads

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -476,6 +476,7 @@ API_SUBDOMAIN = 'api'
 
 # internet archive stuff
 UPLOAD_TO_INTERNET_ARCHIVE = False
+INTERNET_ARCHIVE_MAX_UPLOAD_SIZE = 1024 * 1024 * 100
 INTERNET_ARCHIVE_COLLECTION = 'perma_cc'
 INTERNET_ARCHIVE_IDENTIFIER_PREFIX = 'perma_cc_'
 # Find these at https://archive.org/account/s3.php :


### PR DESCRIPTION
The point of this is to prevent repeated attempts to upload large WARCs that time out and jam the upload queue.

@rebeccacremona I think this does what we were talking about; I'm not sure if it would be better to leave the setting unset by default, and set it only in production.

This does not address whatever manual or other process we need to upload larger WARCs to IA, nor, of course, does it address the problem of creating oversized WARCs ;)