### PR TITLE
Correct path to custom Perma Payments settings file.

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -105,7 +105,7 @@ services:
     # alter config as desired, in the usual way, then comment in this volume
     # and re-run docker-compose up
     # volumes:
-    #   - ./services/docker/perma-payments/settings.py:/perma-payments/config/settings/settings.py
+    #   - ./services/docker/perma-payments/settings.py:/app/web/config/settings/settings.py
     networks:
       - default
       - perma_payments


### PR DESCRIPTION
I'm not sure when this changed, but... Perma Payments settings file is in `/app/web`, not `/perma-payments`. 