### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part XV 

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1562,7 +1562,12 @@ def populate_warc_size(link_guid):
 ### INTERNET ARCHIVE ###
 ###                  ###
 
-CONNECTION_ERRORS = (requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout)
+CONNECTION_ERRORS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.ConnectTimeout,
+    requests.exceptions.HTTPError,
+    requests.exceptions.ReadTimeout
+)
 
 def queue_batched_tasks(task, query, batch_size=1000, **kwargs):
     """


### PR DESCRIPTION
Last night and this morning, a number of IA tasks threw `HTTPError`s (Bad Gateway), which is not a failure mode we'd seen so far. This PR adds that exception set to the list, so that our running count of in-progress tasks and retry behavior work correctly.

I will manually clean up the task counts in a bit, once it's a little easier to see which buckets need resetting.