### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part II

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2821,13 +2821,13 @@ def queue_internet_archive_uploads_for_date(date_string, limit=None):
     query_started = time.time()
     query_ended = None
     try:
-        for guid in to_upload.iterator():
+        for link in to_upload.iterator():
             if not query_ended:
                 # log here: the query won't actually be evaluated until .iterator() is called
                 query_ended = time.time()
                 logger.info(f"Ready to queue links for upload in {query_ended - query_started} seconds.")
-            upload_link_to_internet_archive.delay(guid)
-            queued.append(guid)
+            upload_link_to_internet_archive.delay(link.guid)
+            queued.append(link.guid)
     except SoftTimeLimitExceeded:
         pass
 


### PR DESCRIPTION
There was a bug in [Part I](https://github.com/harvard-lil/perma/pull/3259); I honestly cannot account for how it slipped through. I must have introduced it somehow during refactoring, and thought I tested, but did not.

Raw querysets consist of model objects, with the fields not retrieved by the SQL [deferred](https://docs.djangoproject.com/en/4.1/topics/db/sql/#deferring-model-fields). So, this query does not return data of the same shape as `values_list('guid', flat=True)`.

Pass the guid to the task, not the whole link object.