### PR TITLE
Don't track .dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ ghostdriver.log
 
 *.todo
 
+*.dump
+
 # node
 node_modules
 npm-debug.log


### PR DESCRIPTION
We've been experimenting with running against production-like data locally. That has involved passing around and ingesting large `*.dump` files with `pg_restore`. 

For convenience, this PR adds `*.dump` to .gitignore, so we don't have to be careful about accidentally committing them to the repo.