### PR TITLE
Upload files to existing "daily" digest IA items, Part VI

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -719,7 +719,7 @@ def patch_internet_archive(ia_module):
     ia_module.ArchiveSession.get_s3_load_info = get_s3_load_info
 
 
-def get_complete_ia_rate_limiting_info(include_buckets=True, include_max_buckets=None):
+def get_complete_ia_rate_limiting_info(include_buckets=True, include_max_buckets=100):
     """
     Return information on all known Internet Archive rate limits and their current status.
     """
@@ -786,7 +786,7 @@ def get_complete_ia_rate_limiting_info(include_buckets=True, include_max_buckets
     if include_buckets:
         buckets = InternetArchiveItem.objects.filter(tasks_in_progress__gt=0).values_list('identifier', flat=True)
         if include_max_buckets:
-            buckets = buckets[include_max_buckets]
+            buckets = buckets[:include_max_buckets]
         for bucket in buckets:
             s3_is_overloaded, s3_details = ia_session.get_s3_load_info(identifier=bucket, access_key=settings.INTERNET_ARCHIVE_ACCESS_KEY)
             add_bucket_info(output, bucket, s3_details)


### PR DESCRIPTION
Subsequent to [Part V](https://github.com/harvard-lil/perma/pull/3245), this is now running steadily. We are monitored to see if too many confirmation tasks fail; if they do, we should consider running less frequently than every 15 min, and could also consider reducing the allowed number of retries (if we aren't seeing the retries succeed, then what's the point of trying more than once or twice?).

As a result, we can see that this util for checking ratelimiting is too slow, at this scale, because it is checking too many buckets.

We're going to try capping at 100, and see if that reduction is sufficient.