### PR TITLE
Upload files to existing "daily" digest IA items, Part VIII

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2406,6 +2406,13 @@ def queue_file_uploaded_confirmation_tasks(limit=None):
     """
     file_ids = InternetArchiveFile.objects.filter(
                 status='upload_attempted'
+            ).exclude(
+                item_id__in=[
+                    'daily_perma_cc_2022-07-25',
+                    'daily_perma_cc_2022-07-21',
+                    'daily_perma_cc_2022-07-20',
+                    'daily_perma_cc_2022-07-19'
+                ]
             ).values_list(
                 'id', flat=True
             )[:limit]


### PR DESCRIPTION
There are four "daily" IA items that we don't currently have write access to, because they weren't created with our API key and accidentally weren't added to the perma_cc collection. Upload `confirmation` tasks for files we attempted to upload to these items are gumming up the works: we check on them every 15 minutes.

This PR temporarily excludes those `InternetArchiveFile`s from the `confirmation` queuing task. After the break, we'll fix by asking IA to either delete or fix the four items in question.