### PR TITLE
Resolve python warnings during tests

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -158,7 +158,7 @@ def logged_in_user(page, urls, user):
 # The separation should make it easier to work out, going forward, what can be deleted.
 
 import factory
-from factory.django import DjangoModelFactory
+from factory.django import DjangoModelFactory, Password
 import humps
 
 from decimal import Decimal
@@ -268,7 +268,7 @@ class LinkUserFactory(DjangoModelFactory):
     is_active = True
     is_confirmed = True
 
-    password = factory.PostGenerationMethodCall('set_password', 'pass')
+    password = Password('pass')
 
 
 @register_factory
@@ -291,6 +291,7 @@ class CaptureJobFactory(DjangoModelFactory):
     class Meta:
         model = CaptureJob
         exclude = ('create_link',)
+        skip_postgeneration_save=True
 
     created_by = factory.SubFactory(LinkUserFactory)
     submitted_url = factory.Faker('url')
@@ -307,6 +308,8 @@ class CaptureJobFactory(DjangoModelFactory):
         ),
         no_declaration=None
     )
+    # Required to update CaptureJob.link_id from None, after the Link is generated
+    _ = factory.PostGenerationMethodCall("save")
 
 
 @register_factory

--- a/perma_web/npm-shrinkwrap.json
+++ b/perma_web/npm-shrinkwrap.json
@@ -5292,10 +5292,46 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
+      "dev": true
+    },
+    "lodash.frompairs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
+      "integrity": "sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
+    "lodash.topairs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+      "integrity": "sha512-qrRMbykBSEGdOgQLJJqVSdPWMD7Q+GJJ5jMRfQYb+LTLsw3tYVIabnCzRqTJb2WTo17PG5gNzXuFaZgYH/9SAQ==",
       "dev": true
     },
     "log4js": {
@@ -9500,39 +9536,18 @@
       }
     },
     "webpack-bundle-tracker": {
-      "version": "0.0.93",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-0.0.93.tgz",
-      "integrity": "sha512-t5XQFj4C4N6SZbIorsDXwRow16kNkEIJa6H5RtNpnSJTnMOkFgDJ7dgowObzkXABGG52guoLKvlmfMe0i7o7+g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-tracker/-/webpack-bundle-tracker-1.8.1.tgz",
+      "integrity": "sha512-X1qtXG4ue92gjWQO2VhLVq8HDEf9GzUWE0OQyAQObVEZsFB1SUtSQ7o47agF5WZIaHfJUTKak4jEErU0gzoPcQ==",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "strip-ansi": "^2.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-          "integrity": "sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "strip-ansi": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-          "integrity": "sha512-2h8q2CP3EeOhDJ+jd932PRMpa3/pOJFGoF22J1U/DNbEK2gSW2DqeF46VjCXsSQXhC+k/l8/gaaRBQKL6hUPfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^1.0.0"
-          }
-        }
+        "lodash.assign": "^4.2.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.frompairs": "^4.0.1",
+        "lodash.get": "^4.4.2",
+        "lodash.topairs": "^4.3.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "webpack-cli": {

--- a/perma_web/package.json
+++ b/perma_web/package.json
@@ -55,7 +55,7 @@
     "waypoints": "^4.0.1",
     "webpack": "^4.46.0",
     "webpack-bundle-size-analyzer": "^2.7.0",
-    "webpack-bundle-tracker": "0.0.93",
+    "webpack-bundle-tracker": "^1.8.1",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {

--- a/perma_web/perma/migrations/0017_auto_20230404_1924.py
+++ b/perma_web/perma/migrations/0017_auto_20230404_1924.py
@@ -11,7 +11,7 @@ def backfill_last_login(apps, schema_editor):
     updated = LinkUser.objects.filter(
         is_confirmed=True
     ).exclude(
-        last_login__gt='2023-04-03'
+        last_login__gt='2023-04-03 00:00:00+00:00'
     ).update(
         last_login=Subquery (
             AccessLog.objects.filter(

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -33,7 +33,7 @@ django-settings-context-processor       # make settings available in templates
 
 
 # assets
-django-webpack-loader<1.0.0             # frontend assets building
+django-webpack-loader~=1.0              # frontend assets building
 Pillow                                  # Used by the Django admin for ImageField display
 whitenoise                              # serve static assets
 

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -307,9 +307,9 @@ django-taggit==2.1.0 \
     --hash=sha256:61547a23fc99967c9304107414a09e662b459f4163dbbae32e60b8ba40c34d05 \
     --hash=sha256:a9f41e4ad58efe4b28d86f274728ee87eb98eeae90c9eb4b4efad39e5068184e
     # via -r requirements.in
-django-webpack-loader==0.7.0 \
-    --hash=sha256:7a3c88201aa54481f9399465615cbe7b9aece8081496a6d0287b7cb8e232f447 \
-    --hash=sha256:d28a276ed3d89e97a313b74967e373693f8b86afe629f4c91eea91c5b4f2ec20
+django-webpack-loader==1.8.1 \
+    --hash=sha256:073beda18e2929fa5cd83bafbcaaf975e5945e84a17bfa81927cb6c9f5a17b94 \
+    --hash=sha256:2d50a902256cf94bdd87eac3e7687989c9aa757a63af21db68773115216cedee
     # via -r requirements.in
 djangorestframework==3.13.1 \
     --hash=sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee \

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -46,13 +46,13 @@ billiard==3.6.4.0 \
     --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
     --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
     # via celery
-boto3==1.21.35 \
-    --hash=sha256:4fb810755bca4696effbeb0c6f792295795fae52e895638038dff53965f3f423 \
-    --hash=sha256:ab6e001ba9de1db986634424abff6c79d938c15d0d2fa3ef95eb0939c120b4f6
+boto3==1.33.11 \
+    --hash=sha256:620f1eb3e18e780be58383b4a4e10db003d2314131190514153996032c8d932d \
+    --hash=sha256:8d54fa3a9290020f9a7f488f9cbe821029de0af05a677751b12973a5f726a5e2
     # via -r requirements.in
-botocore==1.24.35 \
-    --hash=sha256:36b5422d8f0c312983582b8b4b056c98e1fd6121cb0b2ddb1f67e882e1ae6867 \
-    --hash=sha256:734aa598af5d6bc0351e6ecce4a91b0b6ccf245febfd8d4de8425211aada5f36
+botocore==1.33.11 \
+    --hash=sha256:b14b328f902d120de0a09eaa657a9a701c0ceeb711197c2f01ef0523f855086c \
+    --hash=sha256:b46227eb3fa9cfdc8f5a83920ef347e67adea8095830ed265a3373b13b54421f
     # via
     #   boto3
     #   s3transfer
@@ -955,9 +955,9 @@ requests-oauthlib==1.3.1 \
     --hash=sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5 \
     --hash=sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a
     # via msrest
-s3transfer==0.5.2 \
-    --hash=sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971 \
-    --hash=sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed
+s3transfer==0.8.2 \
+    --hash=sha256:368ac6876a9e9ed91f6bc86581e319be08188dc60d50e0d56308ed5765446283 \
+    --hash=sha256:c9e56cbe88b28d8e197cf841f1f0c130f246595e77ae5b5a05b69fe7cb83de76
     # via boto3
 schema==0.7.5 \
     --hash=sha256:f06717112c61895cabc4707752b88716e8420a8819d71404501e114f91043197 \

--- a/perma_web/setup.cfg
+++ b/perma_web/setup.cfg
@@ -14,6 +14,8 @@ DJANGO_SETTINGS_MODULE = perma.settings.deployments.settings_testing
 norecursedirs = node_modules
 python_files = tests.py test_*.py *_tests.py
 addopts = --browser chromium --screenshot only-on-failure --output failed_test_files
+filterwarnings =
+    ignore:Unverified HTTPS request
 
 ## http://coverage.readthedocs.io/en/latest/config.html
 [coverage:run]

--- a/perma_web/webpack-stats.json
+++ b/perma_web/webpack-stats.json
@@ -1,1 +1,233 @@
-{"status":"done","chunks":{"single-link":[{"name":"single-link.css","path":"/perma/perma_web/static/bundles/single-link.css"},{"name":"single-link.js","path":"/perma/perma_web/static/bundles/single-link.js"},{"name":"single-link.css.map","path":"/perma/perma_web/static/bundles/single-link.css.map"},{"name":"single-link.js.map","path":"/perma/perma_web/static/bundles/single-link.js.map"}],"global":[{"name":"global.css","path":"/perma/perma_web/static/bundles/global.css"},{"name":"global.js","path":"/perma/perma_web/static/bundles/global.js"},{"name":"global.css.map","path":"/perma/perma_web/static/bundles/global.css.map"},{"name":"global.js.map","path":"/perma/perma_web/static/bundles/global.js.map"}],"create":[{"name":"create.css","path":"/perma/perma_web/static/bundles/create.css"},{"name":"create.js","path":"/perma/perma_web/static/bundles/create.js"},{"name":"create.css.map","path":"/perma/perma_web/static/bundles/create.css.map"},{"name":"create.js.map","path":"/perma/perma_web/static/bundles/create.js.map"}],"single-link-permissions":[{"name":"single-link-permissions.js","path":"/perma/perma_web/static/bundles/single-link-permissions.js"},{"name":"single-link-permissions.js.map","path":"/perma/perma_web/static/bundles/single-link-permissions.js.map"}],"admin-stats":[{"name":"admin-stats.js","path":"/perma/perma_web/static/bundles/admin-stats.js"},{"name":"admin-stats.js.map","path":"/perma/perma_web/static/bundles/admin-stats.js.map"}],"stats":[{"name":"stats.js","path":"/perma/perma_web/static/bundles/stats.js"},{"name":"stats.js.map","path":"/perma/perma_web/static/bundles/stats.js.map"}],"link-delete-confirm":[{"name":"link-delete-confirm.js","path":"/perma/perma_web/static/bundles/link-delete-confirm.js"},{"name":"link-delete-confirm.js.map","path":"/perma/perma_web/static/bundles/link-delete-confirm.js.map"}],"developer-docs":[{"name":"developer-docs.js","path":"/perma/perma_web/static/bundles/developer-docs.js"},{"name":"developer-docs.js.map","path":"/perma/perma_web/static/bundles/developer-docs.js.map"}]}}
+{
+  "status": "done",
+  "assets": {
+    "202a3a988ec9ee1ad746dfe980d65f26.ttf": {
+      "name": "202a3a988ec9ee1ad746dfe980d65f26.ttf",
+      "path": "/perma/perma_web/static/bundles/202a3a988ec9ee1ad746dfe980d65f26.ttf"
+    },
+    "21f212f94a9db6a0e3847c921842aa19.woff": {
+      "name": "21f212f94a9db6a0e3847c921842aa19.woff",
+      "path": "/perma/perma_web/static/bundles/21f212f94a9db6a0e3847c921842aa19.woff"
+    },
+    "235f8246df251c957a93cbdb54db932c.woff": {
+      "name": "235f8246df251c957a93cbdb54db932c.woff",
+      "path": "/perma/perma_web/static/bundles/235f8246df251c957a93cbdb54db932c.woff"
+    },
+    "257ba5031d03546f934e2a7709415bc3.gif": {
+      "name": "257ba5031d03546f934e2a7709415bc3.gif",
+      "path": "/perma/perma_web/static/bundles/257ba5031d03546f934e2a7709415bc3.gif"
+    },
+    "3026bd48214ed3e515b42d48539e0d21.ttf": {
+      "name": "3026bd48214ed3e515b42d48539e0d21.ttf",
+      "path": "/perma/perma_web/static/bundles/3026bd48214ed3e515b42d48539e0d21.ttf"
+    },
+    "30799efa5bf74129468ad4e257551dc3.eot": {
+      "name": "30799efa5bf74129468ad4e257551dc3.eot",
+      "path": "/perma/perma_web/static/bundles/30799efa5bf74129468ad4e257551dc3.eot"
+    },
+    "3dcc0e0f2287e2e955cd8ce8cb08dae0.ttf": {
+      "name": "3dcc0e0f2287e2e955cd8ce8cb08dae0.ttf",
+      "path": "/perma/perma_web/static/bundles/3dcc0e0f2287e2e955cd8ce8cb08dae0.ttf"
+    },
+    "3e5675c89f974f7811eeaf07e2dd5ba3.woff": {
+      "name": "3e5675c89f974f7811eeaf07e2dd5ba3.woff",
+      "path": "/perma/perma_web/static/bundles/3e5675c89f974f7811eeaf07e2dd5ba3.woff"
+    },
+    "3fb7ee3c46a4737ced31105b89e87f0c.eot": {
+      "name": "3fb7ee3c46a4737ced31105b89e87f0c.eot",
+      "path": "/perma/perma_web/static/bundles/3fb7ee3c46a4737ced31105b89e87f0c.eot"
+    },
+    "455808250694e5760bd92b3ce1f070b6.eot": {
+      "name": "455808250694e5760bd92b3ce1f070b6.eot",
+      "path": "/perma/perma_web/static/bundles/455808250694e5760bd92b3ce1f070b6.eot"
+    },
+    "687bde86935596544d81d404d2873e5d.gif": {
+      "name": "687bde86935596544d81d404d2873e5d.gif",
+      "path": "/perma/perma_web/static/bundles/687bde86935596544d81d404d2873e5d.gif"
+    },
+    "7f1320f7ec4f6716054d88c33235d17b.ttf": {
+      "name": "7f1320f7ec4f6716054d88c33235d17b.ttf",
+      "path": "/perma/perma_web/static/bundles/7f1320f7ec4f6716054d88c33235d17b.ttf"
+    },
+    "816d43bc217485bc52e309cd1b356880.woff": {
+      "name": "816d43bc217485bc52e309cd1b356880.woff",
+      "path": "/perma/perma_web/static/bundles/816d43bc217485bc52e309cd1b356880.woff"
+    },
+    "8b18d65d6824460ad37616723e493bcd.woff": {
+      "name": "8b18d65d6824460ad37616723e493bcd.woff",
+      "path": "/perma/perma_web/static/bundles/8b18d65d6824460ad37616723e493bcd.woff"
+    },
+    "8f9468b527d9941c6ff680a1187f720a.gif": {
+      "name": "8f9468b527d9941c6ff680a1187f720a.gif",
+      "path": "/perma/perma_web/static/bundles/8f9468b527d9941c6ff680a1187f720a.gif"
+    },
+    "901074e1322592fd0b82687d09602c9a.woff": {
+      "name": "901074e1322592fd0b82687d09602c9a.woff",
+      "path": "/perma/perma_web/static/bundles/901074e1322592fd0b82687d09602c9a.woff"
+    },
+    "94e202340e24b2cfe027ea6d3d93c35e.eot": {
+      "name": "94e202340e24b2cfe027ea6d3d93c35e.eot",
+      "path": "/perma/perma_web/static/bundles/94e202340e24b2cfe027ea6d3d93c35e.eot"
+    },
+    "a990f611f2305dc12965f186c2ef2690.eot": {
+      "name": "a990f611f2305dc12965f186c2ef2690.eot",
+      "path": "/perma/perma_web/static/bundles/a990f611f2305dc12965f186c2ef2690.eot"
+    },
+    "admin-stats.js": {
+      "name": "admin-stats.js",
+      "path": "/perma/perma_web/static/bundles/admin-stats.js"
+    },
+    "admin-stats.js.map": {
+      "name": "admin-stats.js.map",
+      "path": "/perma/perma_web/static/bundles/admin-stats.js.map"
+    },
+    "bb72c5142ae2ae4ca0f9c0653a09871c.ttf": {
+      "name": "bb72c5142ae2ae4ca0f9c0653a09871c.ttf",
+      "path": "/perma/perma_web/static/bundles/bb72c5142ae2ae4ca0f9c0653a09871c.ttf"
+    },
+    "c4c42ad89a06874362de0ca8909f101c.ttf": {
+      "name": "c4c42ad89a06874362de0ca8909f101c.ttf",
+      "path": "/perma/perma_web/static/bundles/c4c42ad89a06874362de0ca8909f101c.ttf"
+    },
+    "cb3625efa7f7697e0609b1ee54353306.eot": {
+      "name": "cb3625efa7f7697e0609b1ee54353306.eot",
+      "path": "/perma/perma_web/static/bundles/cb3625efa7f7697e0609b1ee54353306.eot"
+    },
+    "create.css": {
+      "name": "create.css",
+      "path": "/perma/perma_web/static/bundles/create.css"
+    },
+    "create.css.map": {
+      "name": "create.css.map",
+      "path": "/perma/perma_web/static/bundles/create.css.map"
+    },
+    "create.js": {
+      "name": "create.js",
+      "path": "/perma/perma_web/static/bundles/create.js"
+    },
+    "create.js.map": {
+      "name": "create.js.map",
+      "path": "/perma/perma_web/static/bundles/create.js.map"
+    },
+    "d8472f7b6012706fc028021e5a654843.ttf": {
+      "name": "d8472f7b6012706fc028021e5a654843.ttf",
+      "path": "/perma/perma_web/static/bundles/d8472f7b6012706fc028021e5a654843.ttf"
+    },
+    "developer-docs.js": {
+      "name": "developer-docs.js",
+      "path": "/perma/perma_web/static/bundles/developer-docs.js"
+    },
+    "developer-docs.js.map": {
+      "name": "developer-docs.js.map",
+      "path": "/perma/perma_web/static/bundles/developer-docs.js.map"
+    },
+    "e3b13bf771abea0c964d38193a3f7d74.gif": {
+      "name": "e3b13bf771abea0c964d38193a3f7d74.gif",
+      "path": "/perma/perma_web/static/bundles/e3b13bf771abea0c964d38193a3f7d74.gif"
+    },
+    "ecdd509cadbf1ea78b8d2e31ec52328c.eot": {
+      "name": "ecdd509cadbf1ea78b8d2e31ec52328c.eot",
+      "path": "/perma/perma_web/static/bundles/ecdd509cadbf1ea78b8d2e31ec52328c.eot"
+    },
+    "fc6efd02434e00d50e3eb6ae2bf253b0.woff": {
+      "name": "fc6efd02434e00d50e3eb6ae2bf253b0.woff",
+      "path": "/perma/perma_web/static/bundles/fc6efd02434e00d50e3eb6ae2bf253b0.woff"
+    },
+    "global.css": {
+      "name": "global.css",
+      "path": "/perma/perma_web/static/bundles/global.css"
+    },
+    "global.css.map": {
+      "name": "global.css.map",
+      "path": "/perma/perma_web/static/bundles/global.css.map"
+    },
+    "global.js": {
+      "name": "global.js",
+      "path": "/perma/perma_web/static/bundles/global.js"
+    },
+    "global.js.map": {
+      "name": "global.js.map",
+      "path": "/perma/perma_web/static/bundles/global.js.map"
+    },
+    "link-delete-confirm.js": {
+      "name": "link-delete-confirm.js",
+      "path": "/perma/perma_web/static/bundles/link-delete-confirm.js"
+    },
+    "link-delete-confirm.js.map": {
+      "name": "link-delete-confirm.js.map",
+      "path": "/perma/perma_web/static/bundles/link-delete-confirm.js.map"
+    },
+    "single-link-permissions.js": {
+      "name": "single-link-permissions.js",
+      "path": "/perma/perma_web/static/bundles/single-link-permissions.js"
+    },
+    "single-link-permissions.js.map": {
+      "name": "single-link-permissions.js.map",
+      "path": "/perma/perma_web/static/bundles/single-link-permissions.js.map"
+    },
+    "single-link.css": {
+      "name": "single-link.css",
+      "path": "/perma/perma_web/static/bundles/single-link.css"
+    },
+    "single-link.css.map": {
+      "name": "single-link.css.map",
+      "path": "/perma/perma_web/static/bundles/single-link.css.map"
+    },
+    "single-link.js": {
+      "name": "single-link.js",
+      "path": "/perma/perma_web/static/bundles/single-link.js"
+    },
+    "single-link.js.map": {
+      "name": "single-link.js.map",
+      "path": "/perma/perma_web/static/bundles/single-link.js.map"
+    },
+    "stats.js": {
+      "name": "stats.js",
+      "path": "/perma/perma_web/static/bundles/stats.js"
+    },
+    "stats.js.map": {
+      "name": "stats.js.map",
+      "path": "/perma/perma_web/static/bundles/stats.js.map"
+    }
+  },
+  "chunks": {
+    "admin-stats": [
+      "admin-stats.js",
+      "admin-stats.js.map"
+    ],
+    "create": [
+      "create.css",
+      "create.js",
+      "create.css.map",
+      "create.js.map"
+    ],
+    "developer-docs": [
+      "developer-docs.js",
+      "developer-docs.js.map"
+    ],
+    "global": [
+      "global.css",
+      "global.js",
+      "global.css.map",
+      "global.js.map"
+    ],
+    "link-delete-confirm": [
+      "link-delete-confirm.js",
+      "link-delete-confirm.js.map"
+    ],
+    "single-link": [
+      "single-link.css",
+      "single-link.js",
+      "single-link.css.map",
+      "single-link.js.map"
+    ],
+    "single-link-permissions": [
+      "single-link-permissions.js",
+      "single-link-permissions.js.map"
+    ],
+    "stats": [
+      "stats.js",
+      "stats.js.map"
+    ]
+  }
+}


### PR DESCRIPTION
I noticed that pytest was reporting a lot of warnings:

![image](https://github.com/harvard-lil/perma/assets/11020492/1d36db27-80c8-46ff-96c8-8b50cd18c7d0)

It turns out that fixing them was no big deal: just a few tweaks and package upgrades. 

There's only one left unresolved, a deprecation warning about a line in `warctools`, which we are still using to produce upload-your-own warcs:

![image](https://github.com/harvard-lil/perma/assets/11020492/cdaa39f3-97f4-412f-af13-53a30adfccdf)

That library is not under active development; if it becomes a problem before we switch to WACZ, we can figure out what we want to do. But in the meantime, I'm leaving it. 