### PR TITLE
Add Link/File-level metadata to "daily" digest IA items, Part IX 

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -50,7 +50,7 @@ from .utils import (Sec1TLSAdapter, tz_datetime,
     pp_date_from_post,
     first_day_of_next_month, today_next_year, preserve_perma_warc,
     write_resource_record_from_asset, user_agent_for_domain,
-    protocol, remove_control_characters, tidy_whitespace)
+    protocol, remove_control_characters)
 
 
 logger = logging.getLogger(__name__)
@@ -2125,8 +2125,8 @@ class InternetArchiveFile(models.Model):
 
     @classmethod
     def standard_metadata_for_link(cls, link):
-        title = tidy_whitespace(f"{link.guid}: {truncatechars(link.submitted_title, 50)}")
-        url = tidy_whitespace(remove_control_characters(link.submitted_url))
+        title = f"{link.guid}: {truncatechars(link.submitted_title, 50)}"
+        url = remove_control_characters(link.submitted_url)
         return {
             "title": title,
             "comments": f"Perma.cc archive of {url} created on {link.creation_timestamp}.",

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -55,7 +55,7 @@ from perma.exceptions import PermaPaymentsCommunicationException
 from perma.utils import (url_in_allowed_ip_range,
     preserve_perma_warc, write_warc_records_recorded_from_web,
     write_resource_record_from_asset,
-    user_agent_for_domain, Sec1TLSAdapter)
+    user_agent_for_domain, Sec1TLSAdapter, remove_whitespace)
 from perma.wsgi_utils import retry_on_exception
 from perma import site_scripts
 
@@ -2028,7 +2028,10 @@ def confirm_added_metadata_to_existing_daily_item_files(file_ids, previous_attem
 
             expected_metadata = InternetArchiveFile.standard_metadata_for_link(link)
             try:
-                assert expected_metadata.items() <= ia_file.metadata.items(), f"{expected_metadata.items()} != {ia_file.metadata.items()}"
+                for k, v in expected_metadata.items():
+                    # IA normalizes whitespace idiosyncratically:
+                    # ignore all whitespace when checking for expected values
+                    assert remove_whitespace(ia_file.metadata.get(k)) == remove_whitespace(v), f"expected {k}: {v}, got {ia_file.metadata.get(k)}."
             except AssertionError:
                 # IA's modify_xml tasks can take some time to complete;
                 # the task for this link appears not to have finished yet.

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -408,8 +408,9 @@ def memento_data_for_url(request, url, qs=None, hash=None):
 def remove_control_characters(s):
     return "".join(ch for ch in s if unicodedata.category(ch)[0]!="C")
 
-def tidy_whitespace(s):
-    return re.sub(' +', ' ', s).strip()
+def remove_whitespace(s):
+    return ''.join(s.split())
+
 
 ### perma payments
 

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -13,7 +13,6 @@ from nacl.public import Box, PrivateKey, PublicKey
 from netaddr import IPAddress, IPNetwork
 import operator
 import os
-import re
 import requests
 import ssl
 import socket


### PR DESCRIPTION
### We did it, for the most part!

We made it through the whole queue of tasks to add file-level metadata to existing "daily" digest IA items, using the versions of the tasks in [the last PR](https://github.com/harvard-lil/perma/pull/3222). 

Just over 4K didn't fully succeed.
```
In [1]: from perma.models import InternetArchiveFile

In [2]: files = InternetArchiveFile.objects.filter(
   ...:     item__span__isempty=False,
   ...:     status='confirmed_present',
   ...:     cached_submitted_url__isnull=True
   ...: )

In [3]: files.count()
Out[3]: 4273
```

### What went wrong with those?

In many cases, around a third, the metadata was successfully added to Internet Archive, but IA altered the whitespace in a manner we didn't predict, causing our `confirm_added_metadata_to_existing_daily_item_files` task to detect a mismatch between what we expected and reality and to subsequently fail.

I tried pretty much all day to figure out how to normalize whitespace the way they do, and failed. To be perfectly honest, I'm not certain it's consistent. I may follow up with our contacts and request more information, but in the meantime, want to push forward.

This PR strips all whitespace when validating, and if successful, stores whatever string IA sends back.

When this is merged, I want to re-run `confirm_added_metadata_to_existing_daily_item_files` for all remaining files in:
```
In [2]: files = InternetArchiveFile.objects.filter(
   ...:     item__span__isempty=False,
   ...:     status='confirmed_present',
   ...:     cached_submitted_url__isnull=True
   ...: )
``` 
as well as any `InternetArchiveFile.objects.filter(cached_title__contains="\n")`, `InternetArchiveFile.objects.filter(cached_title__contains="\t")`, and `InternetArchiveFile.objects.filter(cached_title__contains="\r")`: I believe I am, today, sometimes seeing a mismatch between the whitespace in our DB and the whitespace returned by the IA API even for some files where the `confirm` task once succeeded.

### What about the rest?

The other two thirds did not have updated metadata in IA; I didn't see any reason why not. I filtered out failed `files` whose links' titles had newlines or tabs and then ran `queue_batched_tasks(add_metadata_to_existing_daily_item_files, files, batch_size=100)` on the rest: `Queued 31 batches of size 100 and a single batch of size 34, pks 1505839-1580373.` That ran all day and just finished up, with a 100% success rate.

### Next?

After this, 100% of the `InternetArchiveFile` objects associated with daily items should have their metadata fields populated. If they don't... TBC. 
