### PR TITLE
Improve IA task queuing log line, when there are no links.

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2343,7 +2343,10 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
             else:
                 break
 
-        logger.info(f"Prepared to upload {total_queued} links to internet archive across {len(queued)} days: {', '.join(queued)}.")
+        if total_queued:
+            logger.info(f"Prepared to upload {total_queued} links to internet archive across {len(queued)} days: {', '.join(queued)}.")
+        else:
+            logger.info("Prepared to upload 0 links to internet archive: no pending links in range.")
 
     else:
         logger.info("Skipped the queuing of file upload tasks: max tasks already in progress.")


### PR DESCRIPTION
Now that we are through the backlog, the enqueuing task frequently finds no links to queue. Improve the log line in that case... taking care to include the phrase "Prepared to upload" so that the Grafana dashboard works as desired with needing a tweak.

![image](https://user-images.githubusercontent.com/11020492/232581028-edcd2946-0ea3-4cc3-9fae-2f7140b89ce4.png)
