### PR TITLE
Bookmarklets: remove MS Edge-specific instructions

### DIFF
--- a/perma_web/perma/templates/user_management/settings-tools.html
+++ b/perma_web/perma/templates/user_management/settings-tools.html
@@ -22,14 +22,6 @@
     <p class="body-text">You can create Perma links using our bookmarklet. Drag the following button to your bookmarks bar.</p>
     <a class="btn btn-bookmarklet" href={{bookmarklet}}>Create Perma link</a>
     <p class="body-text">Then, click the button while you’re viewing the page you want to save.</p>
-
-    <h4 class="body-bh">Microsoft Edge Users</h4>
-    <p>You can use our bookmarklet too! Right click this link: <a href="{{bookmarklet}}">Create Perma Link</a>. From the dropdown, select "Add to reading list." While viewing the page you want to save, just open your <a href="https://support.microsoft.com/en-us/help/17171/windows-10-get-to-know-microsoft-edge">"Hub"</a>, then select the Reading List panel and click "Create Perma Link."
-      <span role="button" tabindex="0" aria-label="toggle MS Edge visual demo" onclick="$('#msedge-hub').toggle();">
-        <span class="icon-picture" aria-hidden="true"></span>
-      </span>
-    </p>
-    <p id="msedge-hub" style="width: 250px; display:none;"><img src="{{ STATIC_URL }}img/msedge-hub.png" width="250" class="img-thumbnail" alt="Screenshot of MS Edge Hub"></p>
   {% endwith %}
 
   {% include "api_key_embedded_form.html" %}


### PR DESCRIPTION
This PR removes the following instructions from the "Tools" page, which were specific to earlier versions of Microsoft Edge and are now obsolete:

<img width="1002" alt="Screenshot 2023-05-16 at 4 42 45 PM" src="https://github.com/harvard-lil/perma/assets/625889/f9d1f7e4-3f16-4aed-bc08-d67921879358">

Microsoft Edge users may use the same procedure as users of Google Chrome or Firefox, if they wish to use our bookmarklet.

---

Thanks @kmukk for bringing this problem to my attention 🙏 