### PR TITLE
Convert additional tests to pytest syntax

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -277,3 +277,30 @@ class LinkFactory(DjangoModelFactory):
         ),
         no_declaration=None
     )
+
+
+### fixtures for testing utils ###
+
+@pytest.fixture
+def spoof_perma_payments_post():
+    data = {
+        'encrypted_data': {"timestamp": 1504884268.560902, "desired_field": "desired_field"},
+    }
+    assert 'encrypted_data' in data
+    assert 'timestamp' in data['encrypted_data']
+    assert 'desired_field' in data['encrypted_data']
+    return data
+
+
+@pytest.fixture
+def one_two_three_dict():
+    data = {
+        'one': 'one',
+        'two': 'two',
+        'three': 'three'
+    }
+    assert 'one' in data
+    assert 'two' in data
+    assert 'three' in data
+    assert 'four' not in data
+    return data

--- a/perma_web/perma/tests/test_celery_tasks.py
+++ b/perma_web/perma/tests/test_celery_tasks.py
@@ -1,35 +1,35 @@
 from django.core import mail
 
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from perma.celery_tasks import update_stats, send_js_errors
 from perma.models import UncaughtError
 
+
 @override_settings(CELERY_ALWAYS_EAGER=True)
-class TaskTestCase(TestCase):
+def testUpdateStats(db):
+    # this tests only that the task runs,
+    # not anything about the task itself
+    assert update_stats.delay()
 
-    def testUpdateStats(self):
-        # this tests only that the task runs,
-        # not anything about the task itself
-        self.assertTrue(update_stats.delay())
 
-    def test_send_js_errors(self):
-        response = send_js_errors()
-        self.assertFalse(response)
-        self.assertEqual(len(mail.outbox), 0)
-        unruly_stack_trace = '[{"function": "getNextContents", "column": 6, "line": 304, "file": "static/bundles/create.js"}, {"function": "showFolderContents", "column": 4, "line": 335, "file": "static/bundles/create.js"}]'
-        err = UncaughtError.objects.create(
-            message="oh no!",
-            current_url="perma.cc/about",
-            stack=unruly_stack_trace)
-        err.save()
+def test_send_js_errors(db):
+    response = send_js_errors()
+    assert not response
+    assert len(mail.outbox) == 0
+    unruly_stack_trace = '[{"function": "getNextContents", "column": 6, "line": 304, "file": "static/bundles/create.js"}, {"function": "showFolderContents", "column": 4, "line": 335, "file": "static/bundles/create.js"}]'
+    err = UncaughtError.objects.create(
+        message="oh no!",
+        current_url="perma.cc/about",
+        stack=unruly_stack_trace)
+    err.save()
 
-        response = send_js_errors()
-        self.assertTrue(response)
+    response = send_js_errors()
+    assert response
 
-        message = mail.outbox[0]
-        message_parts = message.body.split('\n')
-        self.assertIn('URL: %s' % err.current_url, message_parts)
-        self.assertIn('Message: %s' % err.message, message_parts)
-        self.assertIn('Function: getNextContents', message_parts)
-        self.assertIn('File: static/bundles/create.js', message_parts)
-        self.assertNotIn('showFolderContents', message_parts)
+    message = mail.outbox[0]
+    message_parts = message.body.split('\n')
+    assert 'URL: %s' % err.current_url in message_parts
+    assert 'Message: %s' % err.message in message_parts
+    assert 'Function: getNextContents' in message_parts
+    assert 'File: static/bundles/create.js' in message_parts
+    assert 'showFolderContents' not in message_parts

--- a/perma_web/perma/tests/test_cloudflare_cache.py
+++ b/perma_web/perma/tests/test_cloudflare_cache.py
@@ -1,34 +1,27 @@
+"""
+    Ensure that our local cache of Cloudflare IP addresses is up to date.
+"""
+
 import requests
 import os
-from unittest import TestCase
 
 from django.conf import settings
 
-
-
-class CloudflareCacheTestCase(TestCase):
-    """
-        Ensure that our local cache of Cloudflare IP addresses is up to date.
-    """
-    message = """
+message = """
 Cloudflare has updated its list of IP addresses since we last grabbed a
 copy. We rely on an up-to-date list of IP addresses for rate limiting,
 LOCKSS security, and other purposes. Please run `invoke dev.update-cloudflare-cache`
 and commit the updated files.
 """
 
-    def test_cloudflare_ip4_cache(self):
-        ip4 = requests.get('https://www.cloudflare.com/ips-v4').text
+def test_cloudflare_ip4_cache():
+    ip4 = requests.get('https://www.cloudflare.com/ips-v4').text
 
-        with open(os.path.join(settings.CLOUDFLARE_DIR, 'ips-v4')) as ip4_cache:
-            self.assertEqual(set(ip4.split()),
-                             set(ip4_cache.read().split()),
-                             msg=self.message)
+    with open(os.path.join(settings.CLOUDFLARE_DIR, 'ips-v4')) as ip4_cache:
+        assert set(ip4.split()) == set(ip4_cache.read().split()), message
 
-    def test_cloudflare_ip6_cache(self):
-        ip6 = requests.get('https://www.cloudflare.com/ips-v6').text
+def test_cloudflare_ip6_cache():
+    ip6 = requests.get('https://www.cloudflare.com/ips-v6').text
 
-        with open(os.path.join(settings.CLOUDFLARE_DIR, 'ips-v6')) as ip6_cache:
-            self.assertEqual(set(ip6.split()),
-                             set(ip6_cache.read().split()),
-                             msg=self.message)
+    with open(os.path.join(settings.CLOUDFLARE_DIR, 'ips-v6')) as ip6_cache:
+        assert set(ip6.split()) ==  set(ip6_cache.read().split()), message

--- a/perma_web/perma/tests/test_email.py
+++ b/perma_web/perma/tests/test_email.py
@@ -1,72 +1,70 @@
 from django.conf import settings
-from django.core import mail
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
 
 from perma.email import registrar_users_plus_stats, send_user_email_copy_admins
 from perma.models import LinkUser, Organization, Registrar
 
-from .utils import PermaTestCase
 
-class EmailTestCase(PermaTestCase):
+def test_send_user_email_copy_admins(mailoutbox):
+    send_user_email_copy_admins(
+        "title",
+        "from@example.com",
+        ["to@example.com"],
+        HttpRequest(),
+        "email/default.txt",
+        {"message": "test message"}
+    )
+    assert len(mailoutbox) == 1
+    message = mailoutbox[0]
+    assert message.from_email == settings.DEFAULT_FROM_EMAIL
+    assert message.cc == [settings.DEFAULT_FROM_EMAIL, "from@example.com"]
+    assert message.to == ["to@example.com"]
+    assert message.reply_to == ["from@example.com"]
 
-    def test_send_user_email_copy_admins(self):
-        send_user_email_copy_admins(
-            "title",
-            "from@example.com",
-            ["to@example.com"],
-            HttpRequest(),
-            "email/default.txt",
-            {"message": "test message"}
-        )
-        self.assertEqual(len(mail.outbox),1)
-        message = mail.outbox[0]
-        self.assertEqual(message.from_email, settings.DEFAULT_FROM_EMAIL)
-        self.assertEqual(message.cc, [settings.DEFAULT_FROM_EMAIL, "from@example.com"])
-        self.assertEqual(message.to, ["to@example.com"])
-        self.assertEqual(message.reply_to, ["from@example.com"])
 
-    def test_registrar_users_plus_stats(self):
-        '''
-            Returns data in the expected format.
-        '''
-        r_list = registrar_users_plus_stats()
-        self.assertIsInstance(r_list, list)
-        self.assertGreater(len(r_list), 0)
-        for user in r_list:
-            self.assertIsInstance(user, dict)
-            expected_keys = [ 'email',
-                              'first_name',
-                              'last_name',
-                              'most_active_org',
-                              'registrar_email',
-                              'registrar_id',
-                              'registrar_name',
-                              'registrar_users',
-                              'total_links',
-                              'year_links' ]
-            self.assertEqual(sorted(user.keys()), expected_keys)
-            for key in ['email', 'first_name', 'last_name', 'registrar_email', 'registrar_name']:
-                self.assertIsInstance(user[key], str)
-                self.assertTrue(user[key])
-            perma_user = LinkUser.objects.get(email=user['email'])
-            self.assertTrue(perma_user.registrar)
-            self.assertTrue(perma_user.is_active)
-            self.assertTrue(perma_user.is_confirmed)
-            self.assertIsInstance(user['total_links'], int)
-            self.assertIsInstance(user['year_links'], int)
-            self.assertIsInstance(user['registrar_id'], int)
-            self.assertIsInstance(user['most_active_org'], (Organization, type(None)))
-            self.assertIsInstance(user['registrar_users'], QuerySet)
-            self.assertGreaterEqual(len(user['registrar_users']), 1)
-            for user in user['registrar_users']:
-                self.assertIsInstance(user, LinkUser)
+def test_registrar_users_plus_stats_specific_registrars(db):
+    '''
+        Returns data in the expected format.
+    '''
+    r_list = registrar_users_plus_stats(registrars=Registrar.objects.filter(email='library@university.edu'))
+    assert isinstance(r_list, list)
+    assert len(r_list) == 1
+    assert r_list[0]['registrar_email'] == 'library@university.edu'
 
-    def test_registrar_users_plus_stats_specific_registrars(self):
-        '''
-            Returns data in the expected format.
-        '''
-        r_list = registrar_users_plus_stats(registrars=Registrar.objects.filter(email='library@university.edu'))
-        self.assertIsInstance(r_list, list)
-        self.assertEqual(len(r_list), 1)
-        self.assertEqual(r_list[0]['registrar_email'], 'library@university.edu')
+
+def test_registrar_users_plus_stats(db):
+    '''
+        Returns data in the expected format.
+    '''
+    r_list = registrar_users_plus_stats()
+    assert isinstance(r_list, list)
+    assert len(r_list) > 0
+    for user in r_list:
+        assert isinstance(user, dict)
+        expected_keys = [ 'email',
+                          'first_name',
+                          'last_name',
+                          'most_active_org',
+                          'registrar_email',
+                          'registrar_id',
+                          'registrar_name',
+                          'registrar_users',
+                          'total_links',
+                          'year_links' ]
+        assert sorted(user.keys()) == expected_keys
+        for key in ['email', 'first_name', 'last_name', 'registrar_email', 'registrar_name']:
+            assert isinstance(user[key], str)
+            assert user[key]
+        perma_user = LinkUser.objects.get(email=user['email'])
+        assert perma_user.registrar
+        assert perma_user.is_active
+        assert perma_user.is_confirmed
+        assert isinstance(user['total_links'], int)
+        assert isinstance(user['year_links'], int)
+        assert isinstance(user['registrar_id'], int)
+        assert isinstance(user['most_active_org'], (Organization, type(None)))
+        assert isinstance(user['registrar_users'], QuerySet)
+        assert len(user['registrar_users']) >= 1
+        for user in user['registrar_users']:
+            assert isinstance(user, LinkUser)

--- a/perma_web/perma/tests/test_urls.py
+++ b/perma_web/perma/tests/test_urls.py
@@ -1,25 +1,23 @@
 from django.urls import reverse
 
 from perma.urls import urlpatterns
-from .utils import PermaTestCase
 
-class UrlsTestCase(PermaTestCase):
 
-    def test_url_status_codes(self):
-        """
-        A really simple test for 500 errors. We test all views that don't
-        take parameters (it's not easy to guess what params they want).
-        """
-        exclude = {
-            'archive_error': 'because it returns 500 by default'
-        }
+def test_url_status_codes(client):
+    """
+    A really simple test for 500 errors. We test all views that don't
+    take parameters (it's not easy to guess what params they want).
+    """
+    exclude = {
+        'archive_error': 'because it returns 500 by default'
+    }
 
-        for urlpattern in urlpatterns:
-            if '?P<' not in urlpattern.pattern._regex \
-                     and urlpattern.name \
-                     and urlpattern.name not in exclude:
-                response = self.client.get(reverse(urlpattern.name))
-                self.assertNotEqual(response.status_code, 500)
+    for urlpattern in urlpatterns:
+        if '?P<' not in urlpattern.pattern._regex \
+                 and urlpattern.name \
+                 and urlpattern.name not in exclude:
+            response = client.get(reverse(urlpattern.name))
+            assert response.status_code != 500
 
-                response = self.client.post(reverse(urlpattern.name))
-                self.assertNotEqual(response.status_code, 500)
+            response = client.post(reverse(urlpattern.name))
+            assert response.status_code != 500

--- a/perma_web/perma/tests/test_utils.py
+++ b/perma_web/perma/tests/test_utils.py
@@ -9,7 +9,6 @@ from django.test.client import RequestFactory
 
 
 from hypothesis import given
-from hypothesis.extra.django import TestCase
 from hypothesis.strategies import characters, text, integers, booleans, datetimes, dates, decimals, uuids, binary, dictionaries
 from perma.utils import (
     AlphaNumericValidator,
@@ -23,201 +22,174 @@ from perma.utils import (
     stringify_data,
     unstringify_data
 )
+import pytest
 
 from .utils import SentinelException
 
-# Fixtures
 
-def spoof_perma_payments_post():
-    data = {
-        'encrypted_data': {"timestamp": 1504884268.560902, "desired_field": "desired_field"},
-    }
-    assert 'encrypted_data' in data
-    assert 'timestamp' in data['encrypted_data']
-    assert 'desired_field' in data['encrypted_data']
-    return data
+def test_get_client_ip():
+    request = RequestFactory().get('/some/route', REMOTE_ADDR="1.2.3.4")
+    assert get_client_ip(request) == "1.2.3.4"
 
+#
+# our custom password validator
+#
 
-def one_two_three_dict():
-    data = {
-        'one': 'one',
-        'two': 'two',
-        'three': 'three'
-    }
-    assert 'one' in data
-    assert 'two' in data
-    assert 'three' in data
-    assert 'four' not in data
-    return data
+def test_lower_upper_number_required():
+    validator = AlphaNumericValidator()
+    lower ='a'
+    upper = 'A'
+    number = '1'
+    for char in (lower, upper, number):
+        with pytest.raises(ValidationError):
+            validator.validate('a')
+    assert validator.validate(lower+upper+number) is None
 
 
-# Tests
-
-class UtilsTestCase(TestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.factory = RequestFactory()
-
-
-    def test_get_client_ip(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="1.2.3.4")
-        self.assertEqual(get_client_ip(request), "1.2.3.4")
+def test_custom_validator_in_use():
+    lower ='a'
+    upper = 'A'
+    number = '1'
+    padding = 'qwertyuio'
+    with pytest.raises(ValidationError):
+        validate_password(padding)
+    assert validate_password(lower+upper+number+padding) is None
 
 
-    # our custom password validator
+#
+# communicate with perma payments
+#
 
-    def test_lower_upper_number_required(self):
-        validator = AlphaNumericValidator()
-        lower ='a'
-        upper = 'A'
-        number = '1'
-        for char in (lower, upper, number):
-            with self.assertRaises(ValidationError):
-                validator.validate('a')
-        self.assertIsNone(validator.validate(lower+upper+number))
+@patch('perma.utils.encrypt_for_perma_payments', autospec=True)
+@patch('perma.utils.stringify_data', autospec=True)
+def test_prep_for_perma_payments(stringify, encrypt):
+    stringify.return_value = sentinel.stringified
+    encrypt.return_value = sentinel.encrypted
 
-    def test_custom_validator_in_use(self):
-        lower ='a'
-        upper = 'A'
-        number = '1'
-        padding = 'qwertyuio'
-        with self.assertRaises(ValidationError):
-            validate_password(padding)
-        self.assertIsNone(validate_password(lower+upper+number+padding))
-
-    # communicate with perma payments
-
-    @patch('perma.utils.encrypt_for_perma_payments', autospec=True)
-    @patch('perma.utils.stringify_data', autospec=True)
-    def test_prep_for_perma_payments(self, stringify, encrypt):
-        stringify.return_value = sentinel.stringified
-        encrypt.return_value = sentinel.encrypted
-
-        assert prep_for_perma_payments({}) == sentinel.encrypted
-        stringify.assert_called_once_with({})
-        encrypt.assert_called_once_with(sentinel.stringified)
+    assert prep_for_perma_payments({}) == sentinel.encrypted
+    stringify.assert_called_once_with({})
+    encrypt.assert_called_once_with(sentinel.stringified)
 
 
-    def test_process_perma_payments_transmission_encrypted_data_not_in_post(self):
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            assert process_perma_payments_transmission({}, [])
-        assert 'No encrypted_data in POST.' in str(excinfo.exception)
+def test_process_perma_payments_transmission_encrypted_data_not_in_post():
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        assert process_perma_payments_transmission({}, [])
+    assert 'No encrypted_data in POST.' in str(excinfo.value)
 
 
-    def test_process_perma_payments_transmission_encrypted_data_none(self):
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            assert process_perma_payments_transmission({'encrypted_data': None}, [])
-        assert 'No encrypted_data in POST.' in str(excinfo.exception)
+def test_process_perma_payments_transmission_encrypted_data_none():
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        assert process_perma_payments_transmission({'encrypted_data': None}, [])
+    assert 'No encrypted_data in POST.' in str(excinfo.value)
 
 
-    def test_process_perma_payments_transmission_encrypted_data_empty(self):
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            assert process_perma_payments_transmission({'encrypted_data': ''}, [])
-        assert 'No encrypted_data in POST.' in str(excinfo.exception)
+def test_process_perma_payments_transmission_encrypted_data_empty():
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        assert process_perma_payments_transmission({'encrypted_data': ''}, [])
+    assert 'No encrypted_data in POST.' in str(excinfo.value)
 
 
-    @patch('perma.utils.decrypt_from_perma_payments', autospec=True)
-    def test_process_perma_payments_transmission_encryption_problem(self, decrypt):
-        decrypt.side_effect = SentinelException
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            process_perma_payments_transmission(spoof_perma_payments_post(), [])
-        assert 'SentinelException' in str(excinfo.exception)
-        assert decrypt.call_count == 1
+@patch('perma.utils.decrypt_from_perma_payments', autospec=True)
+def test_process_perma_payments_transmission_encryption_problem(decrypt, spoof_perma_payments_post):
+    decrypt.side_effect = SentinelException
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        process_perma_payments_transmission(spoof_perma_payments_post, [])
+    assert 'SentinelException' in str(excinfo.value)
+    assert decrypt.call_count == 1
 
 
-    @patch('perma.utils.unstringify_data', autospec=True)
-    @patch('perma.utils.decrypt_from_perma_payments', autospec=True)
-    def test_process_perma_payments_transmission_not_valid_json(self, decrypt, unstringify):
-        unstringify.side_effect = SentinelException
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            process_perma_payments_transmission(spoof_perma_payments_post(), [])
-        assert 'SentinelException' in str(excinfo.exception)
-        assert unstringify.call_count == 1
+@patch('perma.utils.unstringify_data', autospec=True)
+@patch('perma.utils.decrypt_from_perma_payments', autospec=True)
+def test_process_perma_payments_transmission_not_valid_json(decrypt, unstringify, spoof_perma_payments_post):
+    unstringify.side_effect = SentinelException
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        process_perma_payments_transmission(spoof_perma_payments_post, [])
+    assert 'SentinelException' in str(excinfo.value)
+    assert unstringify.call_count == 1
 
 
-    @patch('perma.utils.unstringify_data', autospec=True)
-    @patch('perma.utils.decrypt_from_perma_payments', autospec=True)
-    def test_process_perma_payments_transmission_missing_timestamp(self, decrypt, unstringify):
-        post = spoof_perma_payments_post()
-        del post['encrypted_data']['timestamp']
-        unstringify.return_value = post['encrypted_data']
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            process_perma_payments_transmission(post, [])
-        assert 'Missing timestamp in data.' in str(excinfo.exception)
-
-    @patch('perma.utils.is_valid_timestamp', autospec=True)
-    @patch('perma.utils.unstringify_data', autospec=True)
-    @patch('perma.utils.decrypt_from_perma_payments', autospec=True)
-    def test_process_perma_payments_transmission_expired_timestamp(self, decrypt, unstringify, timestamp):
-        post = spoof_perma_payments_post()
-        unstringify_data.return_value = post['encrypted_data']
-        timestamp.return_value = False
-        with self.assertRaises(InvalidTransmissionException) as excinfo:
-            process_perma_payments_transmission(post, [])
-        assert 'Expired timestamp in data.' in str(excinfo.exception)
+@patch('perma.utils.unstringify_data', autospec=True)
+@patch('perma.utils.decrypt_from_perma_payments', autospec=True)
+def test_process_perma_payments_transmission_missing_timestamp(decrypt, unstringify, spoof_perma_payments_post):
+    post = spoof_perma_payments_post
+    del post['encrypted_data']['timestamp']
+    unstringify.return_value = post['encrypted_data']
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        process_perma_payments_transmission(post, [])
+    assert 'Missing timestamp in data.' in str(excinfo.value)
 
 
-    @patch('perma.utils.is_valid_timestamp', autospec=True)
-    @patch('perma.utils.unstringify_data', autospec=True)
-    @patch('perma.utils.decrypt_from_perma_payments', autospec=True)
-    def test_process_perma_payments_transmission_happy_path(self, decrypt, unstringify, timestamp):
-        post = spoof_perma_payments_post()
-        decrypt.return_value = sentinel.decrypted
-        unstringify.return_value = post['encrypted_data']
-        timestamp.return_value = True
-
-        assert process_perma_payments_transmission(post, ['desired_field']) == {'desired_field': 'desired_field'}
-
-        decrypt.assert_called_once_with(post['encrypted_data'])
-        unstringify.assert_called_once_with(sentinel.decrypted)
-        timestamp.assert_called_once_with(post['encrypted_data']['timestamp'], settings.PERMA_PAYMENTS_TIMESTAMP_MAX_AGE_SECONDS)
+@patch('perma.utils.is_valid_timestamp', autospec=True)
+@patch('perma.utils.unstringify_data', autospec=True)
+@patch('perma.utils.decrypt_from_perma_payments', autospec=True)
+def test_process_perma_payments_transmission_expired_timestamp(decrypt, unstringify, timestamp, spoof_perma_payments_post):
+    post = spoof_perma_payments_post
+    unstringify_data.return_value = post['encrypted_data']
+    timestamp.return_value = False
+    with pytest.raises(InvalidTransmissionException) as excinfo:
+        process_perma_payments_transmission(post, [])
+    assert 'Expired timestamp in data.' in str(excinfo.value)
 
 
-    # perma-payments helpers
+@patch('perma.utils.is_valid_timestamp', autospec=True)
+@patch('perma.utils.unstringify_data', autospec=True)
+@patch('perma.utils.decrypt_from_perma_payments', autospec=True)
+def test_process_perma_payments_transmission_happy_path(decrypt, unstringify, timestamp, spoof_perma_payments_post):
+    post = spoof_perma_payments_post
+    decrypt.return_value = sentinel.decrypted
+    unstringify.return_value = post['encrypted_data']
+    timestamp.return_value = True
 
-    def test_retrieve_fields_returns_only_specified_fields(self):
-        one_two_three = one_two_three_dict()
-        assert retrieve_fields(one_two_three, ['one']) == {'one': 'one'}
-        assert retrieve_fields(one_two_three, ['two']) == {'two': 'two'}
-        assert retrieve_fields(one_two_three, ['one', 'three']) == {'one': 'one', 'three': 'three'}
+    assert process_perma_payments_transmission(post, ['desired_field']) == {'desired_field': 'desired_field'}
 
+    decrypt.assert_called_once_with(post['encrypted_data'])
+    unstringify.assert_called_once_with(sentinel.decrypted)
+    timestamp.assert_called_once_with(post['encrypted_data']['timestamp'], settings.PERMA_PAYMENTS_TIMESTAMP_MAX_AGE_SECONDS)
 
-    def test_retrieve_fields_raises_if_field_absent(self):
-        one_two_three = one_two_three_dict()
-        with self.assertRaises(InvalidTransmissionException):
-            retrieve_fields(one_two_three, ['four'])
+#
+# perma-payments helpers
+#
 
-
-    def test_is_valid_timestamp(self):
-        max_age = 60
-        now = datetime.utcnow().timestamp()
-        still_valid = (datetime.utcnow() + timedelta(seconds=max_age)).timestamp()
-        invalid = (datetime.utcnow() + timedelta(seconds=max_age * 2)).timestamp()
-        self.assertTrue(is_valid_timestamp(now, max_age))
-        self.assertTrue(is_valid_timestamp(still_valid, max_age))
-        self.assertFalse(is_valid_timestamp(invalid, max_age))
-
-
-    preserved = text(alphabet=characters(min_codepoint=1, blacklist_categories=('Cc', 'Cs'))) | integers() | booleans()
-    @given(preserved | dictionaries(keys=text(alphabet=characters(min_codepoint=1, blacklist_categories=('Cc', 'Cs'))), values=preserved))
-    def test_stringify_and_unstringify_data_types_preserved(self, data):
-        assert unstringify_data(stringify_data(data)) == data
+def test_retrieve_fields_returns_only_specified_fields(one_two_three_dict):
+    assert retrieve_fields(one_two_three_dict, ['one']) == {'one': 'one'}
+    assert retrieve_fields(one_two_three_dict, ['two']) == {'two': 'two'}
+    assert retrieve_fields(one_two_three_dict, ['one', 'three']) == {'one': 'one', 'three': 'three'}
 
 
-    oneway = decimals(places=2, min_value=decimal.Decimal(0.00), allow_nan=False, allow_infinity=False) | datetimes() | dates() | uuids()
-    @given(oneway | dictionaries(keys=text(alphabet=characters(min_codepoint=1, blacklist_categories=('Cc', 'Cs'))), values=oneway))
-    def test_stringify_types_lost(self, data):
-        # Some types can be serialized, but not recovered from strings by json.loads.
-        # Instead, you have to manually attempt to convert, by field, if you are expecting one of these types.
-        #
-        # If something can't be serialized, or unserialized,
-        # this test will raise an Exception, rather than failing with an assertion error.
-        unstringify_data(stringify_data(data))
+def test_retrieve_fields_raises_if_field_absent(one_two_three_dict):
+    with pytest.raises(InvalidTransmissionException):
+        retrieve_fields(one_two_three_dict, ['four'])
 
 
-    @given(binary())
-    def test_perma_payments_encrypt_and_decrypt(self, b):
-        ci = encrypt_for_perma_payments(b)
-        assert decrypt_from_perma_payments(ci) == b
+def test_is_valid_timestamp():
+    max_age = 60
+    now = datetime.utcnow().timestamp()
+    still_valid = (datetime.utcnow() + timedelta(seconds=max_age)).timestamp()
+    invalid = (datetime.utcnow() + timedelta(seconds=max_age * 2)).timestamp()
+    assert is_valid_timestamp(now, max_age)
+    assert is_valid_timestamp(still_valid, max_age)
+    assert not is_valid_timestamp(invalid, max_age)
+
+
+preserved = text(alphabet=characters(min_codepoint=1, blacklist_categories=('Cc', 'Cs'))) | integers() | booleans()
+@given(preserved | dictionaries(keys=text(alphabet=characters(min_codepoint=1, blacklist_categories=('Cc', 'Cs'))), values=preserved))
+def test_stringify_and_unstringify_data_types_preserved(data):
+    assert unstringify_data(stringify_data(data)) == data
+
+
+oneway = decimals(places=2, min_value=decimal.Decimal(0.00), allow_nan=False, allow_infinity=False) | datetimes() | dates() | uuids()
+@given(oneway | dictionaries(keys=text(alphabet=characters(min_codepoint=1, blacklist_categories=('Cc', 'Cs'))), values=oneway))
+def test_stringify_types_lost(data):
+    # Some types can be serialized, but not recovered from strings by json.loads.
+    # Instead, you have to manually attempt to convert, by field, if you are expecting one of these types.
+    #
+    # If something can't be serialized, or unserialized,
+    # this test will raise an Exception, rather than failing with an assertion error.
+    unstringify_data(stringify_data(data))
+
+
+@given(binary())
+def test_perma_payments_encrypt_and_decrypt(b):
+    ci = encrypt_for_perma_payments(b)
+    assert decrypt_from_perma_payments(ci) == b
 


### PR DESCRIPTION
In #3415, I began refactoring our python test suite to:

a) use pytest fixtures powered by factory boy instead of our [json fixtures](https://github.com/harvard-lil/perma/tree/develop/perma_web/fixtures)

b) use standard pytest syntax instead of the older [unittest-style syntax](https://docs.pytest.org/en/7.1.x/how-to/unittest.html)

This PR continues the effort, picking off some more of the easier-to-convert modules.

The entirety of `test_email`, `test_utils`, `test_cloudflare_cache`, `test_celery_tasks`, and `test_urls` are converted to pytest syntax, and are _mostly_ (but not entirely) updated to use pytest fixtures: I kicked the can in a couple places on the more complex ones, figuring they will be easier once we have a richer library of pytest fixtures prepared.

A big chunk of `test_models` is also converted and switched over to pytest fixtures. There is still lots to do, but I think this PR converted every test that involves Perma Payments. @kilbergr is going to take the lead on coverting the rest of that file, in a series of upcoming PRs 🙏 🙌.

The diffs are, again, hard to read, but: none of the tests are materially changed: all the same assertions are made, etc. The only thing that has been changed is syntax.