### PR TITLE
Update wacz-exhibitor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           # --ignore-pull-failures for PRs with new images that haven't been pushed yet:
           docker-compose -f docker-compose.yml pull --ignore-pull-failures || true
           docker-compose -f docker-compose.yml up -d        # use -f to suppress docker-compose.override.yml
-          bash make_cert.sh                                 # install SSL certs and restart the nginx and minio containers
+          bash make_cert.sh                                 # install SSL certs and restart the wacz-exhibitor and minio containers
           docker ps -a                                      # show running containers
           docker-compose logs                               # show logs
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,7 +28,7 @@ services:
           - linux/amd64
           - linux/arm64
       x-hash-paths:
-        - services/docker/wacz-exhibitor/nginx.conf
+        - ./nginx.conf
 
   #
   # Perma Payments

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,6 +18,18 @@ services:
         - perma_web/perma-warcprox-ca.pem
         - perma_web/lil-archive-keyring.gpg
 
+  wacz-exhibitor:
+    build:
+      context: ./services/docker/wacz-exhibitor
+      x-bake:
+        tags:
+          - registry.lil.tools/harvardlil/wacz-exhibitor:1-nohash
+        platforms:
+          - linux/amd64
+          - linux/arm64
+      x-hash-paths:
+        - services/docker/wacz-exhibitor/nginx.conf
+
   #
   # Perma Payments
   #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,15 +109,7 @@ services:
   # wacz-exhibitor
   #
   wacz-exhibitor:
-    image: registry.lil.tools/harvardlil/wacz-exhibitor:0.0.12-1
-    build:
-      context: ./services/docker/wacz-exhibitor
-      x-bake:
-        tags:
-          - registry.lil.tools/harvardlil/wacz-exhibitor:0.0.12-1
-        platforms:
-          - linux/amd64
-          - linux/arm64
+    image: registry.lil.tools/harvardlil/wacz-exhibitor:1-nohash
     ports:
       - "127.0.0.1:8080:8080"
     extra_hosts:

--- a/services/docker/wacz-exhibitor/Dockerfile
+++ b/services/docker/wacz-exhibitor/Dockerfile
@@ -1,8 +1,8 @@
 FROM registry.lil.tools/harvardlil/nginx:0.03 as builder
 
 RUN apt-get update && apt-get install -y git
-RUN git clone https://github.com/rebeccacremona/wacz-exhibitor.git
-RUN cd wacz-exhibitor; git checkout override-element-attr
+RUN git clone https://github.com/harvard-lil/wacz-exhibitor.git
+RUN cd wacz-exhibitor; git checkout v0.1.0
 
 FROM registry.lil.tools/harvardlil/nginx:0.03
 

--- a/services/docker/wacz-exhibitor/nginx.conf
+++ b/services/docker/wacz-exhibitor/nginx.conf
@@ -44,7 +44,7 @@ server {
 
   # Serves contents of "/embed" as "/"
   location / {
-    try_files /embed$uri /embed/$uri/ /index.html;
+     root /usr/share/nginx/html/embed;
 
     # Intended CSP Policy:
     # "Everything's allowed within the <iframe>, as long as it's same-origin."
@@ -53,7 +53,7 @@ server {
 
   # Exception to the above rule: "/replay-web-page" folder.
   location /replay-web-page/ {
-    try_files $uri $uri/;
+    try_files $uri $uri/ =404;
   }
 
   #


### PR DESCRIPTION
See ENG-143 and ENG-170.

This PR updates Perma's dev environment to use the latest version of `wacz-exhibitor` and makes the recommended changes to `nginx.conf`.

It also overhauls the `wacz-ehibitor` docker-compose situation... which I think I basically did entirely incorrectly the first time 😂 . I'm not sure what went wrong there... If I got this right, https://github.com/harvard-lil/docker-compose-update-action will now manage the building, tagging, and pushing of the image to the registry. But honestly I'm a little 🤯 about the whole thing; this syntax might not be exactly right.