### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part VIII

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2314,4 +2314,4 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
         else:
             break
 
-    logger.info(f"Queued {total_queued} internet archive uploads: {','.join(queued)}")
+    logger.info(f"Prepared to upload {total_queued} links to internet archive across {len(queued)} days: {','.join(queued)}")

--- a/perma_web/perma/settings/deployments/settings_prod.py
+++ b/perma_web/perma/settings/deployments/settings_prod.py
@@ -15,8 +15,7 @@ CELERY_BEAT_JOB_NAMES = [
     'run-next-capture',
     'sync_subscriptions_from_perma_payments',
     'cache_playback_status_for_new_links',
-    # don't enable the cron yet; enable after manual testing
-    # 'conditionally_queue_internet_archive_uploads_for_date_range',
+    'conditionally_queue_internet_archive_uploads_for_date_range',
     'confirm_files_uploaded_to_internet_archive',
     'confirm_files_deleted_from_internet_archive',
 ]

--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -266,7 +266,7 @@
 
     <script id="rate_limits-template" type="text/x-handlebars-template">
       <div class="row">
-        <div class="col-sm-4">Explicitly scheduled tasks in progress:<br><small>(not including any automatic/followup/deriviative tasks)</small></div>
+        <div class="col-sm-4">Explicitly scheduled tasks in progress:<br><small>(not including any automatic/followup/derivative tasks)</small></div>
         <div class="col-sm-8">{{ inflight }}</div>
       </div>
       <hr>


### PR DESCRIPTION
The manual testing of [Part VII](https://github.com/harvard-lil/perma/pull/3286) went off without a hitch.

This PR sets the task to run every 15 minutes: we should keep an eye on it over the next few days, and see how it does.

I also fixed a typo that @bensteinberg noticed, and improved the message logged by this task on completion, to make it easier to filter out in Grafana.