### PR TITLE
Correct logging

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2271,7 +2271,7 @@ def queue_internet_archive_uploads_for_date(date_string, limit=100):
                 item.save(update_fields=['complete'])
                 logger.info(f"Found no pending links: marked IA Item {item.identifier} complete.")
             else:
-                logger.info(f"Found no pending links for yesterday's IA Item {item.identifier}; not marking complete.")
+                logger.info(f"Found no pending links for recent IA Item {item.identifier}; not marking complete.")
         except InternetArchiveItem.DoesNotExist:
             logger.info(f"Found no pending links for {date_string}.")
         return 0


### PR DESCRIPTION
When you redefine "yesterday" a bunch of times, it becomes harder to see the word going by in the logs.