### PR TITLE
Fix local Perma Payments set up

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,7 +31,7 @@ services:
       - perma_payments
 
   perma-payments:
-    image: registry.lil.tools/harvardlil/perma-payments:4-0713c04cf39c839d249be111ebc30b36
+    image: registry.lil.tools/harvardlil/perma-payments:6-fc3e7a41c2c4ab7dd526cacb63a64e78
     # hack: sleep to give the database time to start up
     command: >
       sh -c "sleep 5 && ./manage.py migrate && invoke run"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -41,6 +41,7 @@ services:
       - pp_db
     environment:
       - DJANGO__DATABASES__default__HOST=pp_db
+      - DOCKERIZED=true
     # TO CUSTOMIZE CONFIG:
     # copy ./services/docker/perma-payments/settings.py.example
     # to ./services/docker/perma-payments/settings.py,


### PR DESCRIPTION
I noticed that the local Perma app was no longer speaking to the local Perma Payments app...

Turns out we:

a) need to use a more recent image, one where `invoke` is installed, and 

b) we need to set the `DOCKERIZED` env var, so that the payments dev server runs on 0.0.0.0 instead of 127.0.0.1. 

I inappropriately [removed DOCKERIZED](https://github.com/harvard-lil/perma/commit/819192de02f58cf81bb9f5b55aef6f1c3177f06e) without actually updating the [Perma Payments setup](https://github.com/harvard-lil/perma-payments/blob/develop/web/tasks.py#L45). Mea culpa.