### PR TITLE
LinkUser `last_login` will be updated by a signal, going forward

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -838,7 +838,9 @@ class LinkUser(CustomerModel, AbstractBaseUser):
     notes = models.TextField(blank=True)
 
     objects = LinkUserManager()
-    tracker = FieldTracker()
+    # Don't add an unconfigured FieldTracker() to LinkUser: it breaks last_login https://github.com/harvard-lil/perma/issues/3296
+    # If tracking is required, enumerate the necessary fields using the fields param https://django-model-utils.readthedocs.io/en/latest/utilities.html#tracking-specific-fields
+    # tracker = FieldTracker(fields=[])
 
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []


### PR DESCRIPTION
This PR removes the `tracker` from `LinkUser` in order to work around https://github.com/harvard-lil/perma/issues/3296: it doesn't seem to be in use.

After deployed, last_login will start getting populated again.

