### PR TITLE
Small Registrar-related admin improvements

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -327,7 +327,7 @@ class RegistrarAdmin(SimpleHistoryAdmin):
     search_fields = ['name', 'email', 'website']
     list_display = ['name', 'status', 'email', 'website', 'show_partner_status', 'partner_display_name', 'logo', 'address', 'latitude', 'longitude', 'registrar_users', 'last_active', 'orgs_count', 'link_count', 'tag_list', 'unlimited', 'nonpaying', 'cached_subscription_status', 'cached_subscription_started', 'cached_subscription_rate', 'base_rate']
     list_editable = ['show_partner_status', 'partner_display_name', 'address','latitude', 'longitude', 'status']
-    list_filter = ('unlimited', 'nonpaying', 'cached_subscription_status')
+    list_filter = ('status', 'unlimited', 'nonpaying', 'cached_subscription_status')
     fieldsets = (
         (None, {'fields': ('name', 'email', 'website', 'status', 'tags', 'orgs_private_by_default')}),
         ("Tier", {'fields': ('nonpaying', 'base_rate', 'cached_subscription_started', 'cached_subscription_status', 'cached_subscription_rate', 'unlimited', 'link_limit', 'link_limit_period', 'bonus_links')}),

--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -242,6 +242,16 @@ class IAItemHasTasksFilter(admin.SimpleListFilter):
             return queryset.filter(tasks_in_progress=0)
 
 
+class RegistrarNameFilter(InputFilter):
+    parameter_name = 'registrar'
+    title = 'Registrar'
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value:
+            return queryset.filter(registrar__name__icontains=value)
+
+
 ### inlines ###
 
 class LinkInline(admin.TabularInline):
@@ -366,7 +376,7 @@ class OrganizationAdmin(SimpleHistoryAdmin):
     fields = ['name', 'registrar']
     search_fields = ['name']
     list_display = ['name', 'registrar', 'org_users', 'last_active', 'first_active', 'user_deleted', 'link_count',]
-    list_filter = ['registrar', 'user_deleted']
+    list_filter = [RegistrarNameFilter, 'user_deleted']
 
     paginator = FasterAdminPaginator
     show_full_result_count = False


### PR DESCRIPTION
Closes https://github.com/harvard-lil/perma/issues/3297. 

Also replaces a slow `<select>` filter with a speedy `<input>`.

<img src="https://user-images.githubusercontent.com/11020492/229621667-df4c8a5f-426f-48f6-ae15-49c9269f850e.png" width=30% height=30%>
<img src="https://user-images.githubusercontent.com/11020492/229621023-867f28a8-ef9b-4436-a0b9-77f8299c557b.png" width=30% height=30%>