### PR TITLE
Update Chromium

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -69,7 +69,7 @@ RUN pip install pip==22.0.4 \
 COPY perma_web/lil-archive-keyring.gpg /usr/share/keyrings/lil-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/lil-archive-keyring.gpg] https://repo.lil.tools/ bullseye-security updates/main" > /etc/apt/sources.list.d/lil-chromium.list
 
-ENV CHROMIUM_VERSION=115.0.5790.170-1~deb11u1
+ENV CHROMIUM_VERSION=116.0.5845.110-1~deb11u1
 RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
     chromium-common=${CHROMIUM_VERSION} \
     chromium-driver=${CHROMIUM_VERSION} \

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -563,7 +563,7 @@ MAX_IMAGE_SIZE = 1024*1024*50  # 50 megapixels
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5790.170 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.110 Safari/537.36"
 PERMA_USER_AGENT_SUFFIX = "(Perma.cc)"
 PERMABOT_USER_AGENT_SUFFIX = "(Perma.cc bot)"
 DOMAINS_REQUIRING_UNIQUE_USER_AGENT = []


### PR DESCRIPTION
See https://chromereleases.googleblog.com/2023/08/chrome-desktop-stable-update.html and the earlier https://chromereleases.googleblog.com/2023/08/stable-channel-update-for-desktop_15.html which we happened to skip.