### PR TITLE
Refactor test_capture_job.py

### DIFF
--- a/perma_web/api/tests/test_current_user_authorization.py
+++ b/perma_web/api/tests/test_current_user_authorization.py
@@ -1,6 +1,13 @@
 from .utils import ApiResourceTestCase
-from perma.tests.test_capture_job import create_capture_job
-from perma.models import LinkUser, Link
+from perma.models import LinkUser, Link, CaptureJob
+
+
+def create_capture_job(user, human=True):
+    link = Link(created_by=user, submitted_url="http://example.com")
+    link.save()
+    capture_job = CaptureJob(created_by=user, link=link, human=human, status='pending')
+    capture_job.save()
+    return capture_job
 
 
 class CurrentUserAuthorizationTestCase(ApiResourceTestCase):

--- a/perma_web/perma/tests/test_capture_job.py
+++ b/perma_web/perma/tests/test_capture_job.py
@@ -22,6 +22,30 @@ def create_capture_job(user, human=True):
     return capture_job
 
 
+def test_hard_timeout(pending_capture_job):
+
+    # simulate a failed run_next_capture()
+    job = CaptureJob.get_next_job(reserve=True)
+
+    # capture_start_time should be set accurately on the server side
+    assert (job.capture_start_time - timezone.now()).total_seconds() < 60
+
+    # clean_up_failed_captures shouldn't affect job, since timeout hasn't passed
+    clean_up_failed_captures()
+    job.refresh_from_db()
+    assert job.status == "in_progress"
+
+    # once job is sufficiently old, clean_up_failed_captures should mark it as failed
+    job.capture_start_time -= timedelta(seconds=settings.CELERY_TASK_TIME_LIMIT+60)
+    job.save()
+    clean_up_failed_captures()
+    job.refresh_from_db()
+    assert job.status == "failed"
+
+    # failed jobs will have a message indicating failure reason
+    assert json.loads(job.message)[api_settings.NON_FIELD_ERRORS_KEY][0] == "Timed out."
+
+
 class CaptureJobTestCase(TransactionTestCase):
 
     fixtures = [
@@ -99,26 +123,3 @@ class CaptureJobTestCase(TransactionTestCase):
         self.assertRaisesRegex(AssertionError, r'^Items in the', self.test_race_condition_prevented)
         CaptureJob.TEST_ALLOW_RACE = False
 
-    def test_hard_timeout(self):
-        create_capture_job(self.user_one)
-
-        # simulate a failed run_next_capture()
-        job = CaptureJob.get_next_job(reserve=True)
-
-        # capture_start_time should be set accurately on the server side
-        self.assertLess((job.capture_start_time - timezone.now()).total_seconds(), 60)
-
-        # clean_up_failed_captures shouldn't affect job, since timeout hasn't passed
-        clean_up_failed_captures()
-        job.refresh_from_db()
-        self.assertEqual(job.status, "in_progress")
-
-        # once job is sufficiently old, clean_up_failed_captures should mark it as failed
-        job.capture_start_time -= timedelta(seconds=settings.CELERY_TASK_TIME_LIMIT+60)
-        job.save()
-        clean_up_failed_captures()
-        job.refresh_from_db()
-        self.assertEqual(job.status, "failed")
-
-        # failed jobs will have a message indicating failure reason
-        self.assertEqual(json.loads(job.message)[api_settings.NON_FIELD_ERRORS_KEY][0], "Timed out.")

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -79,6 +79,7 @@ PyNaCl                                  # encryption
 beautifulsoup4                          # parses html of responses
 coverage                                # record code coverage
 django-admin-smoke-tests                # basic tests for the Django admin
+factory-boy                             # create django model fixtures on demand
 fakeredis[lua]                          # simulate redis backend for tests
 flake8                                  # code linting
 hypothesis                              # run tests with lots of generated input
@@ -88,6 +89,7 @@ pytest-django                           # tools for django in pytest
 pytest-django-ordering                  # runs transaction-wrapped tests before table truncating tests
 pytest-xdist                            # run tests in parallel
 pytest                                  # test runner
+pyhumps                                 # a helper for dealing with camel case and snake case
 pytest-playwright                       # integration tests
 pytest-django-liveserver-ssl            # integration tests w/SSL
 django-extensions                       # runserver_plus for SSL

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -342,6 +342,14 @@ executing==0.8.3 \
     --hash=sha256:c6554e21c6b060590a6d3be4b82fb78f8f0194d809de5ea7df1c093763311501 \
     --hash=sha256:d1eef132db1b83649a3905ca6dd8897f71ac6f8cac79a7e58a1a09cf137546c9
     # via stack-data
+factory-boy==3.3.0 \
+    --hash=sha256:a2cdbdb63228177aa4f1c52f4b6d83fab2b8623bf602c7dedd7eb83c0f69c04c \
+    --hash=sha256:bc76d97d1a65bbd9842a6d722882098eb549ec8ee1081f9fb2e8ff29f0c300f1
+    # via -r requirements.in
+faker==19.12.0 \
+    --hash=sha256:5990380a8ee81cf189d6b85d5fdc1fb43772cb136aca0385a08ff24ef01b9fdf \
+    --hash=sha256:91438f6b1713274ec3f24970ba303617be86ce5caf6f6a0776f1d04777b6ff5f
+    # via factory-boy
 fakeredis[lua]==2.10.2 \
     --hash=sha256:6377c27bc557be46089381d43fd670aece46672d091a494f73ab4c96c34022b3 \
     --hash=sha256:e2a95fbda7b11188c117d68b0f9eecc00600cb449ccf3362a15fc03cf9e2477d
@@ -849,6 +857,10 @@ pygments==2.15.1 \
     --hash=sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c \
     --hash=sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1
     # via ipython
+pyhumps==3.8.0 \
+    --hash=sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6 \
+    --hash=sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3
+    # via -r requirements.in
 pynacl==1.5.0 \
     --hash=sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858 \
     --hash=sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d \
@@ -932,6 +944,7 @@ python-dateutil==2.8.2 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
     # via
     #   botocore
+    #   faker
     #   timegate
 python-slugify==6.1.2 \
     --hash=sha256:272d106cb31ab99b3496ba085e3fea0e9e76dcde967b5e9992500d1f785ce4e1 \


### PR DESCRIPTION
See ENG-415.

This PR refactors test_capture_job.py:

a) to use pytest fixtures powered by factory boy instead of our [json fixtures](https://github.com/harvard-lil/perma/tree/develop/perma_web/fixtures)

b) to use standard pytest syntax instead of the older [unittest-style syntax](https://docs.pytest.org/en/7.1.x/how-to/unittest.html)

This was easy, because I basically already went through this exercise in https://github.com/harvard-lil/perma-capture/commit/b2fe7addb5c4d8c19769e4b552516726b3829761 and related commits, when building the prototype capture service.

I hope to be able to reuse a lot of that work (as intended), as this refactoring project  proceeds!

### Reviewing

The unified diff is very hard to read, but I think if you click through the individual commits, you'll be able to easily see at a glance that the tests haven't been changed.