### PR TITLE
"Incompatible browser" alert

### DIFF
--- a/perma_web/perma/templates/archive/includes/client_side_iframe.html
+++ b/perma_web/perma/templates/archive/includes/client_side_iframe.html
@@ -1,44 +1,60 @@
 <div id="iframe-target"></div>
 <script>
-    // Playback details
-    const name = "{{ link.warc_presigned_url | escapejs }}";
-    const cls = "{{ interstitial|yesno:'interstitial,archive-iframe'}}";
-    const origin = "{{ protocol }}{{ client_side_playback_host }}";
-    const guid = "{{ link.guid }}";
-    const sandbox = {{ link.primary_capture.use_sandbox|yesno:"true,false" }};
-    const embed = {{ embed|yesno:"true,false" }};
-    const screenshot = {{ screenshot|yesno:"true,false" }};
-    const interstitial = {{ interstitial|yesno:"true,false" }};
-    const target = {% if target %}"{{ target }}"{% else %}null{% endif %};
+  // [!] Caution when updating:
+  // This script needs to be written in an ES5-compatible way. 
+  // This is so it doesn't crash before the "incompatible browser" message shows. 
 
-    // Add iframe
-    const frame = document.createElement('iframe');
-    frame.setAttribute('name', name);
-    frame.className = cls;
+  // Playback details
+  const name = "{{ link.warc_presigned_url | escapejs }}";
+  const cls = "{{ interstitial|yesno:'interstitial,archive-iframe'}}";
+  const origin = "{{ protocol }}{{ client_side_playback_host }}";
+  const guid = "{{ link.guid }}";
+  const sandbox = {{ link.primary_capture.use_sandbox|yesno:"true,false" }};
+  const embed = {{ embed|yesno:"true,false" }};
+  const screenshot = {{ screenshot|yesno:"true,false" }};
+  const interstitial = {{ interstitial|yesno:"true,false" }};
+  const target = {% if target %}"{{ target }}"{% else %}null{% endif %};
 
-    const srcQuery = new URLSearchParams();
+  var frame = null;
+  var srcQuery = null;
+
+  // Add iframe
+  frame = document.createElement('iframe');
+  frame.setAttribute('name', name);
+  frame.className = cls;
+
+  // Build query string
+  try {
+    srcQuery = new URLSearchParams();
     srcQuery.append("guid", guid);
     srcQuery.append("embed", "replayonly");
     
     if (screenshot) {
-        srcQuery.append("type", "screenshot");
+      srcQuery.append("type", "screenshot");
     }
 
     if (interstitial) {
-        srcQuery.append("hidden", "true");
-        srcQuery.append("ondemand", "true");
+      srcQuery.append("hidden", "true");
+      srcQuery.append("ondemand", "true");
     }
 
     if (target) {
-        srcQuery.append("target", target);
+      srcQuery.append("target", target);
     }
+  }
+  // Don't bother if `URLSearchParams` is not available: 
+  // If that's the case, neither are the other key features we need for playback. 
+  // Display `<iframe>` as is, which will display "incompatible browser" alert.
+  catch(err) {
+    srcQuery = "";
+  }
 
-    frame.setAttribute("src", `${origin}?${srcQuery}`);
+  frame.setAttribute("src", origin + "?" + srcQuery);
 
-    if (sandbox) {
-        frame.setAttribute("sandbox", "allow-scripts allow-forms allow-same-origin allow-downloads");
-    }
+  if (sandbox) {
+    frame.setAttribute("sandbox", "allow-scripts allow-forms allow-same-origin allow-downloads");
+  }
 
-    const wrapper = document.getElementById("iframe-target");
-    wrapper.appendChild(frame);
+  const wrapper = document.getElementById("iframe-target");
+  wrapper.appendChild(frame);
 </script>

--- a/perma_web/replay/templates/iframe.html
+++ b/perma_web/replay/templates/iframe.html
@@ -116,7 +116,6 @@
 
   <script type="module" src="{% static "vendors/replay-web-page/ui.js" %}"></script>
   <script type="module">
-    return;
     //
     // Module-level constants
     //

--- a/perma_web/replay/templates/iframe.html
+++ b/perma_web/replay/templates/iframe.html
@@ -62,24 +62,34 @@
       font-weight: 300;
       color: #333333;
       padding: 1rem;
+      /* Prevent flashing: */
+      opacity: 0;
+      animation: no-playback-fade-in 0.5s ease-in-out;
+      animation-iteration-count: 1;
+      animation-fill-mode: forwards;
+    }
+
+    @keyframes no-playback-fade-in {
+      0%    { opacity: 0; }
+      20%   { opacity: 0; }
+      80%   { opacity: 0.5; }
+      100%  { opacity: 1; }
     }
 
     #no-playback div {
       text-align: center;
     }
 
-    #no-playback p {
+    #no-playback h2 {
       font-size: clamp(20px, 3vmax, 36px);
       margin-top: 0px;
-      margin-bottom: 1em;
-    }
-
-    #no-playback p:first-of-type {
       margin-bottom: 0.35em;
+      font-weight: 100;
     }
 
-    #no-playback p.small {
+    #no-playback p {
       font-size: clamp(14px, 1.25vmax, 18px);
+      line-height: 1.5em;
       color: gray;
       margin-bottom: 1.5em;
     }
@@ -91,11 +101,26 @@
 </head>
 <body>
 
+  <!-- Will display unless playback logic can kick in -->
+  <main id="no-playback">
+    <div>
+      <h2>Incompatible browser</h2>
+      <p>
+        Please update your browser to visit this Perma Link.<br>
+        Perma.cc has been tested with the latest version of:<br>
+        Google Chrome, Mozilla Firefox, Apple Safari and Microsoft Edge.
+      </p>    
+      <a class="button" href="javascript:history.back()">Go back</a>
+    <div>
+  </main>
+
   <script type="module" src="{% static "vendors/replay-web-page/ui.js" %}"></script>
   <script type="module">
+    return;
     //
     // Module-level constants
     //
+    const noPlayback = document.querySelector("#no-playback");
     const guid = "{{ guid }}";
     const warcSourceAllowedHost = "{{ warc_source_allowed_host }}";
     const warcSource = window.name.startsWith("http") ? new URL(window.name) : null;
@@ -114,6 +139,9 @@
     // If we are in an iframe: offer a replay
     //
     if (guid && window.location != window.parent.location) {
+
+      // Delete `#no-playback` message
+      noPlayback.remove();
 
       // Standard mode: inject and start player.
       if (ondemand !== true) {
@@ -134,19 +162,13 @@
     } 
     //
     // Otherwise :
-    // - Display a simple no-playback page
+    // - Replace `#no-playback` copy to indicate no Perma Link was found
     // - Clean up after any earlier attempted playback (remove once `Clear-Site-Data` is supported).
     //
     else {
-      const content = document.createElement('div');
-      content.id = 'no-playback'
-      content.innerHTML = `
-      <div>
-        <p>No Perma Link to replay.</p>
-        <p class="small">Tip: visiting this page clears your playback cache.</p>
-        <a class="button" href="javascript:history.back()">Go back</a>
-      </div>`;
-      document.body.appendChild(content);
+      noPlayback.querySelector("h2").innerText = `No Perma Link to replay.`;
+      noPlayback.querySelector("p").innerHTML = ``;
+      noPlayback.querySelector("p").innerText = `Tip: visiting this page clears your playback cache`;
 
       await unregisterServiceWorkers();
       await clearStorage();


### PR DESCRIPTION
Tentative implementation of #3141 .

This implementation renders the _"Incompatible browser"_ alert by default, in all cases, at `<iframe>` level. 
The alert gets removed by the playback logic once it kicks in, which it never does on incompatible browsers. 

<img width="1305" alt="Screen Shot 2022-10-31 at 1 19 19 PM" src="https://user-images.githubusercontent.com/625889/199069809-2b8febd5-c1ac-464f-b6fe-108ef820de19.png">


