### PR TITLE
Don't mark an IA item complete if it's yesterday's

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -587,7 +587,7 @@ class LinkBatchAdmin(admin.ModelAdmin):
 class InternetArchiveItemAdmin(admin.ModelAdmin):
     list_display = ['identifier', 'confirmed_exists', 'cached_is_dark', 'added_date', 'span', 'cached_file_count', 'tasks_in_progress', 'complete', 'last_derived', 'derive_required', 'internet_archive_link']
     list_filter = [IAIdentifierFilter, IAItemTypeFilter, IAItemHasTasksFilter, 'confirmed_exists', 'complete', 'cached_is_dark']
-    readonly_fields = ['identifier', 'cached_is_dark', 'added_date', 'span', 'cached_title', 'cached_description', 'cached_file_count', 'complete', 'last_derived', 'derive_required']
+    readonly_fields = ['identifier', 'cached_is_dark', 'added_date', 'span', 'cached_title', 'cached_description', 'cached_file_count', 'last_derived']
 
     paginator = FasterAdminPaginator
     show_full_result_count = False

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2266,7 +2266,7 @@ def queue_internet_archive_uploads_for_date(date_string, limit=100):
         try:
             item = InternetArchiveItem.objects.get(identifier=identifier)
             # Don't mark an item complete if it's yesterday's
-            if timezone.now() - InternetArchiveItem.datetime(f"{date_string} 00:00:00") > timedelta(days=1):
+            if timezone.now() - item.span.lower > timedelta(days=1):
                 item.complete = True
                 item.save(update_fields=['complete'])
                 logger.info(f"Found no pending links: marked IA Item {item.identifier} complete.")

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2265,9 +2265,13 @@ def queue_internet_archive_uploads_for_date(date_string, limit=100):
         )
         try:
             item = InternetArchiveItem.objects.get(identifier=identifier)
-            item.complete = True
-            item.save(update_fields=['complete'])
-            logger.info(f"Found no pending links: marked IA Item {item.identifier} complete.")
+            # Don't mark an item complete if it's yesterday's
+            if timezone.now() - InternetArchiveItem.datetime(f"{date_string} 00:00:00") > timedelta(days=1):
+                item.complete = True
+                item.save(update_fields=['complete'])
+                logger.info(f"Found no pending links: marked IA Item {item.identifier} complete.")
+            else:
+                logger.info(f"Found no pending links for yesterday's IA Item {item.identifier}; not marking complete.")
         except InternetArchiveItem.DoesNotExist:
             logger.info(f"Found no pending links for {date_string}.")
         return 0


### PR DESCRIPTION
We are leaving some IA uploads undone, because we're marking the item complete too early. This does not mark an item complete if it's yesterday's item. 

I'm not sure about the use of `InternetArchiveItem.datetime(f"{date_string} 00:00:00")` as the canonical datetime for the item, but I saw it done [here](https://github.com/harvard-lil/perma/blob/43d389936e8beac8ff02a9c8e0e1ba52bb17d067/perma_web/perma/celery_tasks.py#L1627).