### PR TITLE
Create extensions only in docker envs.

### DIFF
--- a/perma_web/perma/migrations/0016_link_guid_case_insensitive_idx.py
+++ b/perma_web/perma/migrations/0016_link_guid_case_insensitive_idx.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
     # In our docker environment, where the database user does have the power,
     # install them here.
     #
-    # See <placeholder for link to github issue> for context.
+    # See https://github.com/harvard-lil/perma/issues/3308 for context.
     if settings.DATABASES['default']['HOST'] == 'db':
         print("Installing extensions.")
         operations = [

--- a/perma_web/perma/migrations/0016_link_guid_case_insensitive_idx.py
+++ b/perma_web/perma/migrations/0016_link_guid_case_insensitive_idx.py
@@ -4,22 +4,11 @@ import django.contrib.postgres.indexes
 from django.db import migrations
 import django.db.models.functions.text
 
-from django.db.utils import ProgrammingError
-
-
-def create_extensions(apps, schema_editor):
-    """
-    In environments where the database user does not have the power to
-    create extensions, these extensions _must_ have been created by another
-    user prior to running this migration.
-    """
-    try:
-        for extension in ['btree_gin', 'pg_trgm']:
-            schema_editor.execute(f"CREATE EXTENSION IF NOT EXISTS { extension }")
-    except ProgrammingError:
-        # this is actually psycopg2.errors.InsufficientPrivilege under the hood
-        pass
-
+from django.conf import settings
+from django.contrib.postgres.operations import (
+    BtreeGinExtension,
+    TrigramExtension,
+)
 
 class Migration(migrations.Migration):
 
@@ -27,10 +16,25 @@ class Migration(migrations.Migration):
         ('perma', '0015_alter_internetarchiveitem_tasks_in_progress'),
     ]
 
-    operations = [
-        migrations.RunPython(create_extensions, migrations.RunPython.noop, atomic=False),
+    # In environments where the database user does not have the power to
+    # create extensions, these extensions _must_ have been created by another
+    # user prior to running this migration.
+    #
+    # In our docker environment, where the database user does have the power,
+    # install them here.
+    #
+    # See <placeholder for link to github issue> for context.
+    if settings.DATABASES['default']['HOST'] == 'db':
+        print("Installing extensions.")
+        operations = [
+            BtreeGinExtension(),
+            TrigramExtension()
+        ]
+    else:
+        operations = []
+    operations.append(
         migrations.AddIndex(
             model_name='link',
             index=django.contrib.postgres.indexes.GinIndex(django.contrib.postgres.indexes.OpClass(django.db.models.functions.text.Upper('guid'), name='gin_trgm_ops'), name='guid_case_insensitive_idx'),
-        ),
-    ]
+        )
+    )


### PR DESCRIPTION
I will write all of this up in a Github issue shortly, but: we decided that the strategy for conditionally installing extensions introduced in https://github.com/harvard-lil/perma/commit/9ea178b530eac7a523583d7736874a176c6af2f8 was giving us too much trouble. After considering a number of other approaches, we decided to have the migration only be run in our Docker envs instead.

I've tested both branches of the conditional locally.

See https://github.com/harvard-lil/perma/issues/3308 for more discussion.

