### PR TITLE
Linkbatch ordering

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -319,10 +319,5 @@ class LinkBatchSerializer(BaseSerializer):
         fields = ('id', 'started_on', 'created_by', 'capture_jobs', 'target_folder')
 
 
-class DetailedLinkBatchSerializer(BaseSerializer):
-    capture_jobs = CaptureJobSerializer(many=True, read_only=True)
+class DetailedLinkBatchSerializer(LinkBatchSerializer):
     target_folder = FolderSerializer(read_only=True)
-
-    class Meta:
-        model = LinkBatch
-        fields = ('id', 'started_on', 'created_by', 'capture_jobs', 'target_folder')

--- a/perma_web/fabfile/dev.py
+++ b/perma_web/fabfile/dev.py
@@ -24,7 +24,7 @@ def run_django(port="0.0.0.0:8000", use_ssl=False, cert_file='perma-test.crt', h
 
     commands = []
 
-    if settings.ENABLE_BATCH_LINKS and not settings.RUN_TASKS_ASYNC:
+    if not settings.RUN_TASKS_ASYNC:
         print("\nWarning! Batch Link creation will not work as expected:\n" +
               "to create new batches you must run with settings.RUN_TASKS_ASYNC = True\n")
 

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -2095,7 +2095,7 @@ class LinkBatch(models.Model):
         verbose_name_plural = "link batches"
 
     def accessible_to(self, user):
-        return user.is_staff or self.created_by == user
+        return user.is_staff or self.created_by_id == user.pk
 
     def __str__(self):
         return f"LinkBatch {self.pk}"

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -555,7 +555,6 @@ THUMBNAIL_STORAGE_PATH = 'thumbnails'
 
 # feature flags
 SINGLE_LINK_HEADER_TEST = False
-ENABLE_BATCH_LINKS = False
 # N.B. If True, requires RUN_TASKS_ASYNC = True
 
 # security settings -- set these to true if SSL is available
@@ -592,7 +591,6 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'API_VERSION',
     'SECURE_SSL_REDIRECT',
     'DEBUG',
-    'ENABLE_BATCH_LINKS',
     'ENABLE_SPONSORED_USERS',
     'ENABLE_BONUS_LINKS',
     'PLAYBACK_HOST',

--- a/perma_web/perma/templates/js_config.html
+++ b/perma_web/perma/templates/js_config.html
@@ -3,8 +3,7 @@
     API_VERSION: {{ API_VERSION }},
     STATIC_URL: "{{ STATIC_URL }}",
     MEDIA_URL: "{{ MEDIA_URL }}",
-    DEBUG: {{ DEBUG|lower }},
-    ENABLE_BATCH_LINKS: {{ ENABLE_BATCH_LINKS|lower }}
+    DEBUG: {{ DEBUG|lower }}
   },
   api_path = "/api/v" + settings.API_VERSION
 </script>

--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -39,10 +39,7 @@
                     type="submit">
                 Create Perma Link
             </button>
-
-            {% if ENABLE_BATCH_LINKS %}
             <p id="create-batch-links">or <a id="create-batch" data-toggle="modal" href="#batch-modal">create multiple links</a></p>
-            {% endif %}
           </div>
 
           {% if request.user.is_individual %}
@@ -115,7 +112,6 @@
 <div class="container cont-fixed manage-links">
   <div class="row">
     <div class="col-md-3 col-folders">
-      {% if ENABLE_BATCH_LINKS %}
       <div id="batch-list-container" class="_hide">
         <div id="batch-list-toggle">
           <a role="button" class="dropdown" data-toggle="collapse" href="#batch-history" aria-expanded="false" aria-controls="batch-history">
@@ -125,7 +121,6 @@
         <div id="batch-history" class="collapse">
         </div>
       </div>
-      {% endif %}
       <div class="panel-heading">
         Folders
         <span class="buttons">
@@ -173,7 +168,5 @@
 
 {% block modals %}
   {% include "archive/includes/upload_your_own.html" %}
-  {% if ENABLE_BATCH_LINKS %}
-    {% include "archive/includes/link_batch_modal.html" %}
-  {% endif %}
+  {% include "archive/includes/link_batch_modal.html" %}
 {% endblock modals %}

--- a/perma_web/static/bundles/create.js
+++ b/perma_web/static/bundles/create.js
@@ -31675,25 +31675,22 @@ function set_folder_from_dropdown(new_folder_id) {
 
 function populate_link_batch_list() {
   var limit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 7;
-
-  if (settings.ENABLE_BATCH_LINKS) {
-    APIModule.request('GET', '/archives/batches/', {
-      'limit': limit
-    }).then(function (data) {
-      if (data.objects.length > 0) {
-        var template = batchHistoryTemplate({
-          'link_batches': data.objects,
-          'next': data.meta.next
-        });
-        $batch_history.html(template);
-        $batch_list_container.removeClass('_hide');
-        DOMHelpers.scrollIfTallerThanFractionOfViewport(".col-folders", 0.9);
-      }
-    }).catch(function (e) {
-      console.log(e);
-      $batch_history.html('<p>(unavailable)</p>');
-    });
-  }
+  APIModule.request('GET', '/archives/batches/', {
+    'limit': limit
+  }).then(function (data) {
+    if (data.objects.length > 0) {
+      var template = batchHistoryTemplate({
+        'link_batches': data.objects,
+        'next': data.meta.next
+      });
+      $batch_history.html(template);
+      $batch_list_container.removeClass('_hide');
+      DOMHelpers.scrollIfTallerThanFractionOfViewport(".col-folders", 0.9);
+    }
+  }).catch(function (e) {
+    console.log(e);
+    $batch_history.html('<p>(unavailable)</p>');
+  });
 }
 
 function setup_handlers() {

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -166,21 +166,19 @@ function set_folder_from_dropdown(new_folder_id) {
 };
 
 function populate_link_batch_list(limit=7) {
-    if (settings.ENABLE_BATCH_LINKS) {
-        APIModule.request('GET', '/archives/batches/', {
-            'limit': limit
-        }).then(function(data) {
-            if (data.objects.length > 0) {
-                let template = batchHistoryTemplate({'link_batches': data.objects, 'next': data.meta.next});
-                $batch_history.html(template);
-                $batch_list_container.removeClass('_hide');
-                DOMHelpers.scrollIfTallerThanFractionOfViewport(".col-folders", 0.9);
-            }
-        }).catch(function(e){
-            console.log(e);
-            $batch_history.html('<p>(unavailable)</p>')
-        });
-    }
+    APIModule.request('GET', '/archives/batches/', {
+        'limit': limit
+    }).then(function(data) {
+        if (data.objects.length > 0) {
+            let template = batchHistoryTemplate({'link_batches': data.objects, 'next': data.meta.next});
+            $batch_history.html(template);
+            $batch_list_container.removeClass('_hide');
+            DOMHelpers.scrollIfTallerThanFractionOfViewport(".col-folders", 0.9);
+        }
+    }).catch(function(e){
+        console.log(e);
+        $batch_history.html('<p>(unavailable)</p>')
+    });
 }
 
 function setup_handlers() {


### PR DESCRIPTION
- Order capture_jobs for each LinkBatch in the LinkBatch API in the order they were created. I didn't add a general `class Meta: ordering = ['-human', 'order', 'pk']` because there isn't a DB index for that order and it would slow down anything like the admin that might list all of the CaptureJobs.
- Remove the ENABLE_BATCH_LINKS feature flag

Fixes #3044 