### PR TITLE
Tests pass locally with CAPTURE_ENGINE = 'scoop-api'

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -49,7 +49,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:7-974e653a08dc26b20cce869e19be944c
+    image: registry.lil.tools/harvardlil/scoop-rest-api:8-f3ce2f4ae83e6728b83c9690341de980
     init: true
     tty: true
     depends_on:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -70,6 +70,7 @@ services:
       - CREATE_ACCESS_KEY_WITH_LABEL=dev  # create a new access key each time the container starts
     volumes:
       - scoop_access_key:/app/docker/access_keys:delegated
+      - ./services/docker/scoop-rest-api/config.py:/app/scoop_rest_api/config.py
     networks:
       - scoop_rest_api
       - scoop_rest_api_internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
           - 'api.perma.test'
       perma_payments:
       scoop_rest_api:
+        aliases:
+          - 'perma.test'
 
   #
   # Minio

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -39,6 +39,9 @@ def copy_file_or_dir(src, dst):
 
 
 def index_warc_file(warc_file):
+    # Note: warcio will NOT locate the HTTP headers of WARC response records
+    # who use the file:/// protocol.... which is to say, Scoop attachments
+    # https://github.com/webrecorder/warcio/blob/aa702cb321621b233c6e5d2a4780151282a778be/warcio/recordloader.py#L183-L185
     index_file = StringIO()
     indexer = Indexer("warc-target-uri,content-type,http:content-type,http:status", warc_file, index_file)
     indexer.process_one(warc_file, index_file, '')

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -71,6 +71,15 @@ class TestHTTPRequestHandler(SimpleHTTPRequestHandler):
                 self.send_header(header, value)
         return SimpleHTTPRequestHandler.end_headers(self)
 
+    def parse_request(self):
+        super().parse_request()
+        # SimpleHTTPRequestHandler can only handle relative paths,
+        # but under some circumstances, requests can arrive here
+        # with full URLs.
+        if self.path.startswith("http://"):
+            self.path = urllib.parse.urlparse(self.path).path
+        return True
+
 
 def log_api_call(func):
     """
@@ -405,7 +414,7 @@ class ApiResourceTransactionTestCase(ApiResourceTestCaseMixin, TransactionTestCa
         # start server
         for i in range(100):
             try:
-                cls._httpd = TestHTTPServer(('', cls.server_port), TestHTTPRequestHandler)
+                cls._httpd = TestHTTPServer(('0.0.0.0', cls.server_port), TestHTTPRequestHandler)
                 break
             except socket.error:
                 cls.server_port += 1

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1053,9 +1053,10 @@ def capture_with_scoop(capture_job):
             inc_progress(capture_job, min(wait_time/60, 0.99), "Waiting for Scoop to finish")
 
         capture_job.scoop_logs = poll_data
-        states = poll_data['scoop_capture_summary']['states']
-        state = poll_data['scoop_capture_summary']['state']
-        capture_job.scoop_state = states[state]
+        if poll_data.get('scoop_capture_summary'):
+            states = poll_data['scoop_capture_summary']['states']
+            state = poll_data['scoop_capture_summary']['state']
+            capture_job.scoop_state = states[state]
         capture_job.save(update_fields=['scoop_logs', 'scoop_state'])
 
         if poll_data['status'] == 'success':

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1062,6 +1062,8 @@ def capture_with_scoop(capture_job):
         if poll_data['status'] == 'success':
             link.primary_capture.status = 'success'
             link.primary_capture.save(update_fields=['status'])
+        else:
+            logger.error(f"Scoop capture failed: {poll_data}")
 
     except HaltCaptureException:
         print("HaltCaptureException thrown")

--- a/services/docker/scoop-rest-api/config.py
+++ b/services/docker/scoop-rest-api/config.py
@@ -1,0 +1,162 @@
+# This is the default config.py from the Scoop REST API as of 9/6/2023
+# https://github.com/harvard-lil/scoop-rest-api/blob/31c541432fd8e31a04c6e0c5667beb28decfc3ec/scoop_rest_api/config.py
+# We only use it to override the blocklist: we disable it to allow the capturing of
+# localhost in our test suite.
+
+"""
+`config` module: App-wide settings.
+"""
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+#
+# Temporary
+#
+SCREEN_API_TOKEN = ""
+""" (Temporary) screen-api.lil.tools token. """
+
+if "SCREEN_API_TOKEN" in os.environ:
+    SCREEN_API_TOKEN = os.environ["SCREEN_API_TOKEN"]
+
+#
+# Security settings
+#
+ACCESS_KEY_SALT = b"$2b$12$rXmm9AWx82fxw9Jbs1PXI.zebeXu4Ydi1huwxyH5k9flyhccBBTxa"  # default / dev
+
+# Access key salt should be provided via an environment variable.
+# Use bcrypt.gensalt() to generate one.
+if "ACCESS_KEY_SALT" in os.environ:
+    ACCESS_KEY_SALT = os.environ["ACCESS_KEY_SALT"].encode()
+
+MAX_PENDING_CAPTURES = 300
+""" Stop accepting new capture requests if there are over X captures in the queue. """
+
+EXPOSE_SCOOP_LOGS = True
+""" If `True`, Scoop logs will be exposed at API level by capture_to_dict. Handle with care. """
+
+EXPOSE_SCOOP_CAPTURE_SUMMARY = True
+""" If `True`, Scoop's capture summary will be exposed at API level via capture_to_dict. Handle with care. """  # noqa
+
+#
+# Database settings
+#
+DATABASE_USERNAME = "root"
+""" (MySQL) Database username. Should be provided via an environment variable. """
+
+if "DATABASE_USERNAME" in os.environ:
+    DATABASE_USERNAME = os.environ["DATABASE_USERNAME"]
+
+DATABASE_PASSWORD = ""
+""" (MySQL) Database password. Should be provided via an environment variable. """
+
+if "DATABASE_PASSWORD" in os.environ:
+    DATABASE_PASSWORD = os.environ["DATABASE_PASSWORD"]
+
+DATABASE_HOST = "127.0.0.1"
+""" (MySQL) Database host. Should be provided via an environment variable. """
+
+if "DATABASE_HOST" in os.environ:
+    DATABASE_HOST = os.environ["DATABASE_HOST"]
+
+DATABASE_PORT = 3306
+""" (MySQL) Database port. Should be provided via an environment variable. """
+
+if "DATABASE_PORT" in os.environ:
+    DATABASE_PORT = int(os.environ["DATABASE_PORT"])
+
+DATABASE_NAME = "scoop_api"
+""" (MySQL) Database name. Should be provided via an environment variable. """
+
+if "DATABASE_NAME" in os.environ:
+    DATABASE_NAME = os.environ["DATABASE_NAME"]
+
+DATABASE_CA_PATH = ""
+""" (MySQL) If provided, will be used to connect to MySQL via SSL. """
+
+if "DATABASE_CA_PATH" in os.environ:
+    DATABASE_CA_PATH = os.environ["DATABASE_CA_PATH"]
+
+
+#
+# Paths settings
+#
+TEMPORARY_STORAGE_PATH = "./storage"
+""" Directory in which files will be (temporarily) stored. """
+
+TEMPORARY_STORAGE_EXPIRATION = 60 * 60 * 24
+""" How long should temporary files be stored for? (In seconds). Can be provided via an environment variable. """  # noqa
+
+
+#
+# API-wide settings
+#
+API_DOMAIN = "http://localhost:5000"
+""" Root URL of the API. """
+
+if "API_DOMAIN" in os.environ:
+    API_DOMAIN = os.environ["API_DOMAIN"]
+
+API_STORAGE_URL = f"{API_DOMAIN}/storage"
+""" URL for the storage folder. """
+
+#
+# Background processing options
+#
+PROCESSES = 6
+""" How many tick commands (capture processing) should run in parallel."""
+
+if "PROCESSES" in os.environ:
+    PROCESSES = os.environ["PROCESSES"]
+
+PROCESSES_PROXY_PORT = 9000
+"""
+    Default port for Scoop Proxy for a given process.
+    Will be incremented by 1 for each new parallel process.
+"""
+
+#
+# Scoop settings
+#
+DOWNGRADE_TO_WARC = True
+""" If True, Scoop will generate WARCs instead of WACZ files. """
+
+SCOOP_CLI_OPTIONS = {
+    "--log-level": "info",
+    # "--signing-url": "https://authsign.lil.tools/sign",
+    # "--signing-token": "",
+    "--screenshot": "true",
+    "--pdf-snapshot": "false",
+    "--dom-snapshot": "false",
+    "--capture-video-as-attachment": "false",
+    "--capture-certificates-as-attachment": "false",
+    "--provenance-summary": "true",
+    "--attachments-bypass-limits": "true",
+    "--capture-timeout": 40 * 1000,
+    "--load-timeout": 15 * 1000,
+    "--network-idle-timeout": 15 * 1000,
+    "--behaviors-timeout": 15 * 1000,
+    "--capture-video-as-attachment-timeout": 20 * 1000,
+    "--capture-certificates-as-attachment-timeout": 10 * 1000,
+    "--capture-window-x": 1600,
+    "--capture-window-y": 900,
+    "--max-capture-size": int(200 * 1024 * 1024),
+    "--auto-scroll": "true",
+    "--auto-play-media": "true",
+    "--grab-secondary-resources": "true",
+    "--run-site-specific-behaviors": "true",
+    "--headless": "false",  # Note: `xvfb-run --auto-servernum --` prefix may be needed if false.
+    # "--user-agent-suffix": "",
+    # "--blocklist": "/https?:\/\/localhost/,0.0.0.0/8,10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/29,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.18.0.0/15,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,240.0.0.0/4,255.255.255.255/32,::/128,::1/128,::ffff:0:0/96,100::/64,64:ff9b::/96,2001::/32,2001:10::/28,2001:db8::/32,2002::/16,fc00::/7,fe80::/10,ff00::/8",  # noqa
+    "--blocklist": "",
+    "--public-ip-resolver-endpoint": "https://myip.lil.tools",
+}
+"""
+    Options passed to the Scoop CLI during capture.
+    See https://github.com/harvard-lil/scoop for details.
+
+    Options which cannot be set at config level are listed here:
+    - utils.config_check.EXCLUDED_SCOOP_CLI_OPTIONS
+"""


### PR DESCRIPTION
Differences: 
- Scoop doesn't capture Flash's swf files
- Scoop doesn't capture as many favicons (we knew this, and are fine with it)
- Scoop doesn't capture the fallback `src` for images that use `srcset`: TBD.

I have not toggled `CAPTURE_ENGINE = 'scoop-api'` in settings_testing.py: CI will still test with Perma capture, for the time being.