### PR TITLE
Client-side playback: conditional use of `noCache`

### DIFF
--- a/perma_web/perma/templates/archive/includes/client_side_iframe.html
+++ b/perma_web/perma/templates/archive/includes/client_side_iframe.html
@@ -16,11 +16,44 @@
         worker = false
     }
 
+    // If browser doesn't support StorageManager.estimate() API, use `noCache`
+    let cache = false;
+    if (!navigator.storage.estimate) {
+        cache = true;
+    }
+
     // Add iframe
     const frame = document.createElement('iframe');
     frame.setAttribute('name', name);
     frame.className = cls;
-    frame.setAttribute('src', `${origin}?guid=${guid}${embed ? "&embed=replayonly" : ""}${screenshot ? "&type=screenshot" : ""}${interstitial ? "&hidden=true&ondemand=true" : ""}${target ? "&target="+target : ""}${!worker ? "&worker=false" : ""}`)
+
+    const srcQuery = new URLSearchParams();
+    srcQuery.append("guid", guid);
+    srcQuery.append("embed", "replayonly");
+    
+    if (screenshot) {
+        srcQuery.append("type", "screenshot");
+    }
+
+    if (interstitial) {
+        srcQuery.append("hidden", "true");
+        srcQuery.append("ondemand", "true");
+    }
+
+    if (target) {
+        srcQuery.append("target", target);
+    }
+
+    if (!worker) {
+        srcQuery.append("worker", "false");
+    }
+
+    if (!cache) {
+        srcQuery.append("cache", "false");
+    }
+
+    frame.setAttribute("src", `${origin}?${srcQuery}`)
+
     const wrapper = document.getElementById("iframe-target");
     wrapper.appendChild(frame);
 </script>

--- a/perma_web/replay/templates/iframe.html
+++ b/perma_web/replay/templates/iframe.html
@@ -70,6 +70,7 @@
     const sandbox = {{ sandbox|yesno:"true,false" }};
     const replayBase = "{% static "vendors/replay-web-page" %}/";
     const webWorker = {{ web_worker|yesno:"true,false" }};
+    const cache = {{ cache|yesno:"true,false" }};
 
     //
     // If we are in an iframe: offer a replay
@@ -157,7 +158,10 @@
         throw `Forbidden warc source: ${warcSource}`
       }
 
-      console.log(`Requesting playback of Perma Link ${guid} (${url}) from ${warcSource} with${webWorker ? '' : 'out'} a web worker`)
+      console.log(
+        `Requesting playback of Perma Link ${guid} with the following options:`, 
+        {guid, url, warcSource, webWorker, cache}
+      );
 
       const replay = document.createElement('replay-web-page');
       replay.setAttribute('replayBase', replayBase);
@@ -165,10 +169,13 @@
       replay.setAttribute('url', url);
       replay.setAttribute('view', 'replay');
       replay.setAttribute('embed', embedStyle);
-      replay.setAttribute('noCache', '');
 
       if (!sandbox) {
         replay.setAttribute('noSandbox', '');
+      }
+
+      if (!cache) {
+        replay.setAttribute('noCache', '');
       }
 
       if (!webWorker) {

--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -11,8 +11,10 @@ def iframe(request):
     screenshot = request.GET.get('type', '') == 'screenshot'
     replay_only = request.GET.get('embed', '') == 'replayonly' or screenshot
     web_worker = not request.GET.get('worker', '') == 'false'
+    cache = request.GET.get('cache', '') == 'false'
     hidden = request.GET.get('hidden', '') == 'true'
     ondemand = request.GET.get('ondemand', '') == 'true'
+
     if request.GET.get('target', '') == 'blank':
         target = 'blank'
     elif screenshot:
@@ -27,6 +29,7 @@ def iframe(request):
         context['target_url'] = link.screenshot_capture.url if screenshot else link.primary_capture.url
         context['embed_style'] = 'replayonly' if replay_only else 'default'
         context['web_worker'] = web_worker
+        context['cache'] = cache
         context['sandbox'] = link.primary_capture.use_sandbox()
         context['hidden'] = hidden
         context['ondemand'] = ondemand


### PR DESCRIPTION
- Use `noCache` only if `StorageManager.estimate()` is not available. [[1]](https://lil.law.harvard.edu/blog/2022/09/15/opportunities-and-challenges-of-client-side-playback/#:~:text=There%20seems%20to%20be%20a%20strong%2Denough%20correlation%20between)
- Minor syntax tweaks