### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part IX

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2261,9 +2261,9 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
                 in_flight_for_this_day = 0
             bucket_limit = min(daily_limit, to_queue - total_queued) - in_flight_for_this_day
             if bucket_limit > 0:
-                total_queued += bucket_limit
-                queued.append(f"{date_string} ({bucket_limit})")
-                queue_internet_archive_uploads_for_date(date_string, bucket_limit)
+                queued = queue_internet_archive_uploads_for_date(date_string, bucket_limit)
+                total_queued += queued
+                queued.append(f"{date_string} ({queued})")
         else:
             break
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2191,52 +2191,6 @@ def queue_internet_archive_uploads_for_date(date_string, limit=100):
 
 
 @shared_task
-def queue_internet_archive_uploads_for_date_range(start_date_string, end_date_string, daily_limit=100, max_days=4):
-    start = datetime.strptime(start_date_string, '%Y-%m-%d').date()
-    end = datetime.strptime(end_date_string, '%Y-%m-%d').date()
-    if start > end:
-        logger.error(f"Invalid range: start={start} end={end}")
-
-    dates = []
-    for day in date_range(start, end, timedelta(days=1)):
-        if len(dates) < max_days:
-            date_string = day.strftime('%Y-%m-%d')
-            dates.append(date_string)
-            queue_internet_archive_uploads_for_date.delay(date_string, daily_limit)
-        else:
-            break
-
-    logger.info(f"Queued { len(dates) } days of internet archive uploads ({dates}) (up to {daily_limit} each).")
-
-
-@shared_task
-def requeue_internet_archive_uploads_for_date(date_string, status='upload_attempted', limit=100):
-    """
-    A temporary utility task, for re-scheduling the upload of links whose upload
-    attempts are known to have failed and need to be retried.
-
-    Default to a limit of 100 tasks, which preliminary evidence suggests does not routinely
-    trigger rate limits.
-    """
-    identifier = InternetArchiveItem.DAILY_IDENTIFIER.format(
-        prefix=settings.INTERNET_ARCHIVE_DAILY_IDENTIFIER_PREFIX,
-        date_string=date_string
-    )
-
-    files = InternetArchiveFile.objects.filter(
-        item_id=identifier,
-        status=status
-    )[:limit]
-
-    queued = []
-    for file in files.iterator():
-        upload_link_to_internet_archive.delay(file.link_id)
-        queued.append(file.id)
-
-    logger.info(f"Re-queued { len(queued) } links for upload (InternetArchiveFile {queued[0]} through {queued[-1]}).")
-
-
-@shared_task
 def queue_internet_archive_deletions(limit=None):
     """
     Queue deletion tasks for any currently-ineligible Links that were eligible

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2261,9 +2261,9 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
                 in_flight_for_this_day = 0
             bucket_limit = min(daily_limit, to_queue - total_queued) - in_flight_for_this_day
             if bucket_limit > 0:
-                queued = queue_internet_archive_uploads_for_date(date_string, bucket_limit)
-                total_queued += queued
-                queued.append(f"{date_string} ({queued})")
+                count_queued = queue_internet_archive_uploads_for_date(date_string, bucket_limit)
+                total_queued += count_queued
+                queued.append(f"{date_string} ({count_queued})")
         else:
             break
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2163,8 +2163,6 @@ def queue_file_deleted_confirmation_tasks(limit=100):
     logger.info(f"Queued the file deleted confirmation task for {queued} InternetArchiveFiles.")
 
 
-
-@shared_task
 def queue_internet_archive_uploads_for_date(date_string, limit=100):
     """
     Queue upload tasks for all currently-eligible Links created on a given day,
@@ -2188,6 +2186,7 @@ def queue_internet_archive_uploads_for_date(date_string, limit=100):
         pass
 
     logger.info(f"Queued { len(queued) } links for upload ({queued[0]} through {queued[-1]}).")
+    return len(queued)
 
 
 @shared_task
@@ -2262,9 +2261,9 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
                 in_flight_for_this_day = 0
             bucket_limit = min(daily_limit, to_queue - total_queued) - in_flight_for_this_day
             if bucket_limit > 0:
-                queue_internet_archive_uploads_for_date.delay(date_string, bucket_limit)
                 total_queued += bucket_limit
                 queued.append(f"{date_string} ({bucket_limit})")
+                queue_internet_archive_uploads_for_date(date_string, bucket_limit)
         else:
             break
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -458,8 +458,6 @@ CELERY_TASK_ROUTES = {
     'perma.celery_tasks.confirm_file_uploaded_to_internet_archive': {'queue': 'ia-readonly'},
     'perma.celery_tasks.queue_file_deleted_confirmation_tasks': {'queue': 'ia-readonly'},
     'perma.celery_tasks.confirm_file_deleted_from_daily_item': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.queue_internet_archive_uploads_for_date': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.queue_internet_archive_uploads_for_date_range': {'queue': 'ia-readonly'},
     'perma.celery_tasks.conditionally_queue_internet_archive_uploads_for_date_range': {'queue': 'ia-readonly'},
     'perma.celery_tasks.queue_internet_archive_deletions': {'queue': 'ia-readonly'},
 }


### PR DESCRIPTION
I realized while watching the logs go by that [Part VII](https://github.com/harvard-lil/perma/pull/3286) had a logical error: it doesn't care whether a given day actually has any links to upload or not. So, it will never move on to queuing up links for different days in the date range. It will just keep trying the initial set of days over and over. Some time overnight, we should see it stop getting any work done.

With a `daily_limit` of 100, it takes essentially no time to put a day's links on the queue: the db queries are returning in under a second, and the loop is fast. So, this PR moves that logic from its own Celery task into a simple helper function, one that returns how many jobs it actually queued up, and has `conditionally_queue....` track that instead.

As we advance through the range, we'll want to start advancing `IA_UPLOAD_START_DATESTRING`, so that queuing task doesn't have to loop through a bunch of already-finished days before finding a fresh one.