### PR TITLE
Added audio & video types to `INLINE_TYPES` for direct playback

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1799,13 +1799,30 @@ class Capture(models.Model):
         """
         return not self.mime_type().startswith("application/pdf") and not self.show_interstitial()
 
-    INLINE_TYPES = {'image/jpeg', 'image/gif', 'image/png', 'image/tiff', 'text/html', 'text/plain', 'application/pdf',
-                    'application/xhtml', 'application/xhtml+xml'}
+    INLINE_TYPES = {
+        'image/jpeg', 
+        'image/gif', 
+        'image/png', 
+        'image/tiff', 
+        'text/html', 
+        'text/plain', 
+        'application/pdf',
+        'application/xhtml', 
+        'application/xhtml+xml', 
+        'video/mp4', 
+        'video/webm', 
+        'video/ogg', 
+        'application/ogg',
+        'audio/ogg',
+        'audio/mpeg',
+        'audio/x-wav',
+        'audio/wav'
+    }
 
     def show_interstitial(self):
         """
             Whether we should show an interstitial view/download button instead of showing the content directly.
-            True unless we recognize the mime type as something that should be shown inline (PDF/HTML/image).
+            True unless we recognize the mime type as something that should be shown inline (PDF/HTML/image/audio/video).
         """
         return self.mime_type() not in self.INLINE_TYPES
 


### PR DESCRIPTION
## Summary 

This PR deactivates the download interstitial for media formats that `<replay-web-page>` supports. 
This concerns direct captures of media resources, as opposed to pages containing medias. 

The following formats should now play back directly instead of triggering the download interstitial: 
- `video/mp4`
- `video/webm`
- `video/ogg`
- `application/ogg`
- `audio/ogg`
- `audio/mpeg`
- `audio/x-wav`
- `audio/wav`

---

## Expected behavior

### Before
<img width="1417" alt="Screen Shot 2022-10-24 at 11 25 02 AM" src="https://user-images.githubusercontent.com/625889/197564405-a25394e4-798c-4cca-8ced-3b6f3f83bb8e.png">

### After
<img width="1417" alt="Screen Shot 2022-10-24 at 11 23 59 AM" src="https://user-images.githubusercontent.com/625889/197564430-f1cbbacc-be2b-4661-b7b1-6b621d83b704.png">

Users will still be able to download the media by right-clicking it, or by downloading the archive. 