### PR TITLE
Add CSP to replay.perma.cc

### DIFF
--- a/perma_web/replay/views.py
+++ b/perma_web/replay/views.py
@@ -34,7 +34,11 @@ def iframe(request):
 
     response["Clear-Site-Data"] = '"cache", "storage"'
     response["Cache-Control"] = "no-cache, no-store, must-revalidate"
-    
+
+    # Intended CSP Policy:
+    # "Everything's allowed within the <iframe>, as long as it's same-origin."
+    response["Content-Security-Policy"] = "default-src 'self' data: 'unsafe-inline' 'unsafe-hashes' 'unsafe-eval';" # noqa
+
     return response
 
 


### PR DESCRIPTION
This PR adds a fairly _"loose"_ Content Security Policy to replay.perma.cc.

The intended policy can be summarized as: 
```
Everything's allowed within the <iframe>, as long as it's same-origin.
```

The goal is to help prevent potential _"service worker leaks"_ (meaning: requests meant to be intercepted by the service worker that end up reaching the network) that the playback software might not have accounted for yet by using browser-level safety mechanisms. 

---

**Note:** Will require extensive testing on staging before pushing to prod. 