### PR TITLE
Don't clear cookies via Clear-Site-Data header

### DIFF
--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -32,7 +32,7 @@ def iframe(request):
         context['ondemand'] = ondemand
         context['target'] = target
     response = render(request, 'iframe.html', context)
-    response['Clear-Site-Data'] = '"cache", "cookies", "storage"'
+    response['Clear-Site-Data'] = '"cache", "storage"'
     return response
 
 


### PR DESCRIPTION
Even if you send this header from a subdomain, Chrome is clearing all the cookies for the whole domain... which in our case, logs you out of Perma.

This sounds incorrect but intentional: see the [targeted clearing](https://w3c.github.io/webappsec-clear-site-data/#example-targeted) example in the spec, but compare with the remark that they clear for the [entire registered domain](https://w3c.github.io/webappsec-clear-site-data/#clear-cookies).

🤷‍♀️ 

We can consider adding some cookie-cleanup JS in [the template](https://github.com/harvard-lil/perma/blob/develop/perma_web/replay/templates/iframe.html#L188-L191); quick experiments with cnn.com suggest said JS will be finicky.

