### PR TITLE
Less expensive URL filter

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -278,14 +278,14 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
         self.assertEqual(objs[1]['notes'], 'Maybe the source of all cool things on the internet.')
 
     def test_should_allow_filtering_url(self):
-        data = self.successful_get(self.logged_in_list_url, data={'url': 'metafilter'}, user=self.regular_user)
+        data = self.successful_get(self.logged_in_list_url, data={'url': 'metafilter.com'}, user=self.regular_user)
         objs = data['objects']
 
         self.assertEqual(len(objs), 2)
         self.assertEqual(objs[0]['title'], 'MetaFilter | Community Weblog')
 
     def test_should_allow_filtering_by_date_and_query(self):
-        data = self.successful_get(self.logged_in_list_url, data={'url': 'metafilter','date':"2016-12-07T18:55:37Z"}, user=self.regular_user)
+        data = self.successful_get(self.logged_in_list_url, data={'url': 'metafilter.com','date':"2016-12-07T18:55:37Z"}, user=self.regular_user)
         objs = data['objects']
 
         self.assertEqual(len(objs), 1)
@@ -294,7 +294,7 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
 
     def test_should_allow_filtering_by_date_range_and_query(self):
         data = self.successful_get(self.logged_in_list_url, data={
-            'url': 'metafilter',
+            'url': 'metafilter.com',
             'min_date':"2016-12-06T18:55:37Z",
             'max_date':"2016-12-08T18:55:37Z",
         }, user=self.regular_user)

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -12,6 +12,7 @@ from rest_framework.filters import SearchFilter, OrderingFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+import surt
 
 from perma.utils import stream_warc, stream_warc_if_permissible
 from perma.tasks import run_next_capture
@@ -279,10 +280,18 @@ class LinkFilter(django_filters.rest_framework.FilterSet):
     date = django_filters.IsoDateTimeFilter(field_name="creation_timestamp", lookup_expr='date')      # ?date=
     min_date = django_filters.IsoDateTimeFilter(field_name="creation_timestamp", lookup_expr='gte')   # ?min_date=
     max_date = django_filters.IsoDateTimeFilter(field_name="creation_timestamp", lookup_expr='lte')   # ?max_date=
-    url = django_filters.CharFilter(field_name="submitted_url", lookup_expr='icontains')              # ?url=
+    url = django_filters.CharFilter(method='surt_filter')                                             # ?url=
+
     class Meta:
         model = Link
         fields = ['url', 'date', 'min_date', 'max_date']
+
+    def surt_filter(self, queryset, name, value):
+        try:
+            canonicalized = surt.surt(value)
+        except ValueError:
+            return queryset
+        return queryset.filter(submitted_url_surt=canonicalized)
 
 
 # /public/archives

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -286,7 +286,7 @@ class LinkFilter(django_filters.rest_framework.FilterSet):
         model = Link
         fields = ['url', 'date', 'min_date', 'max_date']
 
-    def surt_filter(self, queryset, name, value):
+    def surt_filter(self, queryset, _name, value):
         try:
             canonicalized = surt.surt(value)
         except ValueError:

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -290,6 +290,9 @@ class LinkFilter(django_filters.rest_framework.FilterSet):
         try:
             canonicalized = surt.surt(value)
         except ValueError:
+            # if the user-specified value is not a valid URL and therefore cannot be parsed
+            # and formatted as a surt, return the queryset as is, as though `url` was not
+            # included in the querystring
             return queryset
         return queryset.filter(submitted_url_surt=canonicalized)
 


### PR DESCRIPTION
Make the API's URL filter do an exact match on surt instead of a fuzzy match on submitted_url so that queries over large link sets require less CPU. See [Slack](https://hlslil.slack.com/archives/C07URASMC/p1664542903409909) for context.