### PR TITLE
Case insensitive email addresses

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -137,6 +137,10 @@ class UserForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
     def save(self, commit=True):
+        # From Sept 2022 onwards: all email addresses are lowercase
+        if self.instance.email:
+            self.instance.email = self.instance.email.lower()
+
         # save user, and set a password so that the password_reset flow can be
         # used for email confirmation
         self.instance.set_password(LinkUser.objects.make_random_password(length=20))


### PR DESCRIPTION
First attempt at figuring out a solution for #3152. 

---

I decided to start with the smallest fix I could think of to deal with this issue, and see where the discussion takes us 😄 .

### What does it do?
- It forces `str.lower()` on the `email` field of `UserForm`, so all new users will have a lower case email. This applies to the entire email address.

### Why this might be a good idea?
- It deals with our problem _"moving forward"_, without creating problems for existing users (?).
- We can then handle existing casing conflicts on a case-by-case basis, as brought to our attention.

### Why this might not be a good idea?
- The sign-in form remains case sensitive to accommodate for existing records (and conflicts). 
One can easily imagine users registering as `PersonName@domain.ext` and try to sign-in as `personname@domain.ext`, which would not work.
  - Is this something that can be fixed with a better error message?
  - Or would we want to implement an _"auto-retry"_ on the sign-in form, the second attempt using a lowercase version of the email address?
- [Saving email usernames with their original casing but checking them in a case-insensitive way is sometimes recommended](https://django-improved-user.readthedocs.io/en/stable/email_warning.html). 

---

PS: @rebeccacremona 

I haven't added a test yet, and wanted to ask how you would go about testing this.

**First idea:** adding a test case in `test_views_user_management.py`, something that tries to call the `/sign-up` form twice with the same email, but different casing.

```python3
def test_signup_email_case_insensitive(self):
    self.submit_form('sign_up',
                    data = {'e-address': "personname@test.com", 'first_name': 'Person', 'last_name': 'Name'},
                    success_url = reverse('register_email_instructions'))

    self.submit_form('sign_up',
                    data = {'e-address': "personNAME@test.com", 'first_name': 'Person', 'last_name': 'Name'},
                    error_keys=['email'])
```

---

Ping @kilbergr 