### PR TITLE
Update Chromium and update mechanism

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,7 @@ services:
     build:
       context: .
       dockerfile: ./perma_web/Dockerfile
-      args:
-        chrome-layer-cache-buster: 167F067D-9863-4446-B974-BC2E8483B99F
-    image: perma3:0.147
+    image: perma3:0.148
     tty: true
     command: bash
     # TO AUTOMATICALLY START PERMA:

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -69,8 +69,9 @@ RUN pip install pip==22.0.4 \
     && rm /perma/perma_web/requirements.txt
 
 # Install Chromium and driver
-ARG chrome-layer-cache-buster
-RUN apt-get update && apt-get install -y chromium chromium-driver chromium-l10n chromium-sandbox
+ENV CHROMIUM_VERSION=100.0.4896.88-1~deb11u1
+RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
+    chromium-driver chromium-l10n chromium-sandbox
 
 # dev personalizations / try installing packages without rebuilding everything
 RUN apt-get update && apt-get install -y nano

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -595,7 +595,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []

--- a/update_chromium.sh
+++ b/update_chromium.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
 # This script rebuilds the Docker containers, installing a new version of
-# Chrome if available, and updates our user agent and image version number if
-# necessary. Rebuilding is somewhat time-consuming, so only run it when you
-# have reason to think there's a new Chrome version.
+# Chromium if specified in the Dockerfile, and updates our user agent and
+# image version number if necessary.
 
-ORIG_CACHE_BUSTER=`grep chrome-layer-cache-buster docker-compose.yml | awk  '{print $2}'`
-perl -pi -e "s/chrome-layer-cache-buster: .*/chrome-layer-cache-buster: $(uuidgen)/" docker-compose.yml
 docker-compose up -d --build
 LATEST=`docker-compose exec -T web bash -c "chromium --version" | cut -f 2 -d ' '`
 SETTING=`grep CAPTURE_USER_AGENT perma_web/perma/settings/deployments/settings_common.py | sed 's/.*Chrome\/\([^ ]*\)\(.*\)/\1/'`
@@ -15,7 +12,5 @@ if [ "$LATEST" != "$SETTING" ] ; then
     COUNTER=`grep perma3 docker-compose.yml | cut -f 2 -d '.'`
     let NEWCOUNTER=$COUNTER+1
     perl -pi -e "s/perma3:0.$COUNTER/perma3:0.$NEWCOUNTER/" docker-compose.yml
-else
-    perl -pi -e "s/chrome-layer-cache-buster: .*/chrome-layer-cache-buster: $ORIG_CACHE_BUSTER/" docker-compose.yml
 fi
 docker-compose down


### PR DESCRIPTION
As discussed IRL, this removes the cache-busting mechanism we used for Chrome and specifies Chromium version in the Dockerfile. It retains the update script, which is still needed to increment the image version in docker-compose.yml and update the user-agent setting, after manually updating the Dockerfile.