### PR TITLE
Use WACZ-exhibitor for playback in Perma (behind a feature flag)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,26 @@ services:
           - 'perma.minio.test'
 
   #
+  # wacz-exhibitor
+  #
+  wacz-exhibitor:
+    image: registry.lil.tools/harvardlil/wacz-exhibitor:0.0.10-2
+    build:
+      context: ./services/docker/wacz-exhibitor
+      x-bake:
+        tags:
+          - registry.lil.tools/harvardlil/wacz-exhibitor:0.0.10-2
+        platforms:
+          - linux/amd64
+          - linux/arm64
+    ports:
+      - "127.0.0.1:8080:8080"
+    extra_hosts:
+      - "rejouer.perma.test:127.0.0.1"
+    volumes:
+      - ./services/docker/wacz-exhibitor/ssl:/etc/nginx/certs
+
+  #
   # Upload scanning
   #
   filecheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,12 +109,12 @@ services:
   # wacz-exhibitor
   #
   wacz-exhibitor:
-    image: registry.lil.tools/harvardlil/wacz-exhibitor:0.0.10-2
+    image: registry.lil.tools/harvardlil/wacz-exhibitor:0.0.10-3
     build:
       context: ./services/docker/wacz-exhibitor
       x-bake:
         tags:
-          - registry.lil.tools/harvardlil/wacz-exhibitor:0.0.10-2
+          - registry.lil.tools/harvardlil/wacz-exhibitor:0.0.10-3
         platforms:
           - linux/amd64
           - linux/arm64

--- a/install.md
+++ b/install.md
@@ -29,7 +29,7 @@ Hosts
 Perma serves content at several hosts. To ensure that URLs resolve correctly,
 add the following domains to your computer's hosts file:
 
-    127.0.0.1 perma.test api.perma.test replay.perma.test perma.minio.test
+    127.0.0.1 perma.test api.perma.test replay.perma.test rejouer.perma.test perma.minio.test
 
 For additional information on modifying your hosts file,
 [try this help doc](https://docs.rackspace.com/support/how-to/modify-your-hosts-file).

--- a/make_cert.sh
+++ b/make_cert.sh
@@ -9,7 +9,9 @@ cp "$(mkcert -CAROOT)/rootCA.pem" perma_web/rootCA.pem
 HOSTS=$(docker compose run -T web bash -c "echo \"from django.conf import settings; print(' '.join(host for host in settings.ALLOWED_HOSTS))\" | python ./manage.py shell")
 mkcert -key-file perma_web/perma-test.key -cert-file perma_web/perma-test.crt $HOSTS
 mkcert -key-file services/docker/minio/ssl/private.key -cert-file services/docker/minio/ssl/public.crt perma.minio.test
+mkcert -key-file services/docker/wacz-exhibitor/ssl/private.key -cert-file services/docker/wacz-exhibitor/ssl/public.crt rejouer.perma.test
 
-# For dev convenience: restart minio (which will have crashed immediately) now that the required cert and key files are available
+# For dev convenience: restart minio and wacz-exhibitor (which will have crashed immediately) now that the required cert and key files are available
 # (will be a no-op if the services weren't started in the first place, i.e., if docker compose isn't currently running `up`)
 docker compose restart minio
+docker compose restart wacz-exhibitor

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1755,6 +1755,10 @@ class Link(DeletableModel):
                 'ResponseContentEncoding': ''
         })
 
+    def warc_presigned_url_relative(self):
+        parsed = urlparse(self.warc_presigned_url())
+        return f'{parsed.path}?{parsed.query}'.lstrip('/')
+
     # def get_thumbnail(self, image_data=None):
     #     if self.thumbnail_status == 'failed' or self.thumbnail_status == 'generating':
     #         return None

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -492,7 +492,11 @@ INTERNET_ARCHIVE_UPLOAD_MAX_TMEOUTS = 2
 HOST = 'perma.test:8000'
 ALLOWED_HOSTS = ['perma.test', 'api.perma.test', 'replay.perma.test']
 API_SUBDOMAIN = 'api'
+
 PLAYBACK_SUBDOMAIN = 'replay'
+# Set PLAYBACK_HOST to replay via an externally running instance of wacz-exhibitor.
+# Otherwise, falls back to replay at PLAYBACK_SUBDOMAIN, served by the replay Django app
+PLAYBACK_HOST = None
 
 #
 # Playback
@@ -559,7 +563,8 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'SENTRY_DSN',
     'SENTRY_ENVIRONMENT',
     'SENTRY_TRACES_SAMPLE_RATE',
-    'PLAYBACK_SUBDOMAIN'
+    'PLAYBACK_SUBDOMAIN',
+    'PLAYBACK_HOST'
 )
 
 

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -4,6 +4,8 @@ import os
 
 DEBUG = True
 
+# PLAYBACK_HOST = 'rejouer.perma.test:8080'
+
 # logging
 LOGGING_DIR = os.path.join(SERVICES_DIR, 'logs')
 LOGGING['handlers']['file']['filename'] = os.path.join(LOGGING_DIR, 'django.log')

--- a/perma_web/perma/templates/archive/download_to_view_pdf.html
+++ b/perma_web/perma/templates/archive/download_to_view_pdf.html
@@ -1,5 +1,5 @@
 <div id="playback-interstitial" class="record-message">
-  <p class="hidden record-message-primary">Perma.cc can't display this file type on mobile, but you can view or download the archived file by clicking below.</p>
+  <p class="hidden record-message-primary">Perma.cc can’t display this file type on mobile, but you can view or download the archived file by clicking below.</p>
   <p class="hidden record-message-secondary">File type {{mime_type}}</p>
   {% if PLAYBACK_HOST %}
     <button id="download-button" class="hidden btn btn-primary">View/Download File</button>

--- a/perma_web/perma/templates/archive/download_to_view_pdf.html
+++ b/perma_web/perma/templates/archive/download_to_view_pdf.html
@@ -1,7 +1,14 @@
-<div class="record-message">
-  <p class="record-message-primary">Perma.cc can't display this file type on mobile, but you can view or download the archived file by clicking below.</p>
-  <p class="record-message-secondary">File type {{mime_type}}</p>
+<div id="playback-interstitial" class="record-message">
+  <p class="hidden record-message-primary">Perma.cc can't display this file type on mobile, but you can view or download the archived file by clicking below.</p>
+  <p class="hidden record-message-secondary">File type {{mime_type}}</p>
+  {% if PLAYBACK_HOST %}
+    <button id="download-button" class="hidden btn btn-primary">View/Download File</button>
+    <div>
+      {% include "archive/includes/wacz_exhibitor_iframe.html" with interstitial=True  %}
+    </div>
+  {% else %}
     <div>
       {% include "archive/includes/client_side_iframe.html" with interstitial=True target="blank" %}
     </div>
+  {% endif %}
 </div>

--- a/perma_web/perma/templates/archive/iframe.html
+++ b/perma_web/perma/templates/archive/iframe.html
@@ -13,20 +13,35 @@
     <p class="record-message-secondary">Perma has not yet finished archiving the contents of this link.<br/>Please try again later.</p>
   </div>
 {% elif capture.show_interstitial %}
-  <div class="record-message {{ new_record|yesno:'new-record-message,' }}">
-    <p class="record-message-primary">Perma.cc can’t display this file type but you can view or download the archived file by clicking below.</p>
-    <p class="record-message-secondary">File type {{ capture.mime_type }}</p>
-    <div>
-      {% include "archive/includes/client_side_iframe.html" with interstitial=True %}
-    </div>
+  <div id="playback-interstitial" class="record-message {{ new_record|yesno:'new-record-message,' }}">
+    <p class="hidden record-message-primary">Perma.cc can’t display this file type but you can view or download the archived file by clicking below.</p>
+    <p class="hidden record-message-secondary">File type {{ capture.mime_type }}</p>
+    {% if PLAYBACK_HOST %}
+      <button id="download-button" class="hidden btn btn-primary">View/Download File</button>
+      <div>
+        {% include "archive/includes/wacz_exhibitor_iframe.html" with interstitial=True  %}
+      </div>
+    {% else %}
+      <div>
+        {% include "archive/includes/client_side_iframe.html" with interstitial=True %}
+      </div>
+    {% endif %}
   </div>
 {% else %}
   <div class="capture-wrapper">
     <div class="h_iframe">
-      {% if capture.role == 'screenshot' %}
-        {% include "archive/includes/client_side_iframe.html" with screenshot=True %}
+      {% if PLAYBACK_HOST %}
+        {% if capture.role == 'screenshot' %}
+          {% include "archive/includes/wacz_exhibitor_iframe.html" with screenshot=True %}
+        {% else %}
+          {% include "archive/includes/wacz_exhibitor_iframe.html" %}
+        {% endif %}
       {% else %}
-        {% include "archive/includes/client_side_iframe.html" %}
+        {% if capture.role == 'screenshot' %}
+          {% include "archive/includes/client_side_iframe.html" with screenshot=True %}
+        {% else %}
+          {% include "archive/includes/client_side_iframe.html" %}
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/perma_web/perma/templates/archive/includes/client_side_iframe.html
+++ b/perma_web/perma/templates/archive/includes/client_side_iframe.html
@@ -36,6 +36,12 @@
     if (interstitial) {
       srcQuery.append("hidden", "true");
       srcQuery.append("ondemand", "true");
+
+      // Display the hidden interstitial message.
+      const interstitialElems = document.querySelectorAll("#playback-interstitial .hidden");
+      for (const elem of interstitialElems) {
+        elem.classList.remove("hidden");
+      }
     }
 
     if (target) {

--- a/perma_web/perma/templates/archive/includes/wacz_exhibitor_iframe.html
+++ b/perma_web/perma/templates/archive/includes/wacz_exhibitor_iframe.html
@@ -67,4 +67,32 @@
     wrapper.appendChild(frame);
   }
 
+
+  {% if screenshot %}
+    // Experimental: uses functionality proposed in
+    // https://github.com/rebeccacremona/wacz-exhibitor/tree/override-element-attr
+
+    // set alt text and style the loaded image for cross-browser consistency
+    frame.addEventListener( "load", function(e) {
+
+      frame.contentWindow.postMessage(
+        {"overrideElementAttribute": {
+          "selector": "img",
+          "attributeName": "style",
+          "attributeContents": "display: block; margin: auto; width: auto; height: auto;"
+        }},
+        origin
+      );
+
+      frame.contentWindow.postMessage(
+        {"overrideElementAttribute": {
+          "selector": "img",
+          "attributeName": "alt",
+          "attributeContents": "Screenshot"
+        }},
+        origin
+      );
+    });
+  {% endif %}
+
 </script>

--- a/perma_web/perma/templates/archive/includes/wacz_exhibitor_iframe.html
+++ b/perma_web/perma/templates/archive/includes/wacz_exhibitor_iframe.html
@@ -1,0 +1,70 @@
+<div id="iframe-target"></div>
+
+<!-- Will display unless playback logic can kick in -->
+<div id="no-playback">
+  <div class="record-message">
+    <p class="record-message-primary">Incompatible browser</p>
+    <p class="record-message-secondary">
+      Please update your browser to visit this Perma Link.<br>
+      Perma.cc has been tested with the latest version of:<br>
+      Google Chrome, Mozilla Firefox, Apple Safari and Microsoft Edge.
+    </p>
+    <a class="btn btn-primary" href="javascript:history.back()">Go back</a>
+  </div>
+</div>
+
+<script type="module">
+  // TODO: double check that this is good enough: I am assuming any browser
+  // that can handle <script type="module" can handle playbacks.
+  // Compare with:
+  // https://github.com/harvard-lil/perma/commit/899c3e71b1976024edd23e50b90e5f998384052f
+  const noPlayback = document.querySelector("#no-playback");
+  noPlayback.remove();
+
+  // Playback details
+  const cls = "{{ interstitial|yesno:'background,archive-iframe'}}";
+  const origin = "{{ protocol }}{{ client_side_playback_host }}";
+  const url = {% if screenshot %}"{{ link.screenshot_capture.url | escapejs}}"{% else %}"{{ link.primary_capture.url | escapejs }}"{% endif %}
+  const sandbox = {{ link.primary_capture.use_sandbox|yesno:"true,false" }};
+  const embed = {{ embed|yesno:"true,false" }};
+  const interstitial = {{ interstitial|yesno:"true,false" }};
+
+  var frame = null;
+  var srcQuery = null;
+
+  // Add iframe
+  frame = document.createElement('iframe');
+  frame.className = cls;
+
+  // Build query string
+  srcQuery = new URLSearchParams();
+  srcQuery.append("source", "{{ link.warc_presigned_url_relative | escapejs }}");
+  srcQuery.append("url", url);
+  if (embed) {
+    srcQuery.append("embed", "replayonly");
+  }
+  frame.setAttribute("src", origin + "?" + srcQuery);
+
+  if (sandbox) {
+    frame.setAttribute("sandbox", "allow-scripts allow-forms allow-same-origin allow-downloads allow-modals");
+  }
+
+  const wrapper = document.getElementById("iframe-target");
+  if (interstitial) {
+
+    // Display the hidden interstitial message.
+    const interstitialElems = document.querySelectorAll("#playback-interstitial .hidden");
+    for (const elem of interstitialElems) {
+      elem.classList.remove("hidden");
+    }
+
+    const downloadButton = document.querySelector("#download-button");
+    downloadButton.addEventListener( "click", function(e) {
+     wrapper.appendChild(frame);
+    });
+
+  } else {
+    wrapper.appendChild(frame);
+  }
+
+</script>

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -185,7 +185,7 @@ class CommonViewsTestCase(PermaTestCase):
 
             client = Client(HTTP_USER_AGENT='Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10B350 Safari/8536.25')
             response = client.get(reverse('single_permalink', kwargs={'guid': link.guid}), secure=True)
-            self.assertIn(b"Perma.cc can\'t display this file type on mobile", response.content)
+            self.assertIn(b"Perma.cc can’t display this file type on mobile", response.content)
 
             # Check to see we are requesting an interstitial iframe: we can't check for the download link without JS
             self.assertIn(b'const cls = "interstitial"', response.content)
@@ -193,7 +193,7 @@ class CommonViewsTestCase(PermaTestCase):
             # If not on mobile, display link as normal
             client = Client(HTTP_USER_AGENT='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7')
             response = client.get(reverse('single_permalink', kwargs={'guid': link.guid}), secure=True)
-            self.assertNotIn(b"Perma.cc can\'t display this file type on mobile", response.content)
+            self.assertNotIn(b"Perma.cc can’t display this file type on mobile", response.content)
 
     def test_deleted(self):
         response = self.get('single_permalink', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}}, require_status_code=410, request_kwargs={'follow': True})

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -185,7 +185,7 @@ class CommonViewsTestCase(PermaTestCase):
 
             client = Client(HTTP_USER_AGENT='Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10B350 Safari/8536.25')
             response = client.get(reverse('single_permalink', kwargs={'guid': link.guid}), secure=True)
-            self.assertIn(b"Perma.cc can’t display this file type on mobile", response.content)
+            self.assertIn(b"Perma.cc can\xe2\x80\x99t display this file type on mobile", response.content)
 
             # Check to see we are requesting an interstitial iframe: we can't check for the download link without JS
             self.assertIn(b'const cls = "interstitial"', response.content)
@@ -193,7 +193,7 @@ class CommonViewsTestCase(PermaTestCase):
             # If not on mobile, display link as normal
             client = Client(HTTP_USER_AGENT='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7')
             response = client.get(reverse('single_permalink', kwargs={'guid': link.guid}), secure=True)
-            self.assertNotIn(b"Perma.cc can’t display this file type on mobile", response.content)
+            self.assertNotIn(b"Perma.cc can\xe2\x80\x99t display this file type on mobile", response.content)
 
     def test_deleted(self):
         response = self.get('single_permalink', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}}, require_status_code=410, request_kwargs={'follow': True})

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -214,7 +214,10 @@ def single_permalink(request, guid):
                 return render(request, 'archive/playback-delayed.html', context,  status=200)
 
         logger.info(f'Preparing client-side playback for {link.guid}')
-        context['client_side_playback_host'] = f"{settings.PLAYBACK_SUBDOMAIN}.{settings.HOST}"
+        if settings.PLAYBACK_HOST:
+            context['client_side_playback_host'] = settings.PLAYBACK_HOST
+        else:
+            context['client_side_playback_host'] = f"{settings.PLAYBACK_SUBDOMAIN}.{settings.HOST}"
         context['embed'] = False if request.GET.get('embed') == 'False' else True
 
     response = render(request, 'archive/single-link.html', context)

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -1558,6 +1558,27 @@ body.modal-open {
             margin:0px auto;
         }
     }
+}
 
+/* Fallback screen for old browsers */
+#no-playback,
+#playback-interstitial .hidden{
+  /* Prevent flashing: */
+  opacity: 0;
+  animation: no-playback-fade-in 0.5s ease-in-out;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+}
+@keyframes no-playback-fade-in {
+  0%    { opacity: 0; }
+  20%   { opacity: 0; }
+  80%   { opacity: 0.5; }
+  100%  { opacity: 1; }
+}
 
+iframe.background {
+  visibility: hidden;
+  height: 10px;
+  min-width: 10px;
+  width: 10px;
 }

--- a/services/docker/wacz-exhibitor/Dockerfile
+++ b/services/docker/wacz-exhibitor/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.lil.tools/harvardlil/nginx:0.03 as builder
+
+RUN apt-get update && apt-get install -y git
+RUN git clone https://github.com/harvard-lil/wacz-exhibitor.git
+
+FROM registry.lil.tools/harvardlil/nginx:0.03
+
+COPY --from=builder /wacz-exhibitor/html/ /usr/share/nginx/html/
+COPY ./nginx.conf /etc/nginx/conf.d/nginx.conf

--- a/services/docker/wacz-exhibitor/Dockerfile
+++ b/services/docker/wacz-exhibitor/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.lil.tools/harvardlil/nginx:0.03 as builder
 
 RUN apt-get update && apt-get install -y git
-RUN git clone https://github.com/harvard-lil/wacz-exhibitor.git
+RUN git clone https://github.com/rebeccacremona/wacz-exhibitor.git
+RUN cd wacz-exhibitor; git checkout override-element-attr
 
 FROM registry.lil.tools/harvardlil/nginx:0.03
 

--- a/services/docker/wacz-exhibitor/nginx.conf
+++ b/services/docker/wacz-exhibitor/nginx.conf
@@ -1,0 +1,98 @@
+#
+# Default NGINX configuration file for wacz-exhibitor,
+# with an added SSL stanza for local development,
+# and with the values of `proxy_pass` configured for local Perma's setup.
+#
+# Inspiration:
+# - https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/
+# - https://kevincox.ca/2021/06/04/http-range-caching/
+# - https://github.com/KyleAMathews/docker-nginx/blob/master/nginx.conf
+#
+proxy_cache_path /var/cache/nginx keys_zone=rangecache:10m inactive=60m;
+
+server {
+  listen 8080 ssl;
+  listen [::]:8080 ssl;
+
+  server_name  rejouer.perma.test;
+  ssl_certificate /etc/nginx/certs/public.crt;
+  ssl_certificate_key /etc/nginx/certs/private.key;
+
+  root /usr/share/nginx/html/;
+
+  # Range request caching setup (slice-by-slice approach)
+  slice              1m;
+  proxy_cache_key    $host$uri$is_args$args$slice_range;
+  proxy_set_header   Range $slice_range;
+  proxy_http_version 1.1;
+  proxy_cache_valid  200 206 1h;
+  proxy_cache rangecache;
+
+  # Gzip compression setup
+  gzip on;
+  gzip_http_version 1.0; # Minimum HTTP version for gzip compression
+  gzip_comp_level 5;
+  gzip_min_length 256;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_types
+    application/javascript
+    application/json
+    text/css
+    text/plain;
+  # text/html is always compressed by HttpGzipModule
+
+  # Serves contents of "/embed" as "/"
+  location / {
+    try_files /embed$uri /embed/$uri/ /index.html;
+
+    # Intended CSP Policy:
+    # "Everything's allowed within the <iframe>, as long as it's same-origin."
+    add_header Content-Security-Policy "default-src 'self' data: 'unsafe-inline' 'unsafe-hashes' 'unsafe-eval';";
+  }
+
+  # Exception to the above rule: "/replay-web-page" folder.
+  location /replay-web-page/ {
+    try_files $uri $uri/;
+  }
+
+  #
+  # Access to "warc", "warc.gz", "wacz" files:
+  # - Serve local file from "/archives/" if available.
+  # - Otherwise, try to proxy it from a remote server.
+  #
+  location ~ \.warc {
+    types { } default_type "application/warc";
+    try_files /archives/$uri /archives/$uri/ @remote_warc_archive;
+  }
+
+  location ~ \.warc.gz {
+    gzip_static on;
+    types { } default_type "application/x-gzip";
+    try_files /archives/$uri /archives/$uri/ @remote_warc_gz_archive;
+  }
+
+  location ~ \.wacz {
+    types { } default_type "application/wacz";
+    try_files /archives/$uri /archives/$uri/ @remote_wacz_archive;
+  }
+
+  location @remote_warc_archive {
+    proxy_pass https://perma.minio.test:9000;
+    proxy_hide_header Content-Type;
+    add_header Content-Type "application/warc";
+  }
+
+  location @remote_warc_gz_archive {
+    proxy_pass https://perma.minio.test:9000;
+    proxy_hide_header Content-Type;
+    add_header Content-Type "application/x-gzip";
+  }
+
+  location @remote_wacz_archive {
+    proxy_pass https://perma.minio.test:9000;
+    proxy_hide_header Content-Type;
+    add_header Content-Type "application/wacz";
+  }
+
+}

--- a/services/docker/wacz-exhibitor/ssl/.gitignore
+++ b/services/docker/wacz-exhibitor/ssl/.gitignore
@@ -1,0 +1,3 @@
+*.crt
+*.key
+*.conf


### PR DESCRIPTION
See ENG-99.

[wacz-exhibitor](https://github.com/harvard-lil/wacz-exhibitor) was built to help websites embed WARC and WACZ replays in the [best way possible](https://lil.law.harvard.edu/blog/2022/09/15/opportunities-and-challenges-of-client-side-playback/): we’d do well to use it in Perma! 

Our proposed move to WACZ would allow us to fully benefit from its caching smarts, but we will benefit a bit even while Perma is still primarily serving WARC playbacks.

## This PR

This PR adds the new Django setting `PLAYBACK_HOST`, set to `None` by default. 

If defined, the application will send playbacks to that host instead of to the [`replay` Django app](https://github.com/harvard-lil/perma/tree/develop/perma_web/replay) currently served at a subdomain.

Locally,
- run `docker compose up -d` and then `bash make_cert.sh` to prepare your environment, then
- uncomment `PLAYBACK_HOST = 'rejouer.perma.test:8080'` in settings_dev.py

to direct playbacks to an nginx container serving a [slightly tweaked version of `wacz-exhibitor`](https://github.com/rebeccacremona/wacz-exhibitor/commit/9bc60b6bd477a28bb0e04d96fbd7c1d2fd01e739).

You can toggle back and forth without restarting the Django dev server.

Most playbacks should look identical.

## Exceptions

### Interstitials

While working to re-implement the [custom interstitials](https://github.com/harvard-lil/perma/pull/3036) that handle any playbacks that should trigger downloads... I discovered that they are currently broken 😢: Safari users do not receive a usable download, and other users receive multiple copies. (Bug to be written up shortly.)

So, this PR does NOT re-implement the more complex interstitials we are currently using in prod, which were introduced specifically for Safari.

In production, when a user clicks the "View/Download File" button, we pry into the `replay-web-page` instance and find the internal URL for the payload. Then, we insert an `<a>` into the DOM with that as `href` and click it. That used to reliably trigger a download in all browsers... but alas: in Safari, that network request is NOT intercepted by the service worker, and falls through to the live web, where it either 404s (`replay.perma.cc`) or 500s (`wacz-exhibitor`). 

I cannot think of any further workarounds... So, I just do the simpler thing, our original strategy: don't stick the playback iframe into the page until the user clicks the "View/Download File" button. That reliably triggers one download in all browsers tested except for Safari.

We probably want to talk about this some more... but not as part of this PR.


### Fallback for old browsers

In production, `replay.perma.cc` is responsible for rendering an "update your browser!" message, if a person with a very old browser loads a Perma Link.

When playbacks are mediated by `wacz-exhibitor`, the perma app takes care of it. (TBD: whether that's something that ought to be handled by `wacz-exhibitor` instead; I think probably, but could be wrong!)

I didn't use an identical strategy: this code will attempt a playback for every browser that can read `script type=module`. That might not be good enough 🤷‍♀️ .... but I honestly don't know. Close enough for jazz? If not, we can readdress in a future PR.

This PR arranges for users to see the "update your browser!" message even when playback is mediated by an interstitial; with `replay.perma.cc` playbacks, the message is hidden behind the interstitial.


### Deploying

I think this is safe to merge as-is, it should be a no-op without a setting of the feature flag, except for some trivial changes to interstitial CSS.