### PR TITLE
Use a build arg for transparency

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: perma_web/Dockerfile
+      args:
+        RELEASE: v0.1.0
       x-bake:
         tags:
           - registry.lil.tools/harvardlil/perma-web:61-7306185b56da14d83e3ce0fed7a3d310

--- a/services/docker/wacz-exhibitor/Dockerfile
+++ b/services/docker/wacz-exhibitor/Dockerfile
@@ -1,8 +1,9 @@
 FROM registry.lil.tools/harvardlil/nginx:0.03 as builder
 
 RUN apt-get update && apt-get install -y git
+ARG RELEASE
 RUN git clone https://github.com/harvard-lil/wacz-exhibitor.git
-RUN cd wacz-exhibitor; git checkout v0.1.0
+RUN cd wacz-exhibitor; git checkout ${RELEASE}
 
 FROM registry.lil.tools/harvardlil/nginx:0.03
 


### PR DESCRIPTION
I think it looks cleaner to specify the desired version of `wacz-exhibitor` as a build arg. 

I think this will also prevent the `RUN git clone https://github.com/harvard-lil/wacz-exhibitor.git` image layer from being cached... ensuring that when we do want to upgrade, we get a fresh copy of the repo.