### PR TITLE
Alert if something goes wrong with the Internet Archive task count

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -2462,6 +2462,10 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
     max_to_queue = settings.INTERNET_ARCHIVE_MAX_SIMULTANEOUS_UPLOADS - tasks_in_flight
     to_queue = min(max_to_queue, limit) if limit else max_to_queue
 
+    if to_queue < 0:
+        logger.error(f"Something is amiss with the IA upload process: InternetArchiveItem.inflight_task_count ({InternetArchiveItem.inflight_task_count()}) is larger than settings.INTERNET_ARCHIVE_MAX_SIMULTANEOUS_UPLOADS.")
+        return
+
     if to_queue:
 
         total_queued = 0


### PR DESCRIPTION
ENG-417

Something got scrambled, back in July, with Perma's internal record of how many Internet Archive tasks we currently have in flight: we think things got out-of-whack during a phased reboot of the workers.

Our records ended up in a state where, we thought we had more tasks in flight than is permitted, and so, we refrained from making any more uploads since.

We don't think this will happen again, because of a change in strategy: we will now go into maintenance mode before making changes like this.

But, this PR adds another level of safety: if we get into the same situation again, the upload task will now log to the error log.

