### PR TITLE
Internet Archive strips whitespace from "title".

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -2126,7 +2126,7 @@ class InternetArchiveFile(models.Model):
     def standard_metadata_for_link(cls, link):
         url = remove_control_characters(link.submitted_url)
         return {
-            "title": re.sub(' +', ' ', f"{link.guid}: {truncatechars(link.submitted_title, 50)}"),
+            "title": re.sub(' +', ' ', f"{link.guid}: {truncatechars(link.submitted_title, 50)}").strip(),
             "comments": f"Perma.cc archive of {url} created on {link.creation_timestamp}.",
             "external-identifier": f"urn:X-perma:{link.guid}",
             "external-identifier-match-date": f"X-perma:{link.creation_timestamp.isoformat()}",


### PR DESCRIPTION
We ran a batch of `add_metadata_to_existing_daily_item_files` after deploying the [latest improvements](https://github.com/harvard-lil/perma/pull/3213), and it completed without problems. It surfaced a mismatch of expectations: Internet Archive strips trailing whitespace in the "title" field, e.g. from `'8U6Y-SVSR: FN 20-3 Pa. Code 307 '` to`'8U6Y-SVSR: FN 20-3 Pa. Code 307'`.

This updates our expectations.