### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part III

### DIFF
--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -2497,7 +2497,7 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
         perma_item.cached_title = ia_item.metadata['title']
         perma_item.cached_description = ia_item.metadata.get('description')
         perma_item.save(update_fields=[
-            'confirmed_exists'
+            'confirmed_exists',
             'added_date',
             'cached_title',
             'cached_description'


### PR DESCRIPTION
I did not fully exercise the whole pipeline after [adding a field to explicitly track whether a given IA Item was known to exist or not](https://github.com/harvard-lil/perma/pull/3259/commits/d6f5ebd19fe14d6c2ab81e14454af4ef2fac6e86), subsequent to review of [Part I](https://github.com/harvard-lil/perma/pull/3259).

I made a typo.

This is another example of why automated tests are helpful.