### PR TITLE
Upload files to existing "daily" digest IA items, Part V 

### DIFF
--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -15,6 +15,7 @@ CELERY_BEAT_JOB_NAMES = [
     'run-next-capture',
     'sync_subscriptions_from_perma_payments',
     'cache_playback_status_for_new_links',
+    'confirm_files_uploaded_to_internet_archive',
 ]
 
 # logging


### PR DESCRIPTION
I forgot to add the new confirmation task added in [part IV](https://github.com/harvard-lil/perma/pull/3244) to the prod celery beat settings.