### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part VI

### DIFF
--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -16,6 +16,7 @@ CELERY_BEAT_JOB_NAMES = [
     'sync_subscriptions_from_perma_payments',
     'cache_playback_status_for_new_links',
     'confirm_files_uploaded_to_internet_archive',
+    'confirm_files_deleted_from_internet_archive',
 ]
 
 # logging


### PR DESCRIPTION
[This PR](https://github.com/harvard-lil/perma/pull/3259) added a task that is meant to be run by celerybeat every few minutes, to check and see if the files we requested be deleted from IA were really deleted.

I forgot to add it to the celerybeat job list.

...so, when we just tried out the deletion code (which seems to have gone off without a hitch), no confirmation tasks were scheduled.