### PR TITLE
Opt back in to the default SameSite behavior for session cookies.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -493,11 +493,7 @@ SECURE_SSL_REDIRECT = True
 SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_NAME = '__Host-sessionid'
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
-# Disable SameSite protection (https://www.owasp.org/index.php/SameSite)
-# So that we can set iframe cookies properly, when we receive the redirect from Webrecorder
-# https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-SESSION_COOKIE_SAMESITE
-SESSION_COOKIE_SAMESITE = None
+SESSION_COOKIE_SAMESITE = 'Lax'
 
 API_VERSION = 1
 


### PR DESCRIPTION
Since we [dropped server-side playback](https://github.com/harvard-lil/perma/pull/3169), we no longer need [special cookie settings](https://github.com/harvard-lil/perma/issues/2985) for private playbacks.

This PR explicitly sets the behavior to 'Lax' instead of removing the setting entirely for clarity; we could remove it instead if people think that is preferable.