### PR TITLE
Remove unused utilities.

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -70,7 +70,8 @@ Press `CONTROL-C` to stop the server.
 
 ### Run the tests
 
-`d invoke test`
+`d pytest`
+`d npm test`
 
 See [Testing and Test Coverage](#testing-and-test-coverage) for more
 information about testing Perma.
@@ -102,9 +103,14 @@ To upgrade a single requirement to the latest version:
 
 ### Update the node dependencies
 
-Make your changes in `packages.json`. Then run `update.sh`, a convenience
-script that will create a new `npm-shrinkwrap.json` and will rebuild the
-Docker image with the new dependencies installed.
+Install new packages: `d npm install --save-dev package_name`
+Uninstall new packages: `d npm uninstall package_name`
+
+Update a single package:
+- if necessary, change the pinned version in package.json
+- `d npm update package_name`
+
+Update all dependencies: ``
 
 ### Migrate the database
 
@@ -292,8 +298,6 @@ Javascript tests live in `spec/`.
 
 See the [Common tasks and commands](#common-tasks-and-commands) for the
 common techniques for running the tests.
-
-The `d invoke test` command also generates handy coverage information. You can access it by running `d coverage report`.
 
 
 ### Linting with flake8

--- a/perma_web/tasks/__init__.py
+++ b/perma_web/tasks/__init__.py
@@ -12,11 +12,10 @@ except Exception as e:
     print(f"WARNING: Can't configure Django. {e}")
 
 # import sub-tasks
-from .dev import run, test, pip_compile
+from .dev import run, pip_compile
 from . import dev
 
 ns = Collection()
 ns.add_task(run)
-ns.add_task(test)
 ns.add_task(pip_compile)
 ns.add_collection(dev)

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -72,32 +72,6 @@ def run(ctx, port="0.0.0.0:8000", cert_file='perma-test.crt', key_file='perma-te
                 os.kill(proc.pid, signal.SIGKILL)
 
 
-_default_tests = "functional_tests perma api lockss"
-
-@task
-def test(ctx, apps=_default_tests):
-    """ Run perma tests. (For coverage, run `coverage report` after tests pass.) """
-    test_python(ctx, apps)
-    if apps == _default_tests:
-        test_js(ctx)
-
-@task
-def test_python(ctx, apps=_default_tests):
-    """ Run Python tests. """
-
-    # In order to run functional_tests, we have to run collectstatic, since functional tests use DEBUG=False
-    # For speed we use the default Django STATICFILES_STORAGE setting here, which also has to be set in settings_testing.py
-    if "functional_tests" in apps:
-        ctx.run("DJANGO__STATICFILES_STORAGE=django.contrib.staticfiles.storage.StaticFilesStorage python manage.py collectstatic --noinput")
-
-    ctx.run(f"pytest {apps} --ds=perma.settings.deployments.settings_testing --cov --cov-config=setup.cfg --cov-report= ")
-
-@task
-def test_js(ctx):
-    """ Run Javascript tests. """
-    ctx.run("npm test")
-
-
 @task
 def pip_compile(ctx, args=''):
     # run pip-compile

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-docker-compose exec web npm shrinkwrap --dev
-docker-compose exec web invoke pip-compile
-docker-compose up -d --build
-printf "\n\nYour image has been updated."


### PR DESCRIPTION
We haven't been using these "convenience methods" or this convenience script for a while. Rather than update them to match current dev flows, I think it's better to just remove them.