### PR TITLE
Update Chromium

### DIFF
--- a/perma_web/Dockerfile
+++ b/perma_web/Dockerfile
@@ -69,7 +69,7 @@ RUN pip install pip==22.0.4 \
 COPY perma_web/lil-archive-keyring.gpg /usr/share/keyrings/lil-archive-keyring.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/lil-archive-keyring.gpg] https://repo.lil.tools/ bullseye-security updates/main" > /etc/apt/sources.list.d/lil-chromium.list
 
-ENV CHROMIUM_VERSION=118.0.5993.70-1~deb11u1
+ENV CHROMIUM_VERSION=118.0.5993.117-1~deb11u1
 RUN apt-get update && apt-get install -y chromium=${CHROMIUM_VERSION} \
     chromium-common=${CHROMIUM_VERSION} \
     chromium-driver=${CHROMIUM_VERSION} \

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -569,7 +569,7 @@ MAX_IMAGE_SIZE = 1024*1024*50  # 50 megapixels
 
 CAPTURE_BROWSER = 'Chrome'  # some support for 'Firefox'
 DISABLE_DEV_SHM = False
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.70 Safari/537.36"
+CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.117 Safari/537.36"
 PROXY_CAPTURES = False
 PROXY_ADDRESS = 'localhost:9050'
 DOMAINS_TO_PROXY = []


### PR DESCRIPTION
https://chromereleases.googleblog.com/2023/10/stable-channel-update-for-desktop_24.html

At some point, updates like this will no longer be necessary, once we've removed the non-Scoop capture system, but for now I'll keep updating Chromium, even if we're not using it at the moment.