### PR TITLE
Upload files to existing "daily" digest IA items, Part IV

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -457,6 +457,7 @@ CELERY_TASK_ROUTES = {
     'perma.tasks.populate_internet_archive_file_status': {'queue': 'ia-readonly'},
     'perma.tasks.confirm_added_metadata_to_existing_daily_item_files': {'queue': 'ia-readonly'},
     'perma.tasks.upload_link_to_internet_archive': {'queue': 'ia'},
+    'perma.tasks.queue_file_uploaded_confirmation_tasks': {'queue': 'ia-readonly'},
     'perma.tasks.confirm_file_uploaded_to_internet_archive': {'queue': 'ia-readonly'},
 }
 

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -68,6 +68,10 @@ def post_process_settings(settings):
         'sync_subscriptions_from_perma_payments': {
             'task': 'perma.tasks.sync_subscriptions_from_perma_payments',
             'schedule': crontab(hour='23', minute='0')
+        },
+        'confirm_files_uploaded_to_internet_archive': {
+            'task': 'perma.tasks.queue_file_uploaded_confirmation_tasks',
+            'schedule': crontab(hour='*', minute='15'),
         }
     }
     settings['CELERY_BEAT_SCHEDULE'] = dict(((job, celerybeat_job_options[job]) for job in settings.get('CELERY_BEAT_JOB_NAMES', [])),

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2292,7 +2292,7 @@ def upload_link_to_internet_archive(link_guid, attempts=0, timeouts=0):
         perma_item.save(update_fields=['tasks_in_progress'])
 
         # Record that we are attempting an upload
-        perma_file.status == 'upload_attempted'
+        perma_file.status = 'upload_attempted'
         perma_file.save(update_fields=['status'])
 
         # Get the IA Item

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2387,9 +2387,34 @@ def upload_link_to_internet_archive(link_guid, attempts=0, timeouts=0):
                         logger.warning(msg)
                 return
 
-    # Schedule a confirmation task
-    confirm_file_uploaded_to_internet_archive.delay(perma_file.id)
     logger.info(f"Uploaded {link_guid} to {identifier}: confirmation pending.")
+
+
+@shared_task(acks_late=True)
+def queue_file_uploaded_confirmation_tasks(limit=None):
+    """
+    It takes some time for IA to finish processing uploads, even after the S3-like API
+    returns a success code. This task schedules a confirmation task for each file we've
+    attempted to upload but have not yet verified has succeeded. We do this on a schedule,
+    rather than immediately upon uploading a file, in order to introduce a delay: if we
+    start checking immediately, an intolerable number of attempts fail... which causes
+    too much IA API usage and too much churn.
+
+    This may be too blunt an instrument; we may need to introduce a delay in the confirmation
+    task itself, sleeping between each retry, but we want to try this first: if we can, we want
+    to avoid having sleeping-but-active celery tasks.
+    """
+    file_ids = InternetArchiveFile.objects.filter(
+                status='upload_attempted'
+            ).values_list(
+                'id', flat=True
+            )[:limit]
+
+    queued = 0
+    for file_id in file_ids:
+        confirm_file_uploaded_to_internet_archive.delay(file_id)
+        queued = queued + 1
+    logger.info(f"Queued the file upload confirmation task for {queued} InternetArchiveFiles.")
 
 
 @shared_task(acks_late=True)


### PR DESCRIPTION
[Part III](https://github.com/harvard-lil/perma/pull/3242) was a big improvement.

However... it still didn't work as hoped. All of the files successfully uploaded, but all of the confirmation tasks rescheduled themselves the full dozen times they are allowed to before failing fatally... and then succeeded a minute or two later when I queued them up again. When I test locally, one file at a time, uploads are processed quickly, but when we upload many files in parallel, it takes some time before things are ready for us to run `confirm...`.

We thought about simply increasing the retry limit, but we don't like the idea of just hammering the IA every few milliseconds until our uploads are ready... we don't need to know so badly. 

We thought about adding a `sleep` to the retries, possibly with exponential backoff... but we'd really rather not have workers just sitting there sleeping.

So, we thought we'd try scheduling confirmation tasks periodically (here: every 15 minutes), with the hope that a) the period (15 minutes) is long enough to churn through the whole list that has accumulated and b) if we go in order by primary key, which is to say, checking the old ones first, then the new ones will have a chance to finish before we get to them.

I'm not that optimistic this will turn out to work well enough to get us through the whole pending queue, but... we'll see maybe!!! We'll try against a few sets of 10, and if that works, a few sets of 100 or 1000. If it doesn't, we'll at least have more data to inform the next attempt.