### PR TITLE
Remove nav link for deleted "partners" section 

### DIFF
--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -28,7 +28,6 @@ Perma.cc prevents link rot.
           <li class="reading-toc-chapter"><a href="#why-use-perma">Why use Perma.cc</a></li>
           <li class="reading-toc-chapter"><a href="#how-perma-works">How Perma.cc works</a></li>
           <li class="reading-toc-chapter"><a href="#accounts">Accounts</a></li>
-          <li class="reading-toc-chapter"><a href="#perma-partners">Perma.cc’s Partners</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
This is a follow-up to https://github.com/harvard-lil/perma/pull/3362.