### PR TITLE
CORS headers for api.domain.ext

### DIFF
--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -1,0 +1,15 @@
+from django.middleware.common import CommonMiddleware as DjangoCommonMiddleware
+
+class CORSMiddleware(DjangoCommonMiddleware):
+    """
+       Set `Access-Control-Allow-Origin: *` for API responses, including redirects.
+       Only applies if requests come from api.domain.ext.
+    """
+    def process_response(self, request, response):
+        response = super().process_response(request, response)
+        host = request.get_host()
+
+        if host.startswith("api."):
+            response["Access-Control-Allow-Origin"] = "*"
+            response["Access-Control-Allow-Headers"] = "Authorization"
+        return response

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -115,6 +115,7 @@ MIDDLEWARE = (
     # If you do not want Axes to override the authentication response
     # you can skip installing the middleware and use your own views.
     'axes.middleware.AxesMiddleware',
+    'api.middleware.CORSMiddleware'
 )
 # This defaults to 'SAMEORIGIN' w/ Django 2, but was changed to 'DENY' in Django 3
 X_FRAME_OPTIONS = 'DENY'


### PR DESCRIPTION
- Allows for the API to be used without proxy in a browser context.
- Adds `Access-Control-Allow-Origin: *` to the headers of the response of every API route. 
- Only applies to requests coming out of `api.domain.ext`.