### PR TITLE
Tasks added in #3187 should be routed to the IA celery queue.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -443,6 +443,10 @@ CELERY_TASK_ROUTES = {
     'perma.tasks.cache_playback_status': {'queue': 'background'},
     'perma.tasks.populate_warc_size_fields': {'queue': 'background'},
     'perma.tasks.populate_warc_size': {'queue': 'background'},
+    'perma.tasks.queue_backfill_of_individual_link_internet_archive_objects': {'queue': 'ia'},
+    'perma.tasks.queue_backfill_of_daily_internet_archive_objects': {'queue': 'ia'},
+    'perma.tasks.backfill_daily_internet_archive_objects': {'queue': 'ia'},
+    'perma.tasks.backfill_individual_link_internet_archive_objects': {'queue': 'ia'},
 }
 
 # internet archive stuff


### PR DESCRIPTION
We use three separate celery queues: the main queue (for capture jobs), the background queue (for non-essential things like updating our records on how big newly-captured warcs are), and a separate queue just for Internet Archive-related tasks. That lets us fine-tune the amount of resources devoted to each, by spinning up or down the number of workers for each queue.

The one-time tasks added in #3187 should be routed to the IA-specific celery queue. (I forgot to include this in the original PR).