### PR TITLE
Safari interstitials

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1928,10 +1928,13 @@ class Capture(models.Model):
     def use_sandbox(self):
         """
             Whether the iframe we use to display this capture should be sandboxed.
-            Answer is yes unless we're playing back a PDF, which currently can't
-            be sandboxed in Chrome.
+            Answer is yes, unless:
+            a) we're playing back a PDF, which currently can't be sandboxed in Chrome
+            b) the playback will be an on-demand download mediated by an interstitial,
+               because some browsers (for instance, Safari) may block downloads from sandboxed iframes even when `allow-downloads` is present.
+               See https://perma.cc/M36S-ZLVS for `allow-downloads` support on 6/22/22
         """
-        return not self.mime_type().startswith("application/pdf")
+        return not self.mime_type().startswith("application/pdf") and not self.show_interstitial()
 
     INLINE_TYPES = {'image/jpeg', 'image/gif', 'image/png', 'image/tiff', 'text/html', 'text/plain', 'application/pdf',
                     'application/xhtml', 'application/xhtml+xml'}

--- a/perma_web/replay/templates/iframe.html
+++ b/perma_web/replay/templates/iframe.html
@@ -134,8 +134,8 @@
           // inject a download link and click it
           console.log(`Opening ${elem.src} in a new window`)
           const download = document.createElement('a');
-          download.href = elem.src
-          download.target = '_blank'
+          download.href = elem.src;
+          download.setAttribute('download', '');
           download.click()
         } else if (target==='img'){
           // set alt text and style the loaded image for cross-browser consistency

--- a/perma_web/replay/templates/iframe.html
+++ b/perma_web/replay/templates/iframe.html
@@ -130,7 +130,7 @@
 
       const handle_target = async (elem) => {
         const target = "{{ target }}";
-        if (target==='blank'){
+        if (target==='blank' || ondemand){
           // inject a download link and click it
           console.log(`Opening ${elem.src} in a new window`)
           const download = document.createElement('a');

--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -27,7 +27,7 @@ def iframe(request):
         context['target_url'] = link.screenshot_capture.url if screenshot else link.submitted_url
         context['embed_style'] = 'replayonly' if replay_only else 'default'
         context['web_worker'] = web_worker
-        context['sandbox'] = link.primary_capture.use_sandbox()
+        context['sandbox'] = link.primary_capture.use_sandbox() and not ondemand
         context['hidden'] = hidden
         context['ondemand'] = ondemand
         context['target'] = target

--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -27,15 +27,10 @@ def iframe(request):
         context['target_url'] = link.screenshot_capture.url if screenshot else link.submitted_url
         context['embed_style'] = 'replayonly' if replay_only else 'default'
         context['web_worker'] = web_worker
+        context['sandbox'] = link.primary_capture.use_sandbox()
         context['hidden'] = hidden
         context['ondemand'] = ondemand
         context['target'] = target
-        # only sandbox when:
-        # a) the mime-type allows (https://github.com/harvard-lil/perma/blob/e761f4ab597c293f0fd6612e015428100899f28b/perma_web/perma/models.py#L1928)
-        # b) the playback will be inline in the browser, rather than an on-demand download mediated by an interstitial,
-        #    because some browsers (for instance, Safari) may block downloads from sandboxed iframes even when `allow-downloads` is present.
-        #    See https://perma.cc/M36S-ZLVS for `allow-downloads` support on 6/22/22.
-        context['sandbox'] = link.primary_capture.use_sandbox() and not ondemand
     response = render(request, 'iframe.html', context)
     response['Clear-Site-Data'] = '"cache", "cookies", "storage"'
     return response

--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -27,10 +27,15 @@ def iframe(request):
         context['target_url'] = link.screenshot_capture.url if screenshot else link.submitted_url
         context['embed_style'] = 'replayonly' if replay_only else 'default'
         context['web_worker'] = web_worker
-        context['sandbox'] = link.primary_capture.use_sandbox() and not ondemand
         context['hidden'] = hidden
         context['ondemand'] = ondemand
         context['target'] = target
+        # only sandbox when:
+        # a) the mime-type allows (https://github.com/harvard-lil/perma/blob/e761f4ab597c293f0fd6612e015428100899f28b/perma_web/perma/models.py#L1928)
+        # b) the playback will be inline in the browser, rather than an on-demand download mediated by an interstitial,
+        #    because some browsers (for instance, Safari) may block downloads from sandboxed iframes even when `allow-downloads` is present.
+        #    See https://perma.cc/M36S-ZLVS for `allow-downloads` support on 6/22/22.
+        context['sandbox'] = link.primary_capture.use_sandbox() and not ondemand
     response = render(request, 'iframe.html', context)
     response['Clear-Site-Data'] = '"cache", "cookies", "storage"'
     return response


### PR DESCRIPTION
@matteocargnelutti and I discovered three separate problems with [interstitial-mediated](https://github.com/harvard-lil/perma/pull/3036) (which is to say, download-triggering) client-side playbacks on Safari:

- because [Safari doesn't support `allow-downloads` on an `iframe` sandbox](https://hlslil.slack.com/archives/C07URASMC/p1655910220467019), we remove the sandbox whenever there is an interstitial

- because, when we [open a new tab](https://github.com/harvard-lil/perma/blob/1daf0ec2ee5aeed4a9df35af71b63b2cfb0ef539/perma_web/replay/templates/iframe.html#L138) in Safari, it doesn't direct the request to the service worker, letting it escape to the live web, we adopt a new strategy: use the [`download` attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download) instead

- because replaying a capture of something that -should- download, but wasn't served with all the right HTTP headers (for instance, https://github.com/harvard-lil/h2o/blob/develop/web/test/files/export/export-casebook-no-annotations.docx?raw=true, which is presently served without `Content-Disposition: attachment` and with `Content-Type: text/html; charset=utf-8`), doesn't reliably trigger a download in Safari (though it does in Firefox and Chrome), we force the issue: we use the "insert an anchor tag and click it" strategy for all interstitial-mediated playbacks

We can test with https://perma-stage.org/KW3M-Z39E?view-mode=client-side (a capture of that github-hosted docx) and, on mobile, https://perma-stage.org/QN6M-BWXH?view-mode=client-side