### PR TITLE
Suppres logging and fix stored archive content types

### DIFF
--- a/perma_web/perma/storage_backends.py
+++ b/perma_web/perma/storage_backends.py
@@ -105,3 +105,17 @@ class S3MediaStorage(BaseMediaStorage, S3Boto3Storage):
 
 class AzureMediaStorage(BaseMediaStorage, AzureStorage):
     location = settings.MEDIA_ROOT
+    # suppress azure storage http logging
+    logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.WARNING)
+
+    def get_object_parameters(self, name):
+        """
+        As above, modify stored archive content-type and content-encoding
+        for proper playback.
+        See https://github.com/jschneier/django-storages/issues/917
+        """
+        params = super().get_object_parameters(name)
+        if name.endswith('.gz'):
+            params['content_type'] = 'application/gzip'
+            params['content_encoding'] = ''
+        return params


### PR DESCRIPTION
After updating to a more recent version of perma I found our created archives were no longer playing back - after looking at changes to `S3MediaStorage` it looked like `AzureMediaStorage` needed some tweaks to modify archive content types and encodings too.

I also removed some HTTP logging from the server output.