### PR TITLE
Remove custom logic for where to install pg extensions

### DIFF
--- a/perma_web/perma/migrations/0016_link_guid_case_insensitive_idx.py
+++ b/perma_web/perma/migrations/0016_link_guid_case_insensitive_idx.py
@@ -4,7 +4,6 @@ import django.contrib.postgres.indexes
 from django.db import migrations
 import django.db.models.functions.text
 
-from django.conf import settings
 from django.contrib.postgres.operations import (
     BtreeGinExtension,
     TrigramExtension,
@@ -21,20 +20,14 @@ class Migration(migrations.Migration):
     # user prior to running this migration.
     #
     # In our docker environment, where the database user does have the power,
-    # install them here.
+    # the BtreeGinExtension and TrigramExtension operations will install them here.
     #
-    # See https://github.com/harvard-lil/perma/issues/3308 for context.
-    if settings.DATABASES['default']['HOST'] == 'db':
-        print("Installing extensions.")
-        operations = [
-            BtreeGinExtension(),
-            TrigramExtension()
-        ]
-    else:
-        operations = []
-    operations.append(
+    # See https://github.com/harvard-lil/perma/issues/3308 for discussion.
+    operations = [
+        BtreeGinExtension(),
+        TrigramExtension(),
         migrations.AddIndex(
             model_name='link',
             index=django.contrib.postgres.indexes.GinIndex(django.contrib.postgres.indexes.OpClass(django.db.models.functions.text.Upper('guid'), name='gin_trgm_ops'), name='guid_case_insensitive_idx'),
         )
-    )
+    ]


### PR DESCRIPTION
[This custom logic did not work](https://github.com/harvard-lil/perma/issues/3308#issuecomment-1498072179): while we did get further in the migration, the creation of the index still failed. This PR removes it.

In the meantime, @bensteinberg was able to find a solution on the DB-side. If this PR deploys successfully on stage, which has been migrated back to 0015, then we can close the issue.