### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part V

### DIFF
--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -71,11 +71,11 @@ def post_process_settings(settings):
         },
         'confirm_files_uploaded_to_internet_archive': {
             'task': 'perma.tasks.queue_file_uploaded_confirmation_tasks',
-            'schedule': crontab(minute="*/15"),
+            'schedule': crontab(minute="*/5"),
         },
         'confirm_files_deleted_from_internet_archive': {
             'task': 'perma.tasks.queue_file_deleted_confirmation_tasks',
-            'schedule': crontab(minute="*/15"),
+            'schedule': crontab(minute="*/5"),
         }
     }
     settings['CELERY_BEAT_SCHEDULE'] = dict(((job, celerybeat_job_options[job]) for job in settings.get('CELERY_BEAT_JOB_NAMES', [])),

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1865,20 +1865,8 @@ def confirm_file_uploaded_to_internet_archive(file_id, attempts=0):
     except AssertionError:
         # IA's tasks can take some time to complete;
         # the upload-related tasks for this link appear not to have finished yet.
-        # We need to check again later.
-        retry = (
-            not settings.INTERNET_ARCHIVE_RETRY_FOR_ERROR_LIMIT or
-            (settings.INTERNET_ARCHIVE_RETRY_FOR_ERROR_LIMIT > attempts + 1)
-        )
-        if retry:
-            confirm_file_uploaded_to_internet_archive.delay(file_id, attempts + 1)
-            logger.info(f"Re-queued 'confirm_link_uploaded_to_internet_archive' for InternetArchiveFile {file_id} ({link.guid}).")
-        else:
-            msg = f"Not retrying 'confirm_link_uploaded_to_internet_archive' for {file_id} (IA Item {perma_item.identifier}, File {link.guid}): error retry maximum reached."
-            if settings.INTERNET_ARCHIVE_EXCEPTION_IF_RETRIES_EXCEEDED:
-                logger.exception(msg)
-            else:
-                logger.warning(msg)
+        # We'll need to check again later, the next time celerybeat schedules these tasks.
+        logger.info(f"Submitted upload of {link.guid} to IA Item {perma_item.identifier} not yet confirmed.")
         return
 
     # Update the InternetArchiveFile accordingly

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -784,7 +784,7 @@ def get_complete_ia_rate_limiting_info(include_buckets=True, include_max_buckets
 
     # check for bucket-specific limits
     if include_buckets:
-        buckets = InternetArchiveItem.objects.filter(tasks_in_progress__gt=0).values_list('identifier', flat=True)
+        buckets = InternetArchiveItem.objects.filter(tasks_in_progress__gt=0).values_list('identifier', flat=True).order_by('identifier')
         if include_max_buckets:
             buckets = buckets[:include_max_buckets]
         for bucket in buckets:


### PR DESCRIPTION
### How's it going?

The changes in [Part IV](https://github.com/harvard-lil/perma/pull/3263) helped a lot. We have successfully been making it through batches of 400 links, spread over 4 daily items, processed by 1 celery worker with concurrency of 4, in about 30 minutes. We'll have to see if that remains consistent.

### This PR

This PR is a collection of tweaks. 

#### Confirmation Tasks

The upload confirmation tasks are running very fast, so we're going to check every 5 min instead of every 15, so that we have a clearer picture of how long these things actually take. (I have some suspicion that things are updated in sets of 50 every 15 minutes..... if that is the case, this will demo convincingly, and we can revert.)

We're also going to stop retrying them immediately, if they don't observe that a file has successfully been uploaded... because that retry never succeeds.

#### Concurrent Uploads

As mentioned in my first PR in this series, it is not possible to create an IA Item outside of the upload process: one can only issue a request for a file to uploaded to a given identifier. The intended pattern is that IA will create an Item with that identifier, if it doesn't already exist, and otherwise will reuse the existing Item. I mentioned that I was somewhat concerned that if many uploads were requested in parallel, all before an Item with a given identifier was created, things would go awry (see "concerns about concurrency" in [Part I](https://github.com/harvard-lil/perma/pull/3259)).

Turns out, I was right... but luckily, they seem to go awry in a manageable way. The concurrent attempts DO all attempt to create a new IA Item, but IA errors out rather than allowing itself to get into an inconsistent state. It errors out in a number of ways: sometimes it reports it couldn't get a lock, sometimes it reports that the requested bucket name is unavailable (in a few different ways, depending on exactly where it breaks), etc.

That seems to be fine: the Items look okay, at a glance, and if we re-attempt the upload later, everything goes fine. 

So, instead of worrying about this, I'm just listening for the set of expected errors, and re-queuing the upload if we hear them. There may be more errors to listen for here: time will tell.

### Rate limit report

This also sorts the rate limiting info returned about different Items/buckets by the Item identifier, so that the results come back in a consistent order.