### PR TITLE
Add Link/File-level metadata to "daily" digest IA items, Part VIII

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2041,7 +2041,7 @@ def confirm_added_metadata_to_existing_daily_item_files(file_ids, previous_attem
                 if retry:
                     file_ids_to_check_again.append(file_id)
                 else:
-                    msg = f"Not retrying add metadata task for {file_id} (IA Item {ia_item.identifier}, File {link.guid}): error retry maximum reached."
+                    msg = f"Not retrying confirm metadata task for {file_id} (IA Item {ia_item.identifier}, File {link.guid}): error retry maximum reached."
                     if settings.INTERNET_ARCHIVE_EXCEPTION_IF_RETRIES_EXCEEDED:
                         logger.exception(msg)
                     else:


### PR DESCRIPTION
We processed ~100K InternetArchiveFiles in about 10hrs with the [latest version of the task](https://github.com/harvard-lil/perma/pull/3221) to add file/Perma Link-level metadata to the existing "daily" digest Internet Archive items, and we're pretty happy with the way it ran!

This PR makes a few tweaks to logging. 

After this, we are hoping to run the whole remaining set, which will take several days, but hopefully not more than a week or two, depending on how many have to retry due to (seemingly unavoidable) dropped network connections. 