### PR TITLE
Perma API: CORS Fix update

### DIFF
--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -15,7 +15,7 @@ class CORSMiddleware(DjangoCommonMiddleware):
             # Force HTTP 200 for preflight requests (?).
             # The browser doesn't pass a `Authorization` header during preflight (in most cases), our API therefore assumes this resource can't be accessed.
             if request.method == "OPTIONS" and response.status_code == 401:
-                response.status_code = 204
+                response.status_code = 200
 
             response["Access-Control-Allow-Origin"] = origin
             response["Access-Control-Allow-Headers"] = "Authorization"

--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -7,14 +7,12 @@ class CORSMiddleware(DjangoCommonMiddleware):
     def process_response(self, request, response):
         response = super().process_response(request, response)
 
-        host = request.get_host()
-
         origin = request.headers.get("Origin")
         if not origin: # Set origin to `*` if none was provided.
             origin = "*"
 
-        if host.startswith("api."):
-            # Force HTTP 204 for preflight requests (?).
+        if "/v1/" in request.get_raw_uri(): # Applies to `/v1/` API urls.
+            # Force HTTP 200 for preflight requests (?).
             # The browser doesn't pass a `Authorization` header during preflight (in most cases), our API therefore assumes this resource can't be accessed.
             if request.method == "OPTIONS" and response.status_code == 401:
                 response.status_code = 204


### PR DESCRIPTION
**Tentative:** Using `request.get_host()` to determine which requests need CORS headers might prove problematic on prod. This PR uses a sub-segment of `request.get_raw_uri()` instead as a tentative workaround.

Also changed HTTP status code from 204 to 200 _(responses are not empty)_.