### PR TITLE
Add global feature flag and scaffolding 

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Perma database
-docker-compose exec web invoke dev.init_db
+docker-compose exec web invoke dev.init-db
 
 # Perma SSL cert
 bash make_cert.sh

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -936,10 +936,10 @@ def run_next_capture():
 
     if settings.CAPTURE_ENGINE == 'perma':
         capture_internally(capture_job)
-    elif settings.CAPTURE_ENGINE == 'scoop':
+    elif settings.CAPTURE_ENGINE == 'scoop-api':
         capture_with_scoop(capture_job)
     else:
-        logger.error(f"Invalid settings.CAPTURE_ENGINE: '{settings.CAPTURE_ENGINE}'. Allowed values: 'perma' or 'scoop'.")
+        logger.error(f"Invalid settings.CAPTURE_ENGINE: '{settings.CAPTURE_ENGINE}'. Allowed values: 'perma' or 'scoop-api'.")
 
     if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
         run_next_capture.delay()

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -933,6 +933,25 @@ def run_next_capture():
     capture_job = CaptureJob.get_next_job(reserve=True)
     if not capture_job:
         return  # no jobs waiting
+
+    if settings.CAPTURE_ENGINE == 'perma':
+        capture_internally(capture_job)
+    elif settings.CAPTURE_ENGINE == 'scoop':
+        capture_with_scoop(capture_job)
+    else:
+        logger.error(f"Invalid settings.CAPTURE_ENGINE: '{settings.CAPTURE_ENGINE}'. Allowed values: 'perma' or 'scoop'.")
+
+    if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
+        run_next_capture.delay()
+    else:
+        logger.info("Deployment sentinel is present, not running next capture.")
+
+
+def capture_with_scoop(capture_job):
+    pass
+
+
+def capture_internally(capture_job):
     try:
         # Start warcprox process. Warcprox is a MITM proxy server and needs to be running
         # before, during and after the headless browser.
@@ -1418,10 +1437,6 @@ def run_next_capture():
             capture_job.link.captures.filter(status='pending').update(status='failed')
             if capture_job.status == 'in_progress':
                 capture_job.mark_failed('Failed during capture.')
-    if not os.path.exists(settings.DEPLOYMENT_SENTINEL):
-        run_next_capture.delay()
-    else:
-        logger.info("Deployment sentinel is present, not running next capture.")
 
 
 ###              ###

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -507,8 +507,19 @@ REST_FRAMEWORK = {
 
 PLAYBACK_HOST = 'rejouer.perma.test:8080'
 
+
 #
 # Capture
+#
+CAPTURE_ENGINE = 'perma'  # perma|scoop
+
+#
+# (Scoop)
+#
+SCOOP_API_KEY = None
+
+#
+# (Perma)
 #
 
 # IP ranges we won't archive.
@@ -575,8 +586,6 @@ MAX_PROXY_QUEUE_SIZE = 500 # this is the default in https://github.com/interneta
 # should we default to private?
 PRIVATE_LINKS_ON_FAILURE = False
 PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
-
-SCOOP_API_KEY = None
 
 # We're finding that warcs aren't always available for download from S3
 # instantly, immediately after upload. How long do we want to wait for S3

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -60,12 +60,20 @@ STATICFILES_FINDERS = (         # how to look for static files
 # static files config
 STATICFILES_STORAGE = 'perma.storage_backends.StaticStorage'
 
+WEBPACK_LOADER = {
+    'DEFAULT': {
+        'BUNDLE_DIR_NAME': 'bundles/',
+        'STATS_FILE': os.path.join(PROJECT_ROOT, 'webpack-stats.json'),
+    }
+}
+
 # user-generated files / default_storage config
 MEDIA_URL = '/this-setting-is-not-in-use-in-any-deployments/'
 MEDIA_ROOT ='generated/'
 DEFAULT_FILE_STORAGE = 'perma.storage_backends.S3MediaStorage'
 AWS_S3_SIGNATURE_VERSION = 's3v4'
 AWS_DEFAULT_ACL = 'private'
+WARC_STORAGE_DIR = 'warcs'  # relative to MEDIA_ROOT
 WARC_PRESIGNED_URL_EXPIRES = 15 * 60
 
 TEMPLATES = [
@@ -115,22 +123,15 @@ MIDDLEWARE = (
     'axes.middleware.AxesMiddleware',
     'api.middleware.CORSMiddleware'
 )
-# This defaults to 'SAMEORIGIN' w/ Django 2, but was changed to 'DENY' in Django 3
-X_FRAME_OPTIONS = 'DENY'
-
-# If the Django redis cache is configured but unavailable,
-# the ratelimiting plugin should allow all requests,
-# rather than reject them
-RATELIMIT_FAIL_OPEN = True
-
-RATELIMIT_VIEW = 'perma.views.common.rate_limit'
-CSRF_FAILURE_VIEW = 'perma.views.error_management.csrf_failure'
 
 ROOT_URLCONF = 'urls'
 
+APPEND_SLASH = False
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'perma.wsgi.application'
-
 
 INSTALLED_APPS = (
     # built in apps
@@ -168,11 +169,25 @@ INSTALLED_APPS = (
     'django.contrib.admin',
 )
 
-AUTH_USER_MODEL = 'perma.LinkUser'
+CSRF_FAILURE_VIEW = 'perma.views.error_management.csrf_failure'
+MESSAGE_STORAGE = 'django.contrib.messages.storage.fallback.FallbackStorage'
+TAGGIT_CASE_INSENSITIVE = True
 
+# Security Settings
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_NAME = '__Host-sessionid'
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SAMESITE = 'Lax'
+# This defaults to 'SAMEORIGIN' w/ Django 2, but was changed to 'DENY' in Django 3
+X_FRAME_OPTIONS = 'DENY'
+
+#
+# Authentication
+#
+AUTH_USER_MODEL = 'perma.LinkUser'
 LOGIN_REDIRECT_URL = '/manage/create/'
 LOGIN_URL = 'user_management_limited_login'
-
 
 # Axes, fundamental integration
 AUTHENTICATION_BACKENDS = [
@@ -192,7 +207,6 @@ AXES_COOLOFF_MINUTES = 30
 AXES_COOLOFF_TIME = 'perma.utils.cooloff_time'
 AXES_ONLY_USER_FAILURES = True  # If True, only lock based on username, and never lock based on IP if attempts exceed the limit. Otherwise utilize the existing IP and user locking logic. Default: False
 AXES_RESET_ON_SUCCESS = True  # If True, a successful login will reset the number of failed logins. Default: False
-
 
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -215,11 +229,14 @@ AUTH_PASSWORD_VALIDATORS = [
 # 3 days, in seconds
 PASSWORD_RESET_TIMEOUT = 3 * 24 * 60 * 60
 
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+#
+# Subscription packages/Payments
+#
 
-MESSAGE_STORAGE = 'django.contrib.messages.storage.fallback.FallbackStorage'
+PERMA_PAYMENTS_TIMEOUT = 2
+PERMA_PAYMENTS_TIMESTAMP_MAX_AGE_SECONDS = 120
+PERMA_PAYMENTS_IN_MAINTENANCE = False
 
-# subscription packages
 TIERS = {
     'Individual': [
         {
@@ -279,18 +296,20 @@ BONUS_PACKAGES = [
 DEFAULT_CREATE_LIMIT = 10
 DEFAULT_CREATE_LIMIT_PERIOD = 'once'
 
-# Max file size (for our downloads)
-MAX_ARCHIVE_FILE_SIZE = 1024 * 1024 * 100  # 100 MB
-
-# Max image size for screenshots and thumbnails
-MAX_IMAGE_SIZE = 1024*1024*50  # 50 megapixels
-
+#
 # Rate limits
+#
 MINUTE_LIMIT = '6000/m'
 HOUR_LIMIT = '100000/h'
 DAY_LIMIT = '500000/d'
 REGISTER_MINUTE_LIMIT = '600/m'
 LOGIN_MINUTE_LIMIT = '5000/m'
+
+# If the Django redis cache is configured but unavailable,
+# the ratelimiting plugin should allow all requests,
+# rather than reject them
+RATELIMIT_FAIL_OPEN = True
+RATELIMIT_VIEW = 'perma.views.common.rate_limit'
 
 #
 # Django cache
@@ -309,6 +328,7 @@ CACHE_MAX_AGES = {
 # Dashboard user lists
 MAX_USER_LIST_SIZE = 50
 
+# Logging
 from django.utils.log import DEFAULT_LOGGING
 LOGGING = deepcopy(DEFAULT_LOGGING)
 LOGGING['handlers'] = {
@@ -373,6 +393,124 @@ LOGGING['formatters'] = {
     },
 }
 
+# Proxy whitelisting:
+# If TRUSTED_PROXIES is set, wsgi.py will validate that requests come through these proxies,
+# and then set request.META['REMOTE_ADDR'] to match the client IP that comes before the trusted proxy chain in the
+# X-Forwarded-For header.
+# TRUSTED_PROXIES should be a list of reverse proxies in the chain, where each proxy is a whitelist of IP ranges
+# for that proxy. Proxies should be in order from client to server. For example, given:
+
+#    from .utils.helpers import get_cloudflare_ips
+#    TRUSTED_PROXIES = [get_cloudflare_ips(CLOUDFLARE_DIR), ['<nginx server ip>']]
+
+# if we see a request like:
+
+#    request.META['REMOTE_ADDR'] = '<nginx server ip>'
+#    request.META['HTTP_X_FORWARDED_FOR'] = '<user-supplied junk>, <client ip>, <cloudflare ip>'
+
+# then wsgi.py will make sure that request.META['REMOTE_ADDR'] = '<client ip>'. But if <nginx server ip> or <cloudflare ip>
+# fail to match, wsgi.py will return a 400 Bad Request.
+TRUSTED_PROXIES = []
+CLOUDFLARE_DIR = os.path.join(SERVICES_DIR, 'cloudflare')
+# Http header we will use to determine/test/validate a client's IP address.
+CLIENT_IP_HEADER = 'REMOTE_ADDR'
+
+#
+# Celery settings
+#
+CELERY_BROKER_URL = 'redis://perma-redis:6379/1'
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+# If a task is running longer than five minutes, ask it to shut down
+CELERY_TASK_SOFT_TIME_LIMIT=300
+# If a task is running longer than seven minutes, kill it
+CELERY_TASK_TIME_LIMIT = 420
+# Estimate of active celery workers
+# https://github.com/harvard-lil/perma/issues/2438
+# this value will be reset in settings.utils.post_processing
+WORKER_COUNT = 2
+
+CELERY_TASK_ROUTES = {
+    'perma.celery_tasks.sync_subscriptions_from_perma_payments': {'queue': 'background'},
+    'perma.celery_tasks.cache_playback_status_for_new_links': {'queue': 'background'},
+    'perma.celery_tasks.cache_playback_status': {'queue': 'background'},
+    'perma.celery_tasks.populate_warc_size_fields': {'queue': 'background'},
+    'perma.celery_tasks.populate_warc_size': {'queue': 'background'},
+    # the 'ia' queue is for tasks that alter or may alter Internet Archive's records
+    'perma.celery_tasks.upload_link_to_internet_archive': {'queue': 'ia'},
+    'perma.celery_tasks.delete_link_from_daily_item': {'queue': 'ia'},
+    # the 'ia-readonly' queue is for internal tasks that only affect our database
+    'perma.celery_tasks.queue_file_uploaded_confirmation_tasks': {'queue': 'ia-readonly'},
+    'perma.celery_tasks.confirm_file_uploaded_to_internet_archive': {'queue': 'ia-readonly'},
+    'perma.celery_tasks.queue_file_deleted_confirmation_tasks': {'queue': 'ia-readonly'},
+    'perma.celery_tasks.confirm_file_deleted_from_daily_item': {'queue': 'ia-readonly'},
+    'perma.celery_tasks.conditionally_queue_internet_archive_uploads_for_date_range': {'queue': 'ia-readonly'},
+    'perma.celery_tasks.queue_internet_archive_deletions': {'queue': 'ia-readonly'},
+}
+
+# Schedule celerybeat jobs.
+# These will be added to CELERY_BEAT_SCHEDULE in settings.utils.post_processing
+CELERY_BEAT_JOB_NAMES = []
+
+# Internet Archive stuff
+INTERNET_ARCHIVE_MAX_UPLOAD_SIZE = 1024 * 1024 * 100
+INTERNET_ARCHIVE_COLLECTION = 'perma_cc'
+INTERNET_ARCHIVE_IDENTIFIER_PREFIX = 'perma_cc_'
+INTERNET_ARCHIVE_DAILY_IDENTIFIER_PREFIX = 'daily_perma_cc_'
+# Find these at https://archive.org/account/s3.php :
+INTERNET_ARCHIVE_ACCESS_KEY = ''
+INTERNET_ARCHIVE_SECRET_KEY = ''
+# Rate limiting
+INTERNET_ARCHIVE_MAX_SIMULTANEOUS_UPLOADS = 499  # as of 2023-03-21, this is our "accesskey_ration"
+INTERNET_ARCHIVE_PERMITTED_PROXIMITY_TO_GLOBAL_RATE_LIMIT = 500
+INTERNET_ARCHIVE_PERMITTED_PROXIMITY_TO_RATE_LIMIT = 50
+INTERNET_ARCHIVE_RETRY_FOR_RATELIMITING_LIMIT = None
+INTERNET_ARCHIVE_RETRY_FOR_ERROR_LIMIT = 2
+INTERNET_ARCHIVE_EXCEPTION_IF_RETRIES_EXCEEDED = False
+INTERNET_ARCHIVE_ITEM_LOCK_RETRIES = 4
+INTERNET_ARCHIVE_RETRY_FOR_CONFIRMATION_CONNECTION_ERROR = 3
+INTERNET_ARCHIVE_UPLOAD_MAX_TIMEOUTS = None
+# Other
+INTERNET_ARCHIVE_EXCEPTION_IF_NO_ITEM = False
+INTERNET_ARCHIVE_UPLOAD_MAX_TMEOUTS = 2
+
+#
+# Hosts
+#
+
+HOST = 'perma.test:8000'
+ALLOWED_HOSTS = ['perma.test', 'api.perma.test']
+API_SUBDOMAIN = 'api'
+
+#
+# API
+#
+
+API_VERSION = 1
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'api.authentication.TokenAuthentication',  # authenticate with ApiKey token
+        'rest_framework.authentication.SessionAuthentication',  # authenticate with Django login
+    ),
+    'NON_FIELD_ERRORS_KEY': 'error',  # default key for {'fieldname': 'error message'} error responses
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination', # enable pagination by default
+    'PAGE_SIZE': 300,  # max results per page
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
+    'SEARCH_PARAM': 'q',  # query string key for plain text searches
+    'ORDERING_PARAM': 'order_by',  # query string key to specify ordering of results
+}
+
+#
+# Playback
+#
+
+PLAYBACK_HOST = 'rejouer.perma.test:8080'
+
+#
+# Capture
+#
+
 # IP ranges we won't archive.
 # Via http://en.wikipedia.org/wiki/Reserved_IP_addresses
 BANNED_IP_RANGES = [
@@ -406,98 +544,39 @@ BANNED_IP_RANGES = [
     "ff00::/8",
 ]
 
-# Proxy whitelisting:
-# If TRUSTED_PROXIES is set, wsgi.py will validate that requests come through these proxies,
-# and then set request.META['REMOTE_ADDR'] to match the client IP that comes before the trusted proxy chain in the
-# X-Forwarded-For header.
-# TRUSTED_PROXIES should be a list of reverse proxies in the chain, where each proxy is a whitelist of IP ranges
-# for that proxy. Proxies should be in order from client to server. For example, given:
+# Max file size (for our downloads)
+MAX_ARCHIVE_FILE_SIZE = 1024 * 1024 * 100  # 100 MB
 
-#    from .utils.helpers import get_cloudflare_ips
-#    TRUSTED_PROXIES = [get_cloudflare_ips(CLOUDFLARE_DIR), ['<nginx server ip>']]
+# Max image size for screenshots and thumbnails
+MAX_IMAGE_SIZE = 1024*1024*50  # 50 megapixels
 
-# if we see a request like:
-
-#    request.META['REMOTE_ADDR'] = '<nginx server ip>'
-#    request.META['HTTP_X_FORWARDED_FOR'] = '<user-supplied junk>, <client ip>, <cloudflare ip>'
-
-# then wsgi.py will make sure that request.META['REMOTE_ADDR'] = '<client ip>'. But if <nginx server ip> or <cloudflare ip>
-# fail to match, wsgi.py will return a 400 Bad Request.
-
-TRUSTED_PROXIES = []
-CLOUDFLARE_DIR = os.path.join(SERVICES_DIR, 'cloudflare')
-
-# Http header we will use to determine/test/validate a client's IP address.
-CLIENT_IP_HEADER = 'REMOTE_ADDR'
-
-# Celery settings
-CELERY_BROKER_URL = 'redis://perma-redis:6379/1'
-CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-# If a task is running longer than five minutes, ask it to shut down
-CELERY_TASK_SOFT_TIME_LIMIT=300
-# If a task is running longer than seven minutes, kill it
-CELERY_TASK_TIME_LIMIT = 420
-# Estimate of active celery workers
-# https://github.com/harvard-lil/perma/issues/2438
-# this value will be reset in settings.utils.post_processing
-WORKER_COUNT = 2
-
-CELERY_TASK_ROUTES = {
-    'perma.celery_tasks.sync_subscriptions_from_perma_payments': {'queue': 'background'},
-    'perma.celery_tasks.cache_playback_status_for_new_links': {'queue': 'background'},
-    'perma.celery_tasks.cache_playback_status': {'queue': 'background'},
-    'perma.celery_tasks.populate_warc_size_fields': {'queue': 'background'},
-    'perma.celery_tasks.populate_warc_size': {'queue': 'background'},
-    # the 'ia' queue is for tasks that alter or may alter Internet Archive's records
-    'perma.celery_tasks.upload_link_to_internet_archive': {'queue': 'ia'},
-    'perma.celery_tasks.delete_link_from_daily_item': {'queue': 'ia'},
-    # the 'ia-readonly' queue is for internal tasks that only affect our database
-    'perma.celery_tasks.queue_file_uploaded_confirmation_tasks': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.confirm_file_uploaded_to_internet_archive': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.queue_file_deleted_confirmation_tasks': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.confirm_file_deleted_from_daily_item': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.conditionally_queue_internet_archive_uploads_for_date_range': {'queue': 'ia-readonly'},
-    'perma.celery_tasks.queue_internet_archive_deletions': {'queue': 'ia-readonly'},
+CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
+DISABLE_DEV_SHM = False
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5790.170 Safari/537.36"
+PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
+PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
+DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
+DOMAINS_REQUIRING_BOT_USER_AGENT = []
+PROXY_CAPTURES = False
+PROXY_ADDRESS = 'localhost:9050'
+DOMAINS_TO_PROXY = []
+PROXY_POST_LOAD_DELAY = 5
+CAPTURE_HEADERS = {
+    "Accept": "*/*",
+    "Accept-Encoding": "*",
+    "Accept-Language": "*",
+    "Connection": "keep-alive"
 }
+RESOURCE_LOAD_TIMEOUT = 45 # seconds to wait for at least one resource to load before giving up on capture
+SHUTDOWN_GRACE_PERIOD = 10 # seconds to allow slow threads to finish before we complete the capture job
+MAX_PROXY_THREADS = 100
+MAX_PROXY_QUEUE_SIZE = 500 # this is the default in https://github.com/internetarchive/warcprox/blob/ee6bc151e1758a50f8af2b8f2d9746aa56ec95fb/warcprox/main.py#L192
+# If technical problems prevent proper analysis of a capture,
+# should we default to private?
+PRIVATE_LINKS_ON_FAILURE = False
+PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
 
-# Internet Archive stuff
-INTERNET_ARCHIVE_MAX_UPLOAD_SIZE = 1024 * 1024 * 100
-INTERNET_ARCHIVE_COLLECTION = 'perma_cc'
-INTERNET_ARCHIVE_IDENTIFIER_PREFIX = 'perma_cc_'
-INTERNET_ARCHIVE_DAILY_IDENTIFIER_PREFIX = 'daily_perma_cc_'
-# Find these at https://archive.org/account/s3.php :
-INTERNET_ARCHIVE_ACCESS_KEY = ''
-INTERNET_ARCHIVE_SECRET_KEY = ''
-# Rate limiting
-INTERNET_ARCHIVE_MAX_SIMULTANEOUS_UPLOADS = 499  # as of 2023-03-21, this is our "accesskey_ration"
-INTERNET_ARCHIVE_PERMITTED_PROXIMITY_TO_GLOBAL_RATE_LIMIT = 500
-INTERNET_ARCHIVE_PERMITTED_PROXIMITY_TO_RATE_LIMIT = 50
-INTERNET_ARCHIVE_RETRY_FOR_RATELIMITING_LIMIT = None
-INTERNET_ARCHIVE_RETRY_FOR_ERROR_LIMIT = 2
-INTERNET_ARCHIVE_EXCEPTION_IF_RETRIES_EXCEEDED = False
-INTERNET_ARCHIVE_ITEM_LOCK_RETRIES = 4
-INTERNET_ARCHIVE_RETRY_FOR_CONFIRMATION_CONNECTION_ERROR = 3
-INTERNET_ARCHIVE_UPLOAD_MAX_TIMEOUTS = None
-# Other
-INTERNET_ARCHIVE_EXCEPTION_IF_NO_ITEM = False
-INTERNET_ARCHIVE_UPLOAD_MAX_TMEOUTS = 2
-
-
-#
-# Hosts
-#
-
-HOST = 'perma.test:8000'
-ALLOWED_HOSTS = ['perma.test', 'api.perma.test']
-API_SUBDOMAIN = 'api'
-
-#
-# Playback
-#
-
-PLAYBACK_HOST = 'rejouer.perma.test:8080'
+SCOOP_API_KEY = None
 
 # We're finding that warcs aren't always available for download from S3
 # instantly, immediately after upload. How long do we want to wait for S3
@@ -512,19 +591,51 @@ THUMBNAIL_FORMAT = 'PNG'
 THUMBNAIL_COLORSPACE = None
 # Temporarily work around for https://github.com/jazzband/sorl-thumbnail/issues/476
 TEMPLATE_DEBUG = False
-
 # Relative to MEDIA_ROOT
 THUMBNAIL_STORAGE_PATH = 'thumbnails'
 
-# security settings
-SECURE_SSL_REDIRECT = True
-SESSION_COOKIE_SECURE = True
-SESSION_COOKIE_NAME = '__Host-sessionid'
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SESSION_COOKIE_SAMESITE = 'Lax'
+# tests
+TEST_RUNNER = 'django.test.runner.DiscoverRunner'  # In Django 1.7, including this silences a warning about tests
+TESTING = False
 
-API_VERSION = 1
+### LOCKSS ###
 
+from datetime import timedelta
+ARCHIVE_DELAY = timedelta(hours=24)
+
+LOCKSS_CONTENT_IPS = ""  # IPs of Perma servers allowed to play back LOCKSS content -- e.g. "10.1.146.0/24;140.247.209.64"
+LOCKSS_CRAWL_INTERVAL = "12h"
+LOCKSS_QUORUM = 3
+LOCKSS_DEBUG_IPS = False
+
+#
+# Email
+#
+
+# set a default reply-to email address, the same as Django's DEFAULT_FROM_EMAIL
+# in production, must be different than the production DEFAULT_FROM_EMAIL
+DEFAULT_REPLYTO_EMAIL = 'webmaster@localhost'
+
+# Campaign Monitor (override if you want to actually interact with to
+# campaign monitor)
+CAMPAIGN_MONITOR_AUTH = {'api_key':'fake'}
+CAMPAIGN_MONITOR_REGISTRAR_LIST = 'fake'
+
+# Directs contact form to registrar users under certain circumstances
+CONTACT_REGISTRARS = False
+
+# If using geocoding
+# Via https://console.developers.google.com/apis/api/geocoding_backend/overview
+GEOCODING_KEY = None
+
+REPLAYWEBPAGE_VERSION = '1.8.0'
+REPLAYWEBPAGE_SOURCE_URL = 'https://cdn.jsdelivr.net/npm/replaywebpage'
+
+# Virus Scanning
+SCAN_UPLOADS = False
+SCAN_URL = ''
+
+# Analytics
 USE_ANALYTICS = False
 USE_ANALYTICS_VIEWS = [
     'landing',
@@ -549,6 +660,18 @@ USE_ANALYTICS_VIEWS = [
     'libraries'
 ]
 
+# If USE_SENTRY is True, SENTRY_DSN must be set
+USE_SENTRY = False
+SENTRY_DSN = ''
+SENTRY_ENVIRONMENT = 'dev'
+SENTRY_TRACES_SAMPLE_RATE = 1.0
+SENTRY_SEND_DEFAULT_PII = False
+
+# Before deployment, we suppress the addition of new capture jobs when this file is present
+DEPLOYMENT_SENTINEL = '/tmp/perma-deployment-pending'
+
+# Which settings should be available in all Django templates,
+# without needing to explicitly pass them via the view?
 TEMPLATE_VISIBLE_SETTINGS = (
     'API_VERSION',
     'SECURE_SSL_REDIRECT',
@@ -562,118 +685,3 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'SENTRY_TRACES_SAMPLE_RATE',
     'PLAYBACK_HOST'
 )
-
-
-CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
-DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5790.170 Safari/537.36"
-PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
-PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
-DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []
-DOMAINS_REQUIRING_BOT_USER_AGENT = []
-PROXY_CAPTURES = False
-PROXY_ADDRESS = 'localhost:9050'
-DOMAINS_TO_PROXY = []
-PROXY_POST_LOAD_DELAY = 5
-CAPTURE_HEADERS = {
-    "Accept": "*/*",
-    "Accept-Encoding": "*",
-    "Accept-Language": "*",
-    "Connection": "keep-alive"
-}
-
-APPEND_SLASH = False
-
-# Schedule celerybeat jobs.
-# These will be added to CELERY_BEAT_SCHEDULE in settings.utils.post_processing
-CELERY_BEAT_JOB_NAMES = []
-
-
-# tests
-TEST_RUNNER = 'django.test.runner.DiscoverRunner'  # In Django 1.7, including this silences a warning about tests
-TESTING = False
-
-
-WARC_STORAGE_DIR = 'warcs'  # relative to MEDIA_ROOT
-
-
-### LOCKSS ###
-
-from datetime import timedelta
-ARCHIVE_DELAY = timedelta(hours=24)
-
-LOCKSS_CONTENT_IPS = ""  # IPs of Perma servers allowed to play back LOCKSS content -- e.g. "10.1.146.0/24;140.247.209.64"
-LOCKSS_CRAWL_INTERVAL = "12h"
-LOCKSS_QUORUM = 3
-LOCKSS_DEBUG_IPS = False
-
-RESOURCE_LOAD_TIMEOUT = 45 # seconds to wait for at least one resource to load before giving up on capture
-SHUTDOWN_GRACE_PERIOD = 10 # seconds to allow slow threads to finish before we complete the capture job
-MAX_PROXY_THREADS = 100
-MAX_PROXY_QUEUE_SIZE = 500 # this is the default in https://github.com/internetarchive/warcprox/blob/ee6bc151e1758a50f8af2b8f2d9746aa56ec95fb/warcprox/main.py#L192
-
-WEBPACK_LOADER = {
-    'DEFAULT': {
-        'BUNDLE_DIR_NAME': 'bundles/',
-        'STATS_FILE': os.path.join(PROJECT_ROOT, 'webpack-stats.json'),
-    }
-}
-
-# set a default reply-to email address, the same as Django's DEFAULT_FROM_EMAIL
-# in production, must be different than the production DEFAULT_FROM_EMAIL
-DEFAULT_REPLYTO_EMAIL = 'webmaster@localhost'
-
-# Campaign Monitor (override if you want to actually interact with to
-# campaign monitor)
-CAMPAIGN_MONITOR_AUTH = {'api_key':'fake'}
-CAMPAIGN_MONITOR_REGISTRAR_LIST = 'fake'
-
-# Directs contact form to registrar users under certain circumstances
-CONTACT_REGISTRARS = False
-
-TAGGIT_CASE_INSENSITIVE = True
-
-# If technical problems prevent proper analysis of a capture,
-# should we default to private?
-PRIVATE_LINKS_ON_FAILURE = False
-PRIVATE_LINKS_IF_GENERIC_NOARCHIVE = True
-
-
-REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'api.authentication.TokenAuthentication',  # authenticate with ApiKey token
-        'rest_framework.authentication.SessionAuthentication',  # authenticate with Django login
-    ),
-    'NON_FIELD_ERRORS_KEY': 'error',  # default key for {'fieldname': 'error message'} error responses
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination', # enable pagination by default
-    'PAGE_SIZE': 300,  # max results per page
-    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
-    'SEARCH_PARAM': 'q',  # query string key for plain text searches
-    'ORDERING_PARAM': 'order_by',  # query string key to specify ordering of results
-}
-
-# If using geocoding
-# Via https://console.developers.google.com/apis/api/geocoding_backend/overview
-GEOCODING_KEY = None
-
-PERMA_PAYMENTS_TIMEOUT = 2
-PERMA_PAYMENTS_TIMESTAMP_MAX_AGE_SECONDS = 120
-PERMA_PAYMENTS_IN_MAINTENANCE = False
-
-REPLAYWEBPAGE_VERSION = '1.8.0'
-REPLAYWEBPAGE_SOURCE_URL = 'https://cdn.jsdelivr.net/npm/replaywebpage'
-
-SCOOP_API_KEY = None
-
-SCAN_UPLOADS = False
-SCAN_URL = ''
-
-# If USE_SENTRY is True, SENTRY_DSN must be set
-USE_SENTRY = False
-SENTRY_DSN = ''
-SENTRY_ENVIRONMENT = 'dev'
-SENTRY_TRACES_SAMPLE_RATE = 1.0
-SENTRY_SEND_DEFAULT_PII = False
-
-# Before deployment, we suppress the addition of new capture jobs when this file is present
-DEPLOYMENT_SENTINEL = '/tmp/perma-deployment-pending'

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -511,7 +511,7 @@ PLAYBACK_HOST = 'rejouer.perma.test:8080'
 #
 # Capture
 #
-CAPTURE_ENGINE = 'perma'  # perma|scoop
+CAPTURE_ENGINE = 'perma'  # perma|scoop-api
 
 #
 # (Scoop)

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -628,9 +628,6 @@ CONTACT_REGISTRARS = False
 # Via https://console.developers.google.com/apis/api/geocoding_backend/overview
 GEOCODING_KEY = None
 
-REPLAYWEBPAGE_VERSION = '1.8.0'
-REPLAYWEBPAGE_SOURCE_URL = 'https://cdn.jsdelivr.net/npm/replaywebpage'
-
 # Virus Scanning
 SCAN_UPLOADS = False
 SCAN_URL = ''

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -95,7 +95,7 @@ def test_python(ctx, apps=_default_tests):
     if "functional_tests" in apps:
         ctx.run("DJANGO__STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage python manage.py collectstatic --noinput")
 
-    ctx.run(f"pytest {apps} --no-migrations --ds=perma.settings.deployments.settings_testing --cov --cov-config=setup.cfg --cov-report= ")
+    ctx.run(f"pytest {apps} --ds=perma.settings.deployments.settings_testing --cov --cov-config=setup.cfg --cov-report= ")
 
 @task
 def test_js(ctx):


### PR DESCRIPTION
This is a small PR with a big diff: it's easiest to see commit-by-commit.

It adds a single new setting:
```
CAPTURE_ENGINE = 'perma'  # perma|scoop-api
```

It tweaks the structure of the existing `run_next_capture` Celery task: right at the point where, in `main` right now, the actual work of doing a capture starts, this PR adds a conditional. If `settings.CAPTURE_ENGINE == 'perma'`, call a helper function that runs all the same code as usual. If `settings.CAPTURE_ENGINE == 'scoop-api'`, call a new placeholder helper function where we can start adding the new capture code. Then, regardless of which branch is taken, finish up as usual by checking for the deployment sentinel, and trigger a new `run_next_capture` if not present.

### Why the big diff??

`settings_common.py` has gotten messy over time, and related settings were scattered all around. I wanted to add this feature flag, and kept waffling over where it belonged in the file... and I decided to finally just tidy up a bit.

So the first commit is literally just me cutting and pasting settings around the file (sorry git-blame).

While doing that I spotted a couple unused ones, that I failed to delete in the PR that removed the code that used them.

Finally: the strategy I used to test and see if this broke anything locally, which is to say, running the `invoke` test command, actually uncovered two syntax problems caused by changes made in the past few months. (CI runs `pytest` directly and so didn't catch these... and evidently I've gotten in the habit of invoking `pytest` directly locally too.)

So! A little messy, but hopefully acceptably so.

### Why this strategy?

I wanted to keep the diff in `celery_tasks.py` as small as possible: I did NOT want to wrap the whole thing in a big `if`/`else` and thereby have to re-indent hundreds of lines of code.

I also wanted to make this flexible enough to allow us to easily experiment with/demo the other integration possibilities, even as we move forward with the Scoop REST API. By adding additional options to the flag (say, `scoop-in-docker` or `scoop-api-v2` or whatever), we can neatly insert more alternatives as desired.