### PR TITLE
Fix `cached_path` bug for new org folders

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -715,6 +715,7 @@ class Organization(DeletableModel):
             return
         shared_folder = Folder(name=self.name, organization=self, is_shared_folder=True)
         shared_folder.save()
+        shared_folder.refresh_from_db()
         self.shared_folder = shared_folder
         self.save()
 

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -348,6 +348,13 @@ class ModelsTestCase(PermaTestCase):
         self.assertEqual(f'{f1.pk}-{f3.pk}', f3.cached_path)
         self.assertEqual(f'{f1.pk}-{f3.pk}-{f3_1.pk}', f3_1.cached_path)
 
+    def test_cached_path_is_set_for_new_orgs(self):
+        r = Registrar()
+        r.save()
+        o = Organization(registrar=r)
+        o.save()
+        o.refresh_from_db()
+        assert o.shared_folder.cached_path
 
     def test_link_count_in_time_period_no_links(self):
         '''


### PR DESCRIPTION
See https://github.com/harvard-lil/perma/issues/3193 for details.

Without this, when new orgs are created, their shared folder doesn't get its "path" (location in the folder tree) cached on the model, so every time we need to know it, we have to re-calculate it, which results in a lot of unnecessary database queries.

After this fix is deployed, we'll want to take care of the folders that fell through the cracks.