### PR TITLE
Update Chromium

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -69,7 +69,7 @@ RUN pip install pip==22.0.4 \
 COPY perma_web/lil-archive-keyring.gpg /usr/share/keyrings/lil-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/lil-archive-keyring.gpg] https://repo.lil.tools/ bullseye-security updates/main" > /etc/apt/sources.list.d/lil-chromium.list
 
-ENV CHROMIUM_VERSION=107.0.5304.121-1~deb11u1
+ENV CHROMIUM_VERSION=108.0.5359.94-1~deb11u1
 RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
     chromium-common=${CHROMIUM_VERSION} \
     chromium-driver=${CHROMIUM_VERSION} \

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -550,7 +550,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.5304.121 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.94 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []


### PR DESCRIPTION
https://chromereleases.googleblog.com/2022/12/stable-channel-update-for-desktop.html

Note that we have skipped over 108.0.5359.71-2~deb11u1, the first release of this major version -- the chromium Debian package was only out for a day. https://chromereleases.googleblog.com/2022/11/stable-channel-update-for-desktop_29.html