### PR TITLE
Upload files to existing "daily" digest IA items, Part III

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2448,18 +2448,17 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
     perma_file.update_from_ia_metadata(ia_file.metadata)
     perma_file.status = 'confirmed_present'
     perma_file.cached_size =  ia_file.size
-    if perma_file.tracker.changed():
-        perma_file.save(update_fields=[
-            'status',
-            'cached_size',
-            'cached_title',
-            'cached_comments',
-            'cached_external_identifier',
-            'cached_external_identifier_match_date',
-            'cached_format',
-            'cached_submitted_url',
-            'cached_perma_url'
-        ])
+    perma_file.save(update_fields=[
+        'status',
+        'cached_size',
+        'cached_title',
+        'cached_comments',
+        'cached_external_identifier',
+        'cached_external_identifier_match_date',
+        'cached_format',
+        'cached_submitted_url',
+        'cached_perma_url'
+    ])
 
     # Update InternetArchiveItem accordingly
     perma_item.derive_required = True

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2417,6 +2417,7 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
         # Retry later, without counting this as a failed attempt
         confirm_file_uploaded_to_internet_archive.delay(file_id, attempts)
         logger.info(f"Re-queued 'confirm_link_uploaded_to_internet_archive' for InternetArchiveFile {file_id} ({link.guid}) after ConnectionTimeout.")
+        return
 
     expected_metadata = InternetArchiveFile.standard_metadata_for_link(link)
     try:

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2411,8 +2411,7 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
     try:
         ia_item = internetarchive.get_item(perma_item.identifier)
         ia_file = ia_item.get_file(InternetArchiveFile.WARC_FILENAME.format(guid=link.guid))
-        assert ia_file.exists
-    except (requests.exceptions.ConnectionError, AssertionError):
+    except requests.exceptions.ConnectionError:
         # Sometimes, requests to retrieve the metadata of an IA Item time out.
         # Retry later, without counting this as a failed attempt
         confirm_file_uploaded_to_internet_archive.delay(file_id, attempts)
@@ -2421,6 +2420,7 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
 
     expected_metadata = InternetArchiveFile.standard_metadata_for_link(link)
     try:
+        assert ia_file.exists
         for k, v in expected_metadata.items():
             # IA normalizes whitespace idiosyncratically:
             # ignore all whitespace when checking for expected values

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2404,6 +2404,10 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
     perma_item = perma_file.item
     link = perma_file.link
 
+    if perma_file.status == 'confirmed_present':
+        logger.info(f"InternetArchiveFile {file_id} ({link.guid}) already confirmed to be uploaded to {perma_item.identifier}.")
+        return
+
     try:
         ia_item = internetarchive.get_item(perma_item.identifier)
         ia_file = ia_item.get_file(InternetArchiveFile.WARC_FILENAME.format(guid=link.guid))


### PR DESCRIPTION
[Part II](https://github.com/harvard-lil/perma/pull/3239) worked: we were able to successfully confirm that the first batch of 10 files was uploaded, and were able to successfully upload and confirm a second batch of 10.

But, in the short period of time that ran, I saw almost 500 `confirm` tasks transiently accumulate in the queue. That shouldn't happen: only one `confirm` task should be scheduled per upload, and it should either successfully run or reschedule itself.

I think it's all due to the missing `return` added in this PR: tasks were rescheduling themselves on failure but then continuing. I'm a little surprised that would be enough to get us all the way up to 500... but I don't see any other problems. Let's try another batch of 10 with this fix in place and see if it happens again.

For redundancy, I also added a check at the beginning of the task: if this file has already been confirmed present, quit, rather than redundantly completing the rest of the task.