### PR TITLE
Correct range

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -269,7 +269,7 @@ def stats(request, stat_type=None):
         )
         last_3_hrs_on_previous_day = (
             now - timedelta(days=1) - timedelta(hours=3),
-            now - timedelta(hours=3)
+            now - timedelta(days=1)
         )
         ranges = {
             "last_24_hrs": last_24_hrs,


### PR DESCRIPTION
This corrects the range for "last 3 hours, previous day", which currently looks something like this:

![image (4)](https://github.com/harvard-lil/perma/assets/3776423/dc3558d7-025d-421d-ba24-db559ee499c6)
