### PR TITLE
Added `load="eager"` on RWP for troubleshooting

### DIFF
--- a/perma_web/replay/templates/iframe.html
+++ b/perma_web/replay/templates/iframe.html
@@ -232,6 +232,7 @@
       replay.setAttribute('url', url);
       replay.setAttribute('view', 'replay');
       replay.setAttribute('embed', embedStyle);
+      replay.setAttribute('load', "eager");
       replay.setAttribute('requireSubdomainIframe', '');
 
       if (sandbox) {


### PR DESCRIPTION
Troubleshooting `.warc.gz` loading issues on Safari with RWP 1.7.6. 