### PR TITLE
Upload files to existing "daily" digest IA items, Part II

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2419,7 +2419,7 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
         for k, v in expected_metadata.items():
             # IA normalizes whitespace idiosyncratically:
             # ignore all whitespace when checking for expected values
-            assert remove_whitespace(ia_file.metadata.get(k)) == remove_whitespace(v), f"expected {k}: {v}, got {ia_file.metadata.get(k)}."
+            assert remove_whitespace(ia_file.metadata.get(k, '')) == remove_whitespace(v), f"expected {k}: {v}, got {ia_file.metadata.get(k)}."
     except AssertionError:
         # IA's tasks can take some time to complete;
         # the upload-related tasks for this link appear not to have finished yet.

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2407,7 +2407,8 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
     try:
         ia_item = internetarchive.get_item(perma_item.identifier)
         ia_file = ia_item.get_file(InternetArchiveFile.WARC_FILENAME.format(guid=link.guid))
-    except requests.exceptions.ConnectionError:
+        assert ia_file.exists
+    except (requests.exceptions.ConnectionError, AssertionError):
         # Sometimes, requests to retrieve the metadata of an IA Item time out.
         # Retry later, without counting this as a failed attempt
         confirm_file_uploaded_to_internet_archive.delay(file_id, attempts)


### PR DESCRIPTION
We ran a batch of 10 links against the new tasks added in [Part I](https://github.com/harvard-lil/perma/pull/3238). They went off without a hitch!

But all 10 confirmation tasks failed: when the uploads haven't "finished" yet, things look a bit different than I expected... and evidently, I never ran into that when testing locally.

This PR tweaks the confirmation task accordingly. For style, we check to see that the given file "exists" before checking its metadata... though mere existence is insufficient in this case: it can definitely still be a work in progress at that point. For substance: when a metadatum is absent, we pass the empty string on to the validation code instead of `None`, so that it merely detects a mismatch between expectations and reality, instead of borking.

Unless something else is wrong, the confirmation tasks will now re-queue until the upload is indeed confirmed, or until the retry limit is reached.