### PR TITLE
Correct test for existence of setting

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1744,7 +1744,7 @@ def upload_link_to_internet_archive(link_guid, attempts=0, timeouts=0):
             assert response.status_code == 200, f"IA returned {response.status_code}): {response.text}"
     except SoftTimeLimitExceeded:
         retry = (
-            not settings.INTERNET_ARCHIVE_UPLOAD_MAX_TIMEOUTS or
+            not hasattr(settings, 'INTERNET_ARCHIVE_UPLOAD_MAX_TIMEOUTS') or
             (settings.INTERNET_ARCHIVE_UPLOAD_MAX_TIMEOUTS > timeouts + 1)
         )
         if retry:


### PR DESCRIPTION
Closes #3367.

Another approach would be to set a default for `INTERNET_ARCHIVE_UPLOAD_MAX_TIMEOUTS`, but I think the intent here is to allow the setting not to be present.