### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part XIII

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2188,7 +2188,7 @@ def queue_file_deleted_confirmation_tasks(limit=100):
         logger.info(f"Queued the file deleted confirmation task for {queued} InternetArchiveFiles.")
 
     else:
-        logger.info(f"Skipped the queuing of file deleted confirmation tasks: {tasks_in_ia_readonly_queue} task{tasks_in_ia_readonly_queue} in the ia-readonly queue.")
+        logger.info(f"Skipped the queuing of file deleted confirmation tasks: {tasks_in_ia_readonly_queue} task{pluralize(tasks_in_ia_readonly_queue)} in the ia-readonly queue.")
 
 
 @shared_task

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1736,9 +1736,8 @@ def upload_link_to_internet_archive(link_guid, attempts=0, timeouts=0):
             else:
                 logger.warning(msg)
         return
-    except requests.exceptions.ReadTimeout:
-        # If Internet Archive goes down entirely (as with a power outage), we get a read timeout.
-        # Retry later, without counting this as a failed attempt
+    except (requests.exceptions.ReadTimeout, requests.exceptions.ConnectTimeout):
+        # If Internet Archive is unavailable, retry later, without counting this as a failed attempt.
         logger.info(f"Re-queued 'upload_link_to_internet_archive' for {link_guid} after ReadTimeout.")
         retry_upload(attempts, timeouts)
     except (requests.exceptions.HTTPError, AssertionError) as e:

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -67,6 +67,10 @@ import logging
 logger = logging.getLogger('celery.django')
 
 
+###           ###
+### Capturing ###
+###           ###
+
 ### CONSTANTS ###
 
 RESOURCE_LOAD_TIMEOUT = settings.RESOURCE_LOAD_TIMEOUT # seconds to wait for at least one resource to load before giving up on capture
@@ -915,7 +919,7 @@ def browser_running(browser, onfailure=None):
         raise HaltCaptureException
 
 
-### TASKS ##
+### TASK ##
 
 @shared_task
 @tempdir.run_in_tempdir()
@@ -1420,6 +1424,10 @@ def run_next_capture():
         logger.info("Deployment sentinel is present, not running next capture.")
 
 
+###              ###
+### HOUSEKEEPING ###
+###              ###
+
 @shared_task()
 def update_stats():
     """
@@ -1549,6 +1557,10 @@ def populate_warc_size(link_guid):
     link.warc_size = default_storage.size(link.warc_storage_file())
     link.save(update_fields=['warc_size'])
 
+
+###                  ###
+### INTERNET ARCHIVE ###
+###                  ###
 
 def queue_batched_tasks(task, query, batch_size=1000, **kwargs):
     """

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1853,7 +1853,7 @@ def queue_file_uploaded_confirmation_tasks(limit=None):
         logger.info(f"Queued the file upload confirmation task for {queued} InternetArchiveFiles.")
 
     else:
-        logger.info(f"Skipped the queuing of file upload confirmation tasks: {tasks_in_ia_readonly_queue} task{tasks_in_ia_readonly_queue} in the ia-readonly queue.")
+        logger.info(f"Skipped the queuing of file upload confirmation tasks: {tasks_in_ia_readonly_queue} task{pluralize(tasks_in_ia_readonly_queue)} in the ia-readonly queue.")
 
 @shared_task(acks_late=True)
 def confirm_file_uploaded_to_internet_archive(file_id, attempts=0, connection_errors=0):

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2280,8 +2280,18 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
         return
 
     if not start_date_string:
-        # start the day after the last 'complete' day
+        # for now, start the day after the last 'complete' day
         start = InternetArchiveItem.objects.filter(complete=True).order_by('-span').first().span.lower.date() + timedelta(days=1)
+        # once that completes, and once we have verified that an InternetArchiveItem has been created
+        # for every day in the backlog, with no gaps, we should instead start with the oldest incomplete
+        # day in the backlog:
+        #
+        # oldest_incomplete_daily_item_in_backlog = InternetArchiveItem.objects.filter(
+        #       span__isempty=False,
+        #       span__gt=('2021-11-10', '2021-11-11'),
+        #       complete=False,
+        # ).order_by('span').first()
+        # start = oldest_incomplete_daily_item_in_backlog.span.lower.date()
     else:
         start = datetime.strptime(start_date_string, '%Y-%m-%d').date()
     if not end_date_string:

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -49,6 +49,7 @@ from django.db.models.functions import Greatest
 from django.conf import settings
 from django.utils import timezone
 from django.http import HttpRequest
+from django.template.defaultfilters import pluralize
 
 from perma.models import WeekStats, MinuteStats, Registrar, LinkUser, Link, Organization, Capture, \
     CaptureJob, UncaughtError, InternetArchiveItem, InternetArchiveFile
@@ -1837,7 +1838,7 @@ def queue_file_uploaded_confirmation_tasks(limit=None):
         logger.info(f"Queued the file upload confirmation task for {queued} InternetArchiveFiles.")
 
     else:
-        logger.info(f"Skipped queuing file upload confirmation tasks: {tasks_in_ia_readonly_queue} task(s) in the ia-readonly queue.")
+        logger.info(f"Skipped the queuing of file upload confirmation tasks: {tasks_in_ia_readonly_queue} task{tasks_in_ia_readonly_queue} in the ia-readonly queue.")
 
 @shared_task(acks_late=True)
 def confirm_file_uploaded_to_internet_archive(file_id, attempts=0, connection_errors=0):
@@ -2174,7 +2175,7 @@ def queue_file_deleted_confirmation_tasks(limit=100):
         logger.info(f"Queued the file deleted confirmation task for {queued} InternetArchiveFiles.")
 
     else:
-        logger.info(f"Skipped queuing file deleted confirmation tasks: {tasks_in_ia_readonly_queue} task(s) in the ia-readonly queue.")
+        logger.info(f"Skipped the queuing of file deleted confirmation tasks: {tasks_in_ia_readonly_queue} task{tasks_in_ia_readonly_queue} in the ia-readonly queue.")
 
 
 @shared_task
@@ -2309,4 +2310,4 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
         logger.info(f"Prepared to upload {total_queued} links to internet archive across {len(queued)} days: {', '.join(queued)}.")
 
     else:
-        logger.info("Prepared to upload 0 links to internet archive: max tasks already in progress.")
+        logger.info("Skipped the queuing of file upload tasks: max tasks already in progress.")

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -72,7 +72,7 @@ def post_process_settings(settings):
         },
         'conditionally_queue_internet_archive_uploads_for_date_range': {
             'task': 'perma.celery_tasks.conditionally_queue_internet_archive_uploads_for_date_range',
-            'schedule': crontab(minute="*/15"),
+            'schedule': crontab(minute="*/5"),
             'args': (
                 os.environ.get('IA_UPLOAD_START_DATESTRING') or None,
                 os.environ.get('IA_UPLOAD_END_DATESTRING') or None

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -80,11 +80,11 @@ def post_process_settings(settings):
         },
         'confirm_files_uploaded_to_internet_archive': {
             'task': 'perma.celery_tasks.queue_file_uploaded_confirmation_tasks',
-            'schedule': crontab(minute="*/5"),
+            'schedule': crontab(minute="2-59/5"),
         },
         'confirm_files_deleted_from_internet_archive': {
             'task': 'perma.celery_tasks.queue_file_deleted_confirmation_tasks',
-            'schedule': crontab(minute="*/5"),
+            'schedule': crontab(minute="2-59/5"),
         }
     }
     settings['CELERY_BEAT_SCHEDULE'] = dict(((job, celerybeat_job_options[job]) for job in settings.get('CELERY_BEAT_JOB_NAMES', [])),


### PR DESCRIPTION
This PR makes a few additional tweaks to the upload/deletion pipeline.

- It catches a few additional exceptions that we see being raised regularly.
- It tweaks log messages, for easier filtering in Grafana.

- It adds, commented out, code for a planned second pass through the backlog. We observed that the [current strategy](https://github.com/harvard-lil/perma/commit/7d2c04fc53f6c6fac342d20d21e5da8a3bb6089f) for deciding which day to work on next mistakenly assumes that days will be sequentially marked as "complete" in chronological order... As a result, some partially-done days are being skipped over. The commented-out strategy will go back through and finish up the skipped over days.

And most significantly, it adjusts the timing of the scheduled tasks, to hopefully better take advantage of time where our workers are presently idle:
- `conditionally_queue...` will now run every 5 minutes instead of every 15, but it will only queue tasks if the queue is completely empty
- `confirmation...` tasks will continue to run at 5 min intervals, but will be offset, which should reduce the delay between when an upload is completed and when it is confirmed to have been completed... allowing us to queue up a larger number of tasks.

We'll have to see if the adjusted schedule works as well as I'm hoping. Is it a bad sign that this is XIII in the series?