### PR TITLE
Don't target the submitted URL; target the primary capture's URL.

### DIFF
--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -24,7 +24,7 @@ def iframe(request):
         link = get_object_or_404(Link.objects.prefetch_related('captures'), guid=guid)
         context['guid'] = link.guid
         context['warc_source_allowed_host'] = urllib.parse.urlparse(link.warc_presigned_url()).netloc
-        context['target_url'] = link.screenshot_capture.url if screenshot else link.submitted_url
+        context['target_url'] = link.screenshot_capture.url if screenshot else link.primary_capture.url
         context['embed_style'] = 'replayonly' if replay_only else 'default'
         context['web_worker'] = web_worker
         context['sandbox'] = link.primary_capture.use_sandbox()


### PR DESCRIPTION
In most cases, a `Link`'s `.submitted_url` is the same as the `Link`'s [`.primary_capture.url`](https://github.com/harvard-lil/perma/blob/develop/perma_web/api/views.py#L486)... but not when a user uses the upload-your-own feature to [replace a broken capture with a PDF or image](https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/models.py#L1702).

This PR updates client-side playbacks to point at the correct target URL... as we've long been doing with [server-side playback](https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/views/common.py#L243).