### PR TITLE
Make a stand-alone form for reporting inappropriate content

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -2,6 +2,7 @@ from axes.utils import reset as reset_login_attempts
 
 from django import forms
 from django.contrib.auth.forms import SetPasswordForm
+from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import ModelForm
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -392,3 +393,28 @@ class ContactForm(forms.Form):
     telephone = forms.CharField(label="Do not fill out this box", required=False, widget=forms.Textarea)  # fake message box to fool bots
     box2 = forms.CharField(label="Message", widget=forms.Textarea)
     referer = forms.URLField(widget=forms.HiddenInput, required=False)
+
+
+class ReportForm(forms.Form):
+    """
+    Form for reporting inappropriate content.
+    """
+    reason = forms.ChoiceField(
+        choices = BLANK_CHOICE_DASH +[(reason, reason) for reason in [
+            'Graphic or Dangerous Content',
+            'False or Misinformation',
+            'Copyright Infringement',
+            'Other'
+        ]],
+        label = 'Reason for Reporting'
+    )
+    source = forms.CharField(
+        label="How did you discover this Perma Link?",
+        help_text="If possible, please include the URL where you found the Perma Link.",
+        widget=forms.Textarea
+    )
+    email = forms.EmailField(label="Your email address")
+    box2 = forms.CharField(label="Message (optional)", widget=forms.Textarea, required=False)
+    telephone = forms.CharField(label="Do not fill out this box", required=False, widget=forms.Textarea)  # fake message box to fool bots
+    guid = forms.CharField(widget=forms.HiddenInput, required=False)
+    referer = forms.CharField(widget=forms.HiddenInput, required=False)

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -414,7 +414,6 @@ class ReportForm(forms.Form):
         widget=forms.Textarea
     )
     email = forms.EmailField(label="Your email address")
-    box2 = forms.CharField(label="Message (optional)", widget=forms.Textarea, required=False)
     telephone = forms.CharField(label="Do not fill out this box", required=False, widget=forms.Textarea)  # fake message box to fool bots
     guid = forms.CharField(widget=forms.HiddenInput, required=False)
     referer = forms.CharField(widget=forms.HiddenInput, required=False)

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -192,7 +192,7 @@
           <a href="{% url 'single_permalink' guid=link.guid %}?type=warc_download" role="button" class="btn btn-ui-small btn-dashboard" title="download">Download Archive</a>
         {% endif %}
         {% if not can_edit %}
-          <a href="{% url 'contact' %}?flag={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
+          <a href="{% url 'report' %}?guid={{link.guid}}" role="button" class="btn btn-ui-small btn-dashboard flag" title="Flag as inappropriate">Flag<span class="_verbose"> as inappropriate</span></a>
         {% endif %}
         {# user edit buttons #}
         {% if can_toggle_private %}

--- a/perma_web/perma/templates/email/admin/report.txt
+++ b/perma_web/perma/templates/email/admin/report.txt
@@ -1,0 +1,26 @@
+{% block content %}
+A user has reported that {{ guid }} contains inappropriate material.
+
+{{ request.scheme|add:"://"|add:request.get_host }}{% url 'admin:perma_link_changelist' %}?guid={{ guid | urlencode }}
+
+
+Reason for Reporting
+--------------------
+{{ reason }}
+
+How did you discover this Perma Link?
+-------------------------------------
+{{ source}}{% if message %}
+Message from user
+-----------------
+{{ message }}{% endif %}
+{% endblock%}{% block footer %}
+----
+Troubleshooting Info:
+User email: {{ from_address }}
+Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}
+Affiliations: {{ affiliation_string | default:"(none)" }}
+Referring Page: {{ referer }}
+User agent: {{ request.META.HTTP_USER_AGENT | default:"(unknown)"}}
+{% endblock footer %}
+

--- a/perma_web/perma/templates/email/admin/report.txt
+++ b/perma_web/perma/templates/email/admin/report.txt
@@ -10,10 +10,7 @@ Reason for Reporting
 
 How did you discover this Perma Link?
 -------------------------------------
-{{ source}}{% if message %}
-Message from user
------------------
-{{ message }}{% endif %}
+{{ source}}
 {% endblock%}{% block footer %}
 ----
 Troubleshooting Info:

--- a/perma_web/perma/templates/report.html
+++ b/perma_web/perma/templates/report.html
@@ -1,0 +1,30 @@
+{% extends "base-responsive.html" %}
+{% block title %} | Report Inappropriate Content{% endblock %}
+{% with base_url=request.scheme|add:"://"|add:request.get_host %}
+
+{% block meta %}
+<meta name="robots" content="noarchive">
+{% endblock %}
+
+{% block mainContent %}
+<div class="container cont-fixed">
+  <div class="row">
+    <div class="col-sm-12">
+      <h1 class="page-title">Report</h1>
+
+      <p class="page-dek">{{ base_url }}{{ guid }} contains material that is inappropriate.</p>
+    </div>
+  </div> <!-- row -->
+  <div class="row">
+    <div class="col-sm-9 contact-form">
+      <form action="{% url 'report' %}" method="post">
+        {% csrf_token %}
+        {% include "includes/fieldset.html" with form_classes="fg-100" %}
+        <button type="submit" class="btn">Send</button>
+      </form>
+    </div><!--col -->
+  </div><!--row-->
+</div><!--container-->
+{% endblock mainContent %}
+
+{% endwith %}

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -596,8 +596,7 @@ class CommonViewsTestCase(PermaTestCase):
             error_keys = [
                 'reason',
                 'source',
-                'email',
-                'guid'
+                'email'
             ]
         )
 

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     re_path(r'^privacy-policy/?$', DirectTemplateView.as_view(template_name='privacy_policy.html'), name='privacy_policy'),
     re_path(r'^return-policy/?$', DirectTemplateView.as_view(template_name='return_policy.html'), name='return_policy'),
     re_path(r'^contingency-plan/?$', DirectTemplateView.as_view(template_name='contingency_plan.html'), name='contingency_plan'),
+    re_path(r'^report/?$', common.report, name='report'),
     re_path(r'^contact/?$', common.contact, name='contact'),
     re_path(r'^contact/thanks/?$', common.contact_thanks, name='contact_thanks'),
     #   re_path(r'^is500/?$', DirectTemplateView.as_view(template_name='500.html'), name='is500'),

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -514,7 +514,6 @@ def report(request):
                 context = {
                     "reason": form.cleaned_data['reason'],
                     "source": form.cleaned_data['source'],
-                    "message": form.cleaned_data['box2'],
                     "from_address": from_address,
                     "guid": form.cleaned_data['guid'],
                     "referer": form.cleaned_data['referer'],

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -349,7 +349,6 @@ def rate_limit(request, exception):
     return render(request, "rate_limit.html")
 
 
-@csrf_exempt
 @ratelimit(rate=settings.MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
 def contact(request):
     """


### PR DESCRIPTION
Currently, when a user clicks on the “Flag Inappropriate” button on the “Record Details” tray of a Perma Link they are redirected to our [Contact Form](https://perma.cc/contact?flag=T9KH-SZNL) with a pre-filled message.

We decided to extract that into its own form for special handling: see ENG-96 for more discussion about details and design.

### Flow

This PR adds a form with two new fields: a select/dropdown of reasons for reporting, and a text field requesting info on where the user found the Perma Link. 

![image](https://github.com/harvard-lil/perma/assets/11020492/316a3bbd-3266-4d24-9022-5bc1958e279f)
![image](https://github.com/harvard-lil/perma/assets/11020492/5581c34c-40b5-4e81-bb16-3a76016a396e)

If the reporting user is logged in, their email address is pre-populated for them.

If required fields are missing, users are prompted to fill them in, but otherwise, they are directed to the "Thanks!" page.

![image](https://github.com/harvard-lil/perma/assets/11020492/80155318-a50b-4663-bb3e-e408d825940d)

Perma admins are sent an email something like:
```
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: [perma-contact] Reporting Inappropriate Content
From: webmaster@localhost
To: webmaster@localhost
Date: Mon, 12 Jun 2023 20:33:16 -0000
Message-ID: <168660199633.1417.8184645293545937667@d807b0a87676>
Reply-To: me@me.com


A user has reported that CMU9-DXVG contains inappropriate material.

https://perma.test:8000/admin/perma/link/?guid=CMU9-DXVG


Reason for Reporting
--------------------
Graphic or Dangerous Content

How did you discover this Perma Link?
-------------------------------------
I saw it on Internet Archive.

----
Troubleshooting Info:
User email: me@me.com
Logged in: false
Affiliations: (none)
Referring Page: https://perma.test:8000/CMU9-DXVG
User agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36
```

### Design decisions

I chose _not_ to have the form perform any checks to see if the GUID in question exists. While no more expensive than a regular 404, I wanted to minimize database usage, should a bot slip past our protections and make a gazillion submissions. But, I only send the email if _something_ is supplied for GUID.

I'm not that worried about it, but it could be that we'd rather check for the existence of the link instead.