### PR TITLE
Preparation for a chromium upgrade

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -69,7 +69,7 @@ RUN pip install pip==22.0.4 \
 COPY perma_web/lil-archive-keyring.gpg /usr/share/keyrings/lil-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/lil-archive-keyring.gpg] https://repo.lil.tools/ bullseye-security updates/main" > /etc/apt/sources.list.d/lil-chromium.list
 
-ENV CHROMIUM_VERSION=102.0.5005.61-1~deb11u1
+ENV CHROMIUM_VERSION=102.0.5005.115-1~deb11u1
 RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
     chromium-common=${CHROMIUM_VERSION} \
     chromium-driver=${CHROMIUM_VERSION} \

--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -71,4 +71,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/lil-archive-keyring.gpg] https://re
 
 ENV CHROMIUM_VERSION=102.0.5005.61-1~deb11u1
 RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
-    chromium-driver chromium-l10n chromium-sandbox
+    chromium-common=${CHROMIUM_VERSION} \
+    chromium-driver=${CHROMIUM_VERSION} \
+    chromium-l10n=${CHROMIUM_VERSION} \
+    chromium-sandbox=${CHROMIUM_VERSION}

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -606,7 +606,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.115 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -9,7 +9,7 @@ django-axes==5.27.0                     # limit login attempts
 Fabric3                                 # task automation
 netaddr                                 # to check archive IPs against banned ranges
 pytz                                    # timezone helper
-requests[security]==2.27.1
+requests
 tqdm                                    # progress bar in dev fab tasks
 Werkzeug<2.1                            # pin until https://github.com/django-extensions/django-extensions/issues/1715 lands
 uwsgitop                                # uWSGI monitoring

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -823,9 +823,9 @@ redis==4.1.4 \
     #   -r requirements.in
     #   django-redis
     #   fakeredis
-requests[security]==2.27.1 \
-    --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
-    --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
+requests==2.28.0 \
+    --hash=sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f \
+    --hash=sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b
     # via
     #   -r requirements.in
     #   azure-core


### PR DESCRIPTION
This upgrades `requests` in order to get past a pip resolution problem, discovered when trying to update chromium (and exercise our new chromium-upgrade workflow). It also explicitly installs each chromium package with the specified version, necessary when the repo contains more than one version.