### PR TITLE
Add deployment sentinel

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -27,6 +27,9 @@ from .serializers import FolderSerializer, CaptureJobSerializer, LinkSerializer,
 from django.conf import settings
 from django.urls import reverse
 
+import logging
+logger = logging.getLogger(__name__)
+
 ### BASE VIEW ###
 
 class BaseView(APIView):
@@ -525,6 +528,8 @@ class AuthenticatedLinkListView(BaseView):
                 capture_job.save(update_fields=['status', 'link'])
                 if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
                     run_next_capture.delay()
+                else:
+                    logger.info("Deployment sentinel is present, not running next capture.")
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         raise_invalid_capture_job(capture_job, serializer.errors)

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import csv
 import django_filters
+import os.path
 from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
 from django.db import transaction
 from django.db.models import Prefetch
@@ -522,7 +523,8 @@ class AuthenticatedLinkListView(BaseView):
                 capture_job.status = 'pending'
                 capture_job.link = link
                 capture_job.save(update_fields=['status', 'link'])
-                run_next_capture.delay()
+                if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
+                    run_next_capture.delay()
 
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         raise_invalid_capture_job(capture_job, serializer.errors)

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -666,3 +666,6 @@ SENTRY_DSN = ''
 SENTRY_ENVIRONMENT = 'dev'
 SENTRY_TRACES_SAMPLE_RATE = 1.0
 SENTRY_SEND_DEFAULT_PII = False
+
+# Before deployment, we suppress the addition of new capture jobs when this file is present
+DEPLOYMENT_SENTINEL = '/tmp/perma-deployment-pending'

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1416,6 +1416,8 @@ def run_next_capture():
                 capture_job.mark_failed('Failed during capture.')
     if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
         run_next_capture.delay()
+    else:
+        logger.info("Deployment sentinel is present, not running next capture.")
 
 
 @shared_task()

--- a/perma_web/perma/tasks.py
+++ b/perma_web/perma/tasks.py
@@ -1414,7 +1414,8 @@ def run_next_capture():
             capture_job.link.captures.filter(status='pending').update(status='failed')
             if capture_job.status == 'in_progress':
                 capture_job.mark_failed('Failed during capture.')
-    run_next_capture.delay()
+    if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
+        run_next_capture.delay()
 
 
 @shared_task()


### PR DESCRIPTION
As part of draining the queue of tasks before deployment, we suppress the addition of new capture jobs. The addition and removal of the sentinel is handled by a salt orchestration.