### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part X

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2282,8 +2282,9 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
             bucket_limit = min(daily_limit, to_queue - total_queued) - in_flight_for_this_day
             if bucket_limit > 0:
                 count_queued = queue_internet_archive_uploads_for_date(date_string, bucket_limit)
-                total_queued += count_queued
-                queued.append(f"{date_string} ({count_queued})")
+                if count_queued:
+                    total_queued += count_queued
+                    queued.append(f"{date_string} ({count_queued})")
         else:
             break
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2244,8 +2244,15 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
     - there are not enough qualifying links in the date range
     - there are not enough qualifying links in the date range, while respecting daily_limit
     """
-    start = datetime.strptime(start_date_string, '%Y-%m-%d').date()
-    end = datetime.strptime(end_date_string, '%Y-%m-%d').date()
+    if not start_date_string:
+        # start the day after the last 'complete' day
+        start = InternetArchiveItem.objects.filter(complete=True).order_by('-span').first().span.lower.date() + timedelta(days=1)
+    else:
+        start = datetime.strptime(start_date_string, '%Y-%m-%d').date()
+    if not end_date_string:
+        end = datetime.now().date()
+    else:
+        end = datetime.strptime(end_date_string, '%Y-%m-%d').date()
     if start > end:
         logger.error(f"Invalid range: start={start} end={end}")
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2163,32 +2163,6 @@ def queue_file_deleted_confirmation_tasks(limit=100):
     logger.info(f"Queued the file deleted confirmation task for {queued} InternetArchiveFiles.")
 
 
-def queue_internet_archive_uploads_for_date(date_string, limit=100):
-    """
-    Queue upload tasks for all currently-eligible Links created on a given day,
-    if we have not yet attempted to upload them to a "daily" Item.
-    """
-    to_upload = Link.objects.ia_upload_pending(date_string, limit)
-
-    # Queue the tasks
-    queued = []
-    query_started = time.time()
-    query_ended = None
-    try:
-        for link in to_upload.iterator():
-            if not query_ended:
-                # log here: the query won't actually be evaluated until .iterator() is called
-                query_ended = time.time()
-                logger.info(f"Ready to queue links for upload in {query_ended - query_started} seconds.")
-            upload_link_to_internet_archive.delay(link.guid)
-            queued.append(link.guid)
-    except SoftTimeLimitExceeded:
-        pass
-
-    logger.info(f"Queued { len(queued) } links for upload ({queued[0]} through {queued[-1]}).")
-    return len(queued)
-
-
 @shared_task
 def queue_internet_archive_deletions(limit=None):
     """
@@ -2218,6 +2192,45 @@ def queue_internet_archive_deletions(limit=None):
         pass
 
     logger.info(f"Queued { len(queued) } links for deletion ({queued[0]} through {queued[-1]}).")
+
+
+def queue_internet_archive_uploads_for_date(date_string, limit=100):
+    """
+    Queue upload tasks for all currently-eligible Links created on a given day,
+    if we have not yet attempted to upload them to a "daily" Item.
+    """
+    to_upload = Link.objects.ia_upload_pending(date_string, limit)
+
+    if to_upload:
+        # Queue the tasks
+        queued = []
+        query_started = time.time()
+        query_ended = None
+        try:
+            for link in to_upload.iterator():
+                if not query_ended:
+                    # log here: the query won't actually be evaluated until .iterator() is called
+                    query_ended = time.time()
+                    logger.info(f"Ready to queue links for upload in {query_ended - query_started} seconds.")
+                upload_link_to_internet_archive.delay(link.guid)
+                queued.append(link.guid)
+        except SoftTimeLimitExceeded:
+            pass
+        logger.info(f"Queued { len(queued) } links for upload ({queued[0]} through {queued[-1]}).")
+        return len(queued)
+    else:
+        identifier = InternetArchiveItem.DAILY_IDENTIFIER.format(
+            prefix=settings.INTERNET_ARCHIVE_DAILY_IDENTIFIER_PREFIX,
+            date_string=date_string
+        )
+        try:
+            item = InternetArchiveItem.objects.get(identifier=identifier)
+            item.complete = True
+            item.save(update_fields=['complete'])
+            logger.info(f"Found no pending links: marked IA Item {item.identifier} complete.")
+        except InternetArchiveItem.DoesNotExist:
+            logger.info(f"Found no pending links for {date_string}.")
+        return 0
 
 
 @shared_task

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -4,7 +4,6 @@
 
 from celery.schedules import crontab
 import celery
-from datetime import datetime
 import os
 
 def post_process_settings(settings):
@@ -75,8 +74,8 @@ def post_process_settings(settings):
             'task': 'perma.celery_tasks.conditionally_queue_internet_archive_uploads_for_date_range',
             'schedule': crontab(minute="*/15"),
             'args': (
-                os.environ.get('IA_UPLOAD_START_DATESTRING') or '2021-11-10' ,
-                os.environ.get('IA_UPLOAD_END_DATESTRING') or datetime.now().strftime('%Y-%m-%d')
+                os.environ.get('IA_UPLOAD_START_DATESTRING') or None,
+                os.environ.get('IA_UPLOAD_END_DATESTRING') or None
             )
         },
         'confirm_files_uploaded_to_internet_archive': {


### PR DESCRIPTION
This PR fixes an oversight in this series: the queuing function assumes that at least one link will always be queued. If it isn't, [this logging line](https://github.com/harvard-lil/perma/compare/develop...rebeccacremona:completed-days?expand=1#diff-d8b159c0525b4635c3804b94e55f7d489d32862fd98bc145c471bcd4a1ac5652L2188) throws `IndexError`s. 

Instead of just fixing the log line, I decided to add special handling for that case. When no eligible links are found for a given day, we provisionally mark that day's InternetArchiveItem "complete." 

That metadatum won't necessarily be true, going forward: planned future work, which will handle Perma Links that are toggled from public to private and vice versa, will be toggling this field and triggering the appropriate work... But, it is useful in the time being: we can use it to determine where in the backlog to start queuing, when `conditionally_queue_internet_archive_uploads_for_date_range` runs. 

This PR arranges for `conditionally_queue_internet_archive_uploads_for_date_range` to look for the most recent 'complete' day, and start the day after that.

### Deploying

Before this is deployed, I will go into the Django admin or the shell, and mark the 4 days we finished working on last night "complete".

