### PR TITLE
Add Link/File-level metadata to "daily" digest IA items, Part IV

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -50,7 +50,7 @@ from .utils import (Sec1TLSAdapter, tz_datetime,
     pp_date_from_post,
     first_day_of_next_month, today_next_year, preserve_perma_warc,
     write_resource_record_from_asset, user_agent_for_domain,
-    protocol, remove_control_characters)
+    protocol, remove_control_characters, tidy_whitespace)
 
 
 logger = logging.getLogger(__name__)
@@ -2124,9 +2124,10 @@ class InternetArchiveFile(models.Model):
 
     @classmethod
     def standard_metadata_for_link(cls, link):
-        url = remove_control_characters(link.submitted_url)
+        title = tidy_whitespace(f"{link.guid}: {truncatechars(link.submitted_title, 50)}")
+        url = tidy_whitespace(remove_control_characters(link.submitted_url))
         return {
-            "title": re.sub(' +', ' ', f"{link.guid}: {truncatechars(link.submitted_title, 50)}").strip(),
+            "title": title,
             "comments": f"Perma.cc archive of {url} created on {link.creation_timestamp}.",
             "external-identifier": f"urn:X-perma:{link.guid}",
             "external-identifier-match-date": f"X-perma:{link.creation_timestamp.isoformat()}",

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1763,7 +1763,7 @@ def queue_batched_tasks(task, query, batch_size=1000, **kwargs):
     if remainder:
         task.delay(pks, **kwargs)
 
-    logger.info(f"Queued {batches_queued} batches of size {batch_size}{' and a remainder of size ' + str(remainder) if remainder else ''}.")
+    logger.info(f"Queued {batches_queued} batches of size {batch_size}{' and a single batch of size ' + str(remainder) if remainder else ''}.")
 
 
 @shared_task(acks_late=True)
@@ -2007,7 +2007,7 @@ def confirm_added_metadata_to_existing_daily_item_files(file_ids, previous_attem
             'cached_submitted_url',
             'cached_perma_url'
         ])
-        logger.info(f"Updated metadata of { len(updated_files) } InternetArchiveFiles.")
+        logger.info(f"Confirmed update of { len(updated_files) } InternetArchiveFiles.")
 
     if file_ids_to_check_again:
         attempts_dict = {

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -13,6 +13,7 @@ from nacl.public import Box, PrivateKey, PublicKey
 from netaddr import IPAddress, IPNetwork
 import operator
 import os
+import re
 import requests
 import ssl
 import socket
@@ -406,6 +407,9 @@ def memento_data_for_url(request, url, qs=None, hash=None):
 
 def remove_control_characters(s):
     return "".join(ch for ch in s if unicodedata.category(ch)[0]!="C")
+
+def tidy_whitespace(s):
+    return re.sub(' +', ' ', s).strip()
 
 ### perma payments
 


### PR DESCRIPTION
The tiniest of tweaks to the task to add metadata to "daily" digest IA items; see [the last PR](https://github.com/harvard-lil/perma/pull/3213) for more of the story.

This PR:
- improves two log lines that we found suboptimal;
- removes whitespace from `submitted_url` according to IA's strategies, because that is indeed how they are saving things, even though that might actually be a meaningful change; and
- includes a try/except around the actual request to modify metadata, which we found occasionally times out.

I decided not to reduce the noisy logging, if we hit rate limits, at least for now. It probably should be noisy? To be discussed.