### PR TITLE
API CORS: Added "Content-Type" to the list of allowed headers

### DIFF
--- a/perma_web/api/middleware.py
+++ b/perma_web/api/middleware.py
@@ -19,7 +19,7 @@ class CORSMiddleware(DjangoCommonMiddleware):
                 response.status_code = 200
 
             response["Access-Control-Allow-Origin"] = origin
-            response["Access-Control-Allow-Headers"] = "Authorization"
+            response["Access-Control-Allow-Headers"] = "Authorization,Content-Type"
             response["Access-Control-Allow-Methods"] = "*"
             #response["Access-Control-Allow-Credentials"] = "true"
             # ^ Uncomment if we want to allow the browser to implicitly pass stored credentials.


### PR DESCRIPTION
**Reason for adding this headers to the allow list:** 
Some preflight requests may have `Content-Type: "application/json"` in their headers, which may get rejected depending on client implementation of CORS. 