### PR TITLE
Upload files to and delete files from "daily" digest IA items, Part XVII

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2325,7 +2325,12 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
                     date_string=date_string
                 )
                 try:
-                    in_flight_for_this_day = InternetArchiveItem.objects.get(identifier=identifier).tasks_in_progress
+                    item = InternetArchiveItem.objects.get(identifier=identifier)
+                    if item.complete:
+                        # if this day is already complete, skip it, and move on to the
+                        # next day in the range
+                        continue
+                    in_flight_for_this_day = item.tasks_in_progress
                 except InternetArchiveItem.DoesNotExist:
                     in_flight_for_this_day = 0
                 bucket_limit = min(daily_limit, to_queue - total_queued) - in_flight_for_this_day


### PR DESCRIPTION
The queuing strategy enabled in [Part XVI](https://github.com/harvard-lil/perma/pull/3311) looks for the earliest incomplete date, and then steps up, one day at a time, from there, until it has scheduled the desired number of tasks. It doesn't check to see whether a day is already known to have been finished, before checking for upload-eligible links... which is fine, but a little inelegant: it results in unnecessary log lines and an unnecessary call to the DB.

This PR adds a quick check.

Thanks to @bensteinberg for noticing the infelicity.