### PR TITLE
Perma API: Reworked CORS management

### DIFF
--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -2,14 +2,27 @@ from django.middleware.common import CommonMiddleware as DjangoCommonMiddleware
 
 class CORSMiddleware(DjangoCommonMiddleware):
     """
-       Set `Access-Control-Allow-Origin: *` for API responses, including redirects.
-       Only applies if requests come from api.domain.ext.
+       Add CORS headers to requests made to `api.domain.ext`, so the API can be used in the browser.
     """
     def process_response(self, request, response):
         response = super().process_response(request, response)
+
         host = request.get_host()
+        origin = request.headers.get("Origin")
+
+        if not origin:
+            origin = "*"
 
         if host.startswith("api."):
-            response["Access-Control-Allow-Origin"] = "*"
+            # Always return HTTP 200 for preflight requests in that context (?)
+            # Note: This is a workaround to circumvent auth issues during preflight.
+            if request.method == "OPTIONS":
+                response.status_code = 200
+
+            response["Access-Control-Allow-Origin"] = origin
             response["Access-Control-Allow-Headers"] = "Authorization"
+            response["Access-Control-Allow-Methods"] = "*"
+            #response["Access-Control-Allow-Credentials"] = "true"
+            # ^ Uncomment if we want to allow fetch() / XMLHttpRequest to implicitly pass credentials (i.e: HTTP auth stored in session).  
+
         return response

--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -8,21 +8,21 @@ class CORSMiddleware(DjangoCommonMiddleware):
         response = super().process_response(request, response)
 
         host = request.get_host()
-        origin = request.headers.get("Origin")
 
-        if not origin:
+        origin = request.headers.get("Origin")
+        if not origin: # Set origin to `*` if none was provided.
             origin = "*"
 
         if host.startswith("api."):
-            # Always return HTTP 200 for preflight requests in that context (?)
-            # Note: This is a workaround to circumvent auth issues during preflight.
-            if request.method == "OPTIONS":
+            # Force HTTP 200 for preflight requests (?).
+            # This is a temporary workaround to account for the fact that the browser will not pass a `Authorization` header during preflight, which will trigger a 401.
+            if request.method == "OPTIONS" and response.status_code == 401:
                 response.status_code = 200
 
             response["Access-Control-Allow-Origin"] = origin
             response["Access-Control-Allow-Headers"] = "Authorization"
             response["Access-Control-Allow-Methods"] = "*"
             #response["Access-Control-Allow-Credentials"] = "true"
-            # ^ Uncomment if we want to allow fetch() / XMLHttpRequest to implicitly pass credentials (i.e: HTTP auth stored in session).  
+            # ^ Uncomment if we want to allow `fetch()` / `XMLHttpRequest`` to implicitly pass credentials (i.e: HTTP auth stored in session).  
 
         return response

--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -14,10 +14,10 @@ class CORSMiddleware(DjangoCommonMiddleware):
             origin = "*"
 
         if host.startswith("api."):
-            # Force HTTP 200 for preflight requests (?).
-            # The browser doesn't pass a `Authorization` header during preflight (in most cases).
+            # Force HTTP 204 for preflight requests (?).
+            # The browser doesn't pass a `Authorization` header during preflight (in most cases), our API therefore assumes this resource can't be accessed.
             if request.method == "OPTIONS" and response.status_code == 401:
-                response.status_code = 200
+                response.status_code = 204
 
             response["Access-Control-Allow-Origin"] = origin
             response["Access-Control-Allow-Headers"] = "Authorization"

--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -15,7 +15,7 @@ class CORSMiddleware(DjangoCommonMiddleware):
 
         if host.startswith("api."):
             # Force HTTP 200 for preflight requests (?).
-            # This is a temporary workaround to account for the fact that the browser will not pass a `Authorization` header during preflight, which will trigger a 401.
+            # The browser doesn't pass a `Authorization` header during preflight (in most cases).
             if request.method == "OPTIONS" and response.status_code == 401:
                 response.status_code = 200
 
@@ -23,6 +23,6 @@ class CORSMiddleware(DjangoCommonMiddleware):
             response["Access-Control-Allow-Headers"] = "Authorization"
             response["Access-Control-Allow-Methods"] = "*"
             #response["Access-Control-Allow-Credentials"] = "true"
-            # ^ Uncomment if we want to allow `fetch()` / `XMLHttpRequest`` to implicitly pass credentials (i.e: HTTP auth stored in session).  
+            # ^ Uncomment if we want to allow the browser to implicitly pass stored credentials.
 
         return response


### PR DESCRIPTION
### Problems identified with previous implementation
- We [can't / shouldn't have both `Access-Control-Allow-Origin: *` and use the `Authorization` header](https://javascript.info/fetch-crossorigin#summary) in that context.
- Setting `Access-Control-Allow-Origin` to the origin of the incoming request still results in failed preflight requests, as the `Authorization` header is not passed during preflight _(Django therefore returns HTTP 401)_. 

### Proposed fix
- Set `Access-Control-Allow-Origin` to the origin of the incoming request when possible
- _"Force"_ HTTP 204 on `OPTIONS` requests that resulted in a 401, so CORS preflight passes.

### Not included / commented out
- I don't believe we want passive cross-origin credentials passing _(i.e cookies, stored HTTP auth)_. I left `Access-Control-Allow-Credentials` commented-off on purpose. 

Workaround tested on Chrome latest, Firefox latest.