### PR TITLE
Check `targetUrlResolved` against `PRIVATE_BY_POLICY_DOMAINS`

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -49,7 +49,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:13-7077f40b8607621df9827f31bba4e7d4
+    image: registry.lil.tools/harvardlil/scoop-rest-api:15-36faf86818fcb2094e47cfe37c443515
     init: true
     tty: true
     depends_on:

--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -101,8 +101,8 @@ if settings.DEBUG and hasattr(settings, 'DEBUG_TOOLBAR_CONFIG'):
     urlpatterns += [re_path(r'^__debug__/', include(debug_toolbar.urls))]
 
 # views that only load when running our tests:
-# if settings.TESTING:
-from .tests import views as test_views
-urlpatterns += [
-    re_path(r'tests/redirect-to-file$', test_views.redirect_to_file, name='redirect_to_file')
-]
+if settings.TESTING:
+    from .tests import views as test_views
+    urlpatterns += [
+        re_path(r'tests/redirect-to-file$', test_views.redirect_to_file, name='redirect_to_file')
+    ]

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -847,11 +847,11 @@ def save_scoop_capture(link, capture_job, data):
     ])
 
     # Make this link private by policy, if the captured domain is on the list.
-    # For now, just check the primary URL, since Scoop does not yet expose the URL
-    # that the capture request resolved to.
-    content_url = data['scoop_capture_summary']['exchangeUrls'][0]
-    if any(domain in content_url for domain in settings.PRIVATE_BY_POLICY_DOMAINS):
-        safe_save_fields(link, is_private=True, private_reason='domain')
+    target_url = data['scoop_capture_summary']['targetUrl']
+    content_url = data['scoop_capture_summary']['targetUrlResolved']
+    for url in [target_url, content_url]:
+        if any(domain in url for domain in settings.PRIVATE_BY_POLICY_DOMAINS):
+            safe_save_fields(link, is_private=True, private_reason='domain')
 
     # See if the primary URL has been munged in any way since we last saw it.
     if link.primary_capture.url != data['scoop_capture_summary']['exchangeUrls'][0]:


### PR DESCRIPTION
In https://github.com/harvard-lil/perma/pull/3392, we implemented a new policy for when to make Perma Links private: we maintain a list of domains to check against.

At the time, when capturing with Scoop, it was only possible for Perma to check the target URL.

As of [Scoop 0.5.5](https://github.com/harvard-lil/scoop/releases/tag/0.5.5), added to the [Scoop API](https://github.com/harvard-lil/scoop-rest-api/commit/e83c96ae7f2c6153fd92770db6c7581414157676) recently, we can now also see the URL that the browser "lands on", after any redirects, and check that too.

This PR does so.

See ENG-352.

----

Note: I spent a lot of time yesterday trying to add a test for this, experimenting with 3 approaches, none of which worked in all circumstances, and all of which were intricate.  For a feature of this importance.... I think it is more appropriate to leave it untested. I'm happy to say more, if people are curious.