### PR TITLE
Track playwright errors

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -329,6 +329,7 @@ def capture_with_scoop(capture_job):
             didnt_load = "ERROR Navigation to page failed (about:blank)"
             proxy_error = "ERROR An error occurred during capture setup"
             blocklist_error = "TypeError: Cannot read properties of undefined (reading 'match')"
+            playwright_error = "${arg.guid} was not bound in the connection"
             if poll_data['stderr_logs'] and didnt_load in poll_data['stderr_logs']:
                 logger.warning(f"{capture_job.link_id}: Scoop failed to load submitted URL ({capture_job.submitted_url}).")
                 capture_job.link.tags.add('scoop-load-failure')
@@ -338,6 +339,9 @@ def capture_with_scoop(capture_job):
             elif poll_data['stderr_logs'] and blocklist_error in poll_data['stderr_logs']:
                 logger.warning(f"{capture_job.link_id}: Scoop failed while checking the blocklist.")
                 capture_job.link.tags.add('scoop-blocklist-failure')
+            elif poll_data['stderr_logs'] and playwright_error in poll_data['stderr_logs']:
+                logger.warning(f"{capture_job.link_id}: Scoop failed with a Playwright error.")
+                capture_job.link.tags.add('scoop-playwright-failure')
             elif not poll_data['stderr_logs'] and not poll_data['stdout_logs']:
                 logger.warning(f"{capture_job.link_id}: Scoop failed without logs ({poll_data['id_capture']}).")
                 capture_job.link.tags.add('scoop-silent-failure')

--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -359,6 +359,7 @@
             <dt>Killed by Celery:</dt><dd>{{ this.last_hour.celery_timeout }}  ({{ this.last_hour.celery_timeout_percent}}%)</dd>
             <dt>Proxy error:</dt><dd>{{ this.last_hour.proxy_error }}  ({{ this.last_hour.proxy_error_percent}}%)</dd>
             <dt>Blocklist error:</dt><dd>{{ this.last_hour.blocklist_error }}  ({{ this.last_hour.blocklist_error_percent}}%)</dd>
+            <dt>Playwright error:</dt><dd>{{ this.last_hour.playwright_error }}  ({{ this.last_hour.playwright_error_percent}}%)</dd>
             <dt>Scoop timeout:</dt><dd>{{ this.last_hour.timeout }}  ({{ this.last_hour.timeout_percent}}%)</dd>
             <dt>URL didn't load:</dt><dd>{{ this.last_hour.didnt_load }}  ({{ this.last_hour.didnt_load_percent}}%)</dd>
           </dl>
@@ -372,6 +373,7 @@
             <dt>Killed by Celery:</dt><dd>{{ this.last_3_hrs.celery_timeout }}  ({{ this.last_3_hrs.celery_timeout_percent}}%)</dd>
             <dt>Proxy error:</dt><dd>{{ this.last_3_hrs.proxy_error }}  ({{ this.last_3_hrs.proxy_error_percent}}%)</dd>
             <dt>Blocklist error:</dt><dd>{{ this.last_3_hrs.blocklist_error }}  ({{ this.last_3_hrs.blocklist_error_percent}}%)</dd>
+            <dt>Playwright error:</dt><dd>{{ this.last_3_hrs.playwright_error }}  ({{ this.last_3_hrs.playwright_error_percent}}%)</dd>
             <dt>Scoop timeout:</dt><dd>{{ this.last_3_hrs.timeout }}  ({{ this.last_3_hrs.timeout_percent}}%)</dd>
             <dt>URL didn't load:</dt><dd>{{ this.last_3_hrs.didnt_load }}  ({{ this.last_3_hrs.didnt_load_percent}}%)</dd>
           </dl>
@@ -385,6 +387,7 @@
             <dt>Killed by Celery:</dt><dd>{{ this.last_24_hrs.celery_timeout }}  ({{ this.last_24_hrs.celery_timeout_percent}}%)</dd>
             <dt>Proxy error:</dt><dd>{{ this.last_24_hrs.proxy_error }}  ({{ this.last_24_hrs.proxy_error_percent}}%)</dd>
             <dt>Blocklist error:</dt><dd>{{ this.last_24_hrs.blocklist_error }}  ({{ this.last_24_hrs.blocklist_error_percent}}%)</dd>
+            <dt>Playwright error:</dt><dd>{{ this.last_24_hrs.playwright_error }}  ({{ this.last_24_hrs.playwright_error_percent}}%)</dd>
             <dt>Scoop timeout:</dt><dd>{{ this.last_24_hrs.timeout }}  ({{ this.last_24_hrs.timeout_percent}}%)</dd>
             <dt>URL didn't load:</dt><dd>{{ this.last_24_hrs.didnt_load }}  ({{ this.last_24_hrs.didnt_load_percent}}%)</dd>
           </dl>
@@ -401,6 +404,7 @@
             <dt>Killed by Celery:</dt><dd>{{ this.last_hour_on_previous_day.celery_timeout }}  ({{ this.last_hour_on_previous_day.celery_timeout_percent}}%)</dd>
             <dt>Proxy error:</dt><dd>{{ this.last_hour_on_previous_day.proxy_error }}  ({{ this.last_hour_on_previous_day.proxy_error_percent}}%)</dd>
             <dt>Blocklist error:</dt><dd>{{ this.last_hour_on_previous_day.blocklist_error }}  ({{ this.last_hour_on_previous_day.blocklist_error_percent}}%)</dd>
+            <dt>Playwright error:</dt><dd>{{ this.last_hour_on_previous_day.playwright_error }}  ({{ this.last_hour_on_previous_day.playwright_error_percent}}%)</dd>
             <dt>Scoop timeout:</dt><dd>{{ this.last_hour_on_previous_day.timeout }}  ({{ this.last_hour_on_previous_day.timeout_percent}}%)</dd>
             <dt>URL didn't load:</dt><dd>{{ this.last_hour_on_previous_day.didnt_load }}  ({{ this.last_hour_on_previous_day.didnt_load_percent}}%)</dd>
           </dl>
@@ -414,6 +418,7 @@
             <dt>Killed by Celery:</dt><dd>{{ this.last_3_hrs_on_previous_day.celery_timeout }}  ({{ this.last_3_hrs_on_previous_day.celery_timeout_percent}}%)</dd>
             <dt>Proxy error:</dt><dd>{{ this.last_3_hrs_on_previous_day.proxy_error }}  ({{ this.last_3_hrs_on_previous_day.proxy_error_percent}}%)</dd>
             <dt>Blocklist error:</dt><dd>{{ this.last_3_hrs_on_previous_day.blocklist_error }}  ({{ this.last_3_hrs_on_previous_day.blocklist_error_percent}}%)</dd>
+            <dt>Playwright error:</dt><dd>{{ this.last_3_hrs_on_previous_day.playwright_error }}  ({{ this.last_3_hrs_on_previous_day.playwright_error_percent}}%)</dd>
             <dt>Scoop timeout:</dt><dd>{{ this.last_3_hrs_on_previous_day.timeout }}  ({{ this.last_3_hrs_on_previous_day.timeout_percent}}%)</dd>
             <dt>URL didn't load:</dt><dd>{{ this.last_3_hrs_on_previous_day.didnt_load }}  ({{ this.last_3_hrs_on_previous_day.didnt_load_percent}}%)</dd>
           </dl>
@@ -428,6 +433,7 @@
             <dt>Killed by Celery:</dt><dd>{{ this.previous_24_hrs.celery_timeout }}  ({{ this.previous_24_hrs.celery_timeout_percent}}%)</dd>
             <dt>Proxy error:</dt><dd>{{ this.previous_24_hrs.proxy_error }}  ({{ this.previous_24_hrs.proxy_error_percent}}%)</dd>
             <dt>Blocklist error:</dt><dd>{{ this.previous_24_hrs.blocklist_error }}  ({{ this.previous_24_hrs.blocklist_error_percent}}%)</dd>
+            <dt>Playwright error:</dt><dd>{{ this.previous_24_hrs.playwright_error }}  ({{ this.previous_24_hrs.playwright_error_percent}}%)</dd>
             <dt>Scoop timeout:</dt><dd>{{ this.previous_24_hrs.timeout }}  ({{ this.previous_24_hrs.timeout_percent}}%)</dd>
             <dt>URL didn't load:</dt><dd>{{ this.previous_24_hrs.didnt_load }}  ({{ this.previous_24_hrs.didnt_load_percent}}%)</dd>
           </dl>

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -322,6 +322,11 @@ def stats(request, stat_type=None):
                     creation_timestamp__range=range_tuple
                 ).count()
 
+                playwright_error = Link.objects.all_with_deleted().filter(
+                    tags__name__in=['scoop-playwright-failure'],
+                    creation_timestamp__range=range_tuple
+                ).count()
+
                 timeout = Link.objects.all_with_deleted().filter(
                     tags__name__in=['scoop-silent-failure'],
                     creation_timestamp__range=range_tuple
@@ -343,6 +348,8 @@ def stats(request, stat_type=None):
                     "proxy_error_percent": round(proxy_error/denominator * 100, 1),
                     "blocklist_error": blocklist_error,
                     "blocklist_error_percent": round(blocklist_error/denominator * 100, 1),
+                    "playwright_error": playwright_error,
+                    "playwright_error_percent": round(playwright_error/denominator * 100, 1),
                     "timeout": timeout,
                     "timeout_percent": round(timeout/denominator * 100, 1),
                     "didnt_load": didnt_load,
@@ -362,6 +369,8 @@ def stats(request, stat_type=None):
                     "proxy_error_percent": 0,
                     "blocklist_error": 0,
                     "blocklist_error_percent": 0,
+                    "playwright_error": 0,
+                    "playwright_error_percent": 0,
                     "timeout": 0,
                     "timeout_percent": 0,
                     "didnt_load": 0,


### PR DESCRIPTION
See ENG-490.

We're sporadically seeing a particular error message from Playwright during Scoop captures: not frequently enough to be a cause for concern, but frequently enough that I'd like to count their occurrence, rather than considering them anomalous.

This PR adds that to the list of routine errors we are tracking this way. 