### PR TITLE
Temporary workaround for mobile PDF interstitials

### DIFF
--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
-from django.test import override_settings, Client
+from django.test import override_settings
 
 from perma.urls import urlpatterns
 from perma.models import Registrar, Link, CaptureJob
@@ -178,6 +178,8 @@ class CommonViewsTestCase(PermaTestCase):
                 self.assertNotIn('memento-datetime', response.headers)
                 self.assertNotIn('link', response.headers)
 
+    # Feature temporarily disabled
+    """
     def test_redirect_to_download(self):
         with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             # Give user option to download to view pdf if on mobile
@@ -191,6 +193,7 @@ class CommonViewsTestCase(PermaTestCase):
             client = Client(HTTP_USER_AGENT='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7')
             response = client.get(reverse('single_permalink', kwargs={'guid': link.guid}), secure=True)
             self.assertNotIn(b"Perma.cc can\xe2\x80\x99t display this file type on mobile", response.content)
+    """
 
     def test_deleted(self):
         response = self.get('single_permalink', reverse_kwargs={'kwargs': {'guid': 'ABCD-0003'}}, require_status_code=410, request_kwargs={'follow': True})

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -23,7 +23,7 @@ from perma.wsgi_utils import retry_on_exception
 
 from ..models import Link, Registrar, Organization, LinkUser
 from ..forms import ContactForm, ReportForm, check_honeypot
-from ..utils import (if_anonymous, ratelimit_ip_key, redirect_to_download,
+from ..utils import (if_anonymous, ratelimit_ip_key,
     protocol, stream_warc_if_permissible,
     timemap_url, timegate_url, memento_url, memento_data_for_url, url_with_qs_and_hash,
     remove_control_characters)
@@ -101,7 +101,7 @@ def single_permalink(request, guid):
     """
     Given a Perma ID, serve it up.
     """
-    raw_user_agent = request.META.get('HTTP_USER_AGENT', '')
+    # raw_user_agent = request.META.get('HTTP_USER_AGENT', '')
 
     # Create a canonical version of guid (non-alphanumerics removed, hyphens every 4 characters, uppercase),
     # and forward to that if it's different from current guid.

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -155,7 +155,11 @@ def single_permalink(request, guid):
 
     # Special handling for mobile pdf viewing because it can be buggy
     # Redirecting to a download page if on mobile
-    redirect_to_download_view = redirect_to_download(capture_mime_type, raw_user_agent)
+    # redirect_to_download_view = redirect_to_download(capture_mime_type, raw_user_agent)
+    # [!] TEMPORARY WORKAROUND (07-07-2023):
+    # Users reported not being able to download PDFs on mobile.
+    # Trying to playback PDFs on mobile instead until this is sorted out (seems to be working ok).
+    redirect_to_download_view = False
 
     # If this record was just created by the current user, we want to do some special-handling:
     # for instance, show them a message in the template, and give the playback extra time to initialize


### PR DESCRIPTION
@kmukk reported that the mobile interstitial for PDFs isn't working as expected: nothing happens on click.

After looking into the issue, it appears that this might be due to the way we interact with replayweb.page in that context: most definitely TBD, and this will require a proper diagnosis.

In the meantime: since it appears that we can now render PDFs within `<replay-web-page>` on mobile, in concertation with @kmukk and @bensteinberg, we've decided to disable the interstitial for the time being.

Users _should_ therefore now see the PDFs on mobile instead of the interstitial, and still be able to download them if they so choose.