### PR TITLE
Add Link/File-level metadata to "daily" digest IA items.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -448,6 +448,8 @@ CELERY_TASK_ROUTES = {
     'perma.tasks.backfill_daily_internet_archive_objects': {'queue': 'ia'},
     'perma.tasks.backfill_individual_link_internet_archive_objects': {'queue': 'ia'},
     'perma.tasks.populate_internet_archive_file_status': {'queue': 'ia'},
+    'perma.tasks.add_metadata_to_existing_daily_item_files': {'queue': 'ia'},
+    'perma.tasks.confirm_added_metadata_to_existing_daily_item_files': {'queue': 'ia'},
 }
 
 # internet archive stuff
@@ -458,6 +460,9 @@ INTERNET_ARCHIVE_DAILY_IDENTIFIER_PREFIX = 'daily_perma_cc_'
 # Find these at https://archive.org/account/s3.php :
 INTERNET_ARCHIVE_ACCESS_KEY = ''
 INTERNET_ARCHIVE_SECRET_KEY = ''
+# Rate limiting
+INTERNET_ARCHIVE_PERMITTED_PROXIMITY_TO_RATE_LIMIT = 20
+
 
 #
 # Hosts


### PR DESCRIPTION
### Context

We are reorganizing Perma's [Internet Archive collection](https://archive.org/details/perma_cc). In the past, we would add an "Item" with a single "File" to the collection for each new Perma Link; going forward, we've been asked to instead create one digest-like Item per day, with Files for each of the Perma Links created on that day. 

See this [internal document](https://docs.google.com/document/d/1yeiW47MahmTPC4Sh4zunCXgaapBTX8k8DjDb8r-9ifM/edit#heading=h.j7du1d5sm17f) for a complete description of the project; see also its [project board](https://github.com/orgs/harvard-lil/projects/6/views/1).  

### This PR

2949 "daily" digest Items were created on Perma.cc's behalf by the Internet Archive team, who used their own scripts to produce them from the "individual" Items we've created ourselves over the past years. These daily Items do not presently have any metadata about the Perma archives they contain: they have only the creation date (not timestamp), GUID, and WARC file.

This PR includes tasks for adding details like the target URL and the capture timestamp to the Item's file-level metadata, which is a stored in a generated "\<identifier\>_files.xml" file associated with the Item. (See https://archive.org/developers/md-write.html#targets.) The best I can tell, that metadata is not searchable and is not presently displayed in the IA GUI... but we think it ought to be present regardless.

### Deploying

These tasks do two things we haven't tried before:

- using `ia_session.get_tasks_api_rate_limit` and `ia_session.s3_is_overloaded` to see if we are approaching any rate limits before issuing scheduling requests to IA;

- re-queueing tasks that fail or are skipped due to rate-limiting automatically.

We'll have to see how that works out! I did my best to predict how the IA API will respond in all situations, but I may have missed some cases: the docs don't provide an exhaustive set of possible return values.

If my handling of the rate-limiting proves insufficient, or if we see tasks re-queuing themselves ad infinitum due to unhandled errors or the like, let's just clear the IA celery queue and start fresh after I push the necessary fixes: we should be able to pick up where we left off.

After this code is merged, I propose to run a single task via the Django shell, and inspect the results in IA and the Django admin after everything is done:
```
from perma.models import InternetArchiveFile
from perma.tasks import add_metadata_to_existing_daily_item_files

add_metadata_to_existing_daily_item_files([991])
```

[991](https://perma.cc/admin/perma/internetarchivefile/991/change/) is one of the two I've been experimenting with locally): you can see dev-style metadata for it (and another link) at this moment in https://ia804600.us.archive.org/7/items/daily_perma_cc_2021-10-01/daily_perma_cc_2021-10-01_files.xml

![image](https://user-images.githubusercontent.com/11020492/201158379-aa6b15d3-3de7-4021-8d86-28ee29983cfa.png)

...that should get updated to prod-style metadata when we run this task.

Presuming that looks good, I propose to then run a test batch of 1,500: our rate limit for `modify_xml.php` tasks is 1000, I think, so with any luck, this will give us a change to either gently test out skipping/re-scheduling code, or see if, under current conditions and with our current concurrency settings, we seem to be scheduling work at a manageable clip.

```
from perma.models import InternetArchiveFile
from perma.tasks import queue_batched_tasks, add_metadata_to_existing_daily_item_files

files = InternetArchiveFile.objects.filter(
    item__span__isempty=False,
    status='confirmed_present',
    cached_submitted_url__isnull=True
)[:1500]
queue_batched_tasks(add_metadata_to_existing_daily_item_files, files, batch_size=100)
```

I think we should plan to keep the concurrency low: these tasks will be unusually quick for us to schedule, but will still take time for them to process.

(I had hoped to schedule a smaller number of batch updates using their [multi-write](https://archive.org/developers/md-write.html#multi-target-writes) API, but alas, there is no wrapper for it in the `internetarchive` python package, and I don't want to try and do this one thing without the package.) 
