### PR TITLE
Hide the replayweb.page chrome unless `embed=False` is requested.

### DIFF
--- a/perma_web/perma/templates/archive/includes/client_side_iframe.html
+++ b/perma_web/perma/templates/archive/includes/client_side_iframe.html
@@ -5,7 +5,7 @@
     const cls = "{{ interstitial|yesno:'interstitial,archive-iframe'}}";
     const origin = "{{ protocol }}{{ client_side_playback_host }}";
     const guid = "{{ link.guid }}";
-    const embed = {{ compare_replays|yesno:"true,false" }};
+    const embed = {{ embed|yesno:"true,false" }};
     const screenshot = {{ screenshot|yesno:"true,false" }};
     const interstitial = {{ interstitial|yesno:"true,false" }};
     const target = {% if target %}"{{ target }}"{% else %}null{% endif %};

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -223,6 +223,7 @@ def single_permalink(request, guid):
         if context['view_mode'] in ['client-side', 'compare']:
             logger.info(f'Preparing client-side playback for {link.guid}')
             context['client_side_playback_host'] = f"{settings.PLAYBACK_SUBDOMAIN}.{settings.HOST}"
+            context['embed'] = False if request.GET.get('embed') == 'False' else True
         if context['view_mode'] in ['server-side', 'compare']:
             try:
                 logger.info(f"Preparing server-side play back of {link.guid}")


### PR DESCRIPTION
The team decided that we'd rather hide the replayweb.page interface by default, displaying it only on demand or to power users. This PR hides it unless you supply the GET param `embed=False`. It does not add anything to the UI for power users: this will be just for us (or anyone who reads the code), for the time being.

New default:

![image](https://user-images.githubusercontent.com/11020492/182176072-65dbe0b6-ded8-4786-a6c9-35957fcb06e8.png)

With &embed=False:
![image](https://user-images.githubusercontent.com/11020492/182176161-5b99bbd3-663f-4e21-bd7c-bdbc672aa5f9.png)
