### PR TITLE
Free disk space in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      ### free disk space ###
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       ### build docker images locally ###
 
       - name: Rebuild docker images


### PR DESCRIPTION
This is an attempt to free disk space so the GitHub actions runner does not run out; we've seen image build failures like
```
ERROR: failed to solve: failed to create temp dir: mkdir /tmp/containerd-mount4076981537: no space left on device
```
 I'm using the default setup from https://github.com/marketplace/actions/free-disk-space-ubuntu -- we can do something like this manually so as not to have the dependency, if that seems better.