### PR TITLE
Update Chromium

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -66,6 +66,6 @@ RUN pip install pip==22.0.4 \
     && rm /perma/perma_web/requirements.txt
 
 # Install Chromium and driver
-ENV CHROMIUM_VERSION=100.0.4896.127-1~deb11u1
+ENV CHROMIUM_VERSION=101.0.4951.41-1~deb11u1
 RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
     chromium-driver chromium-l10n chromium-sandbox

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -595,7 +595,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []

--- a/update_chromium.sh
+++ b/update_chromium.sh
@@ -6,7 +6,7 @@
 docker-compose up -d --build
 LATEST=`docker-compose exec -T web bash -c "chromium --version" | cut -f 2 -d ' '`
 SETTING=`grep CAPTURE_USER_AGENT perma_web/perma/settings/deployments/settings_common.py | sed 's/.*Chrome\/\([^ ]*\)\(.*\)/\1/'`
-if [ "$LATEST" != "$SETTING" ] ; then
+if [ "$LATEST" != "$SETTING" ] && [ "$LATEST" != "" ]; then
     perl -pi -e "s/$SETTING/$LATEST/" perma_web/perma/settings/deployments/settings_common.py
 fi
 docker-compose down


### PR DESCRIPTION
In the absence of a release post or other announcement, here's a log of source changes:

https://chromium.googlesource.com/chromium/src/+log/100.0.4896.127..101.0.4951.41?pretty=fuller&n=10000

This PR also tweaks the update script to prevent it from writing a spurious change to `settings_common.py` if it can't get the new Chromium package.