### PR TITLE
Tweak playback tray

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -146,8 +146,14 @@
         </div>
         {% if request.user.is_staff %}
           <div class="tray-detail-group admin-only">
-            <dt class="tray-detail-title">Captured by</dt>
-            <dd class="tray-detail-entry">{{link.captured_by_software}}</dd>
+            <dt class="tray-detail-title">Source</dt>
+            {% if link.captured_by_software == 'upload' %}
+              <dd class="tray-detail-entry">User Upload</dd>
+            {% elif link.captured_by_software == 'perma' %}
+              <dd class="tray-detail-entry">Captured by Perma (internal)</dd>
+            {% else %}
+              <dd class="tray-detail-entry">Captured by Scoop</dd>
+            {% endif %}
           </div>
         {% endif %}
           {% if can_delete  and not link.capture_job.status == 'in_progress' %}

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -155,6 +155,13 @@
               <dd class="tray-detail-entry">Captured by Scoop</dd>
             {% endif %}
           </div>
+        {% else %}
+          {% if link.captured_by_software == 'upload' %}
+            <div class="tray-detail-group">
+              <dt class="tray-detail-title">Source</dt>
+              <dd class="tray-detail-entry">User Upload</dd>
+            </div>
+          {% endif %}
         {% endif %}
           {% if can_delete  and not link.capture_job.status == 'in_progress' %}
             <div class="tray-detail-group temporary-options">
@@ -189,6 +196,12 @@
             <dt class="tray-detail-title">Description</dt>
             <dd class="tray-detail-entry">{{link.submitted_description}}</dd>
           </div>
+          {% if link.captured_by_software == 'upload' %}
+            <div class="tray-detail-group">
+              <dt class="tray-detail-title">Source</dt>
+              <dd class="tray-detail-entry">User Upload</dd>
+            </div>
+          {% endif %}
         {% endif %}
         {% comment %}
           {% if link.organization %}


### PR DESCRIPTION
See ENG-346 and ENG-301.

This PR does two closely-related, minor things.

a) As per ENG-346, it rewords the admin-only field in the playback tray stating whether a given Perma Link was captured by Perma, captured by Scoop, or uploaded by a user:

![image](https://github.com/harvard-lil/perma/assets/11020492/9c5c5c70-f512-4928-9872-142d4d967e79)
![image](https://github.com/harvard-lil/perma/assets/11020492/8e921626-6884-4b01-9978-95fd3204b824)
![image](https://github.com/harvard-lil/perma/assets/11020492/e7a943cc-df7a-4d31-838a-017b541ca13b)



b) As per ENG-301, it displays a "Source: User Upload" field to non-staff, too, when that is the case:

![image](https://github.com/harvard-lil/perma/assets/11020492/6d8b419b-0cd8-4a77-880c-dd431aa4b78b)
![image](https://github.com/harvard-lil/perma/assets/11020492/fed9c057-402a-4701-817f-3f55072e7697)
