### PR TITLE
Minor version PG upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - redis_data:/data:delegated
   db:
-    image: registry.lil.tools/library/postgres:12.8
+    image: registry.lil.tools/library/postgres:12.11
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: perma


### PR DESCRIPTION
Our stage and prod DB instances have "Auto minor version upgrade" enabled, and have made it from 12.8 to 12.11.

https://www.postgresql.org/docs/release/12.11/