### PR TITLE
"Description" not present on all individual link IA items.

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1584,7 +1584,7 @@ def backfill_individual_link_internet_archive_objects(link_guid):
             'added_date': InternetArchiveItem.datetime(ia_item.metadata['addeddate']),
             'cached_file_count': ia_item.files_count,
             'cached_title': ia_item.metadata['title'],
-            'cached_description': ia_item.metadata['description']
+            'cached_description': ia_item.metadata.get('description')
         }
     )
     logger.info(f"{'Created IA Item' if created else 'Existing IA Item found'} for {identifier}.")


### PR DESCRIPTION
This PR fixes a bug in [#3187](https://github.com/harvard-lil/perma/pull/3187): I expected all Items to have their "description" field populated in Internet Archive, and they don't. Our test run against the first 1000 Perma Links uploaded to IA found 6 such Items. This fix will let us run against our full collection.

### Context

We are reorganizing Perma's [Internet Archive collection](https://archive.org/details/perma_cc). In the past, we would add an "Item" with a single "File" to the collection for each new Perma Link; going forward, we've been asked to instead create one digest-like Item per day, with Files for each of the Perma Links created on that day.

See this [internal document](https://docs.google.com/document/d/1yeiW47MahmTPC4Sh4zunCXgaapBTX8k8DjDb8r-9ifM/edit#heading=h.j7du1d5sm17f) for a complete description of the project; see also its [project board](https://github.com/orgs/harvard-lil/projects/6/views/1).