### PR TITLE
Rek sponsored links test

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -167,7 +167,7 @@ from dateutil.relativedelta import relativedelta
 from django.db.models import signals
 from django.utils import timezone
 
-from perma.models import Registrar, Organization, LinkUser, Link, CaptureJob
+from perma.models import Registrar, Organization, LinkUser, Link, CaptureJob, Sponsorship
 from perma.utils import pp_date_from_post
 
 
@@ -269,6 +269,36 @@ class LinkUserFactory(DjangoModelFactory):
     is_confirmed = True
 
     password = factory.PostGenerationMethodCall('set_password', 'pass')
+
+
+@register_factory
+class RegistrarUserFactory(LinkUserFactory):
+    registrar = factory.SubFactory(RegistrarFactory)
+
+
+# SponsorshipFactory has to come after RegistrarUserFactory and LinkUserFactory,
+# and before SponsoredUserFactory
+@register_factory
+class SponsorshipFactory(DjangoModelFactory):
+    class Meta:
+        model = Sponsorship
+
+    user = factory.SubFactory(LinkUserFactory)
+    registrar = factory.SubFactory(RegistrarFactory)
+    created_by = factory.SubFactory(
+        RegistrarUserFactory,
+        registrar=factory.SelfAttribute('..registrar')
+    )
+
+
+@register_factory
+class SponsoredUserFactory(LinkUserFactory):
+
+    sponsorships = factory.RelatedFactoryList(
+        SponsorshipFactory,
+        size=1,
+        factory_related_name='user'
+    )
 
 
 @register_factory

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -387,6 +387,9 @@ class FolderFactory(DjangoModelFactory):
     class Meta:
         model = Folder
 
+
+@register_factory
+class SponsoredFolderFactory(FolderFactory):
     sponsored_by = factory.SubFactory(RegistrarFactory)
 
 ### fixtures for testing customer interactions
@@ -438,13 +441,13 @@ def user_with_links_this_month_before_the_15th(link_user, link_factory):
 
 
 @pytest.fixture
-def complex_user_with_bonus_link(link_user_factory, folder_factory, organization, registrar,
-                                 sponsorship_factory, link_factory, in_subfolder=False):
+def complex_user_with_bonus_link(link_user_factory, folder_factory,
+                                 organization, registrar, sponsorship_factory, link_factory):
     user = link_user_factory(link_limit=2, bonus_links=0)
     user.organizations.add(organization)
-    sponsorship_factory(registrar=registrar, user=user, created_by=user)
-    folder_factory(sponsored_by=registrar, parent=user.top_level_folders()[0], name='Test Library')
-    folder_factory(sponsored_by=None, parent=user.top_level_folders()[0], name='Subfolder')
+    registrar_user = RegistrarUserFactory(registrar=registrar)
+    sponsorship_factory(registrar=registrar, user=user, created_by=registrar_user)
+    folder_factory(parent=user.top_level_folders()[0], name='Subfolder')
     bonus_link = link_factory(created_by=user, bonus_link=True)
     user.refresh_from_db()
     return user, bonus_link

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -12,6 +12,7 @@ from perma.models import (
     ACTIVE_SUBSCRIPTION_STATUSES,
     FIELDS_REQUIRED_FROM_PERMA_PAYMENTS,
     Link, Organization, Registrar, Folder,
+    Sponsorship,
     link_count_in_time_period,
     most_active_org_in_time_period,
     subscription_is_active
@@ -1522,7 +1523,8 @@ def test_move_bonus_link_to_another_personal_subfolder(complex_user_with_bonus_l
 
 def test_move_bonus_link_to_sponsored_folder(complex_user_with_bonus_link):
     user, bonus_link = complex_user_with_bonus_link
-    sponsored_folder = user.folders.get(name="Test Library")
+    sponsorship = Sponsorship.objects.get(user=user)
+    sponsored_folder = Folder.objects.get(name=sponsorship.registrar)
 
     # establish baseline
     links_remaining, _ , bonus_links = user.get_links_remaining()
@@ -1566,7 +1568,8 @@ def test_move_subfolder_with_bonus_links_to_sponsored_folder(complex_user_with_b
     user, bonus_link = complex_user_with_bonus_link
     subfolder = user.folders.get(name="Subfolder")
     bonus_link.move_to_folder_for_user(subfolder, user)
-    sponsored_folder = user.folders.get(name="Test Library")
+    sponsorship = Sponsorship.objects.get(user=user)
+    sponsored_folder = Folder.objects.get(name=sponsorship.registrar)
 
     # establish baseline
     links_remaining, _ , bonus_links = user.get_links_remaining()

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -1459,6 +1459,21 @@ def test_registrar_most_active_org_this_year(registrar, organization_factory, li
     assert registrar.most_active_org_this_year() == o2
 
 
+#
+# Link limit for sponsored users
+#
+
+def test_sponsored_links_not_counted_against_personal_total(sponsored_user, link_factory):
+    breakpoint()
+    assert sponsored_user.get_links_remaining()[0] == 10
+    link = link_factory(creation_timestamp=timezone.now().replace(day=1), guid="AAAA-AAAA", created_by=sponsored_user)
+
+    assert sponsored_user.get_links_remaining()[0] == 9
+    link.move_to_folder_for_user(sponsored_user.sponsorships.first().folders.first(), sponsored_user)
+    assert sponsored_user.get_links_remaining()[0] == 10
+
+
+
 # Fixtures
 
 def complex_user_with_bonus_link(in_subfolder=False):
@@ -1480,19 +1495,6 @@ def complex_user_with_bonus_link(in_subfolder=False):
 # Tests
 
 class ModelsTestCase(PermaTestCase):
-
-    #
-    # Link limit for sponsored users
-    #
-
-    def test_sponsored_links_not_counted_against_personal_total(self):
-        sponsored_user = LinkUser.objects.get(email='test_sponsored_user@example.com')
-        self.assertEqual(sponsored_user.get_links_remaining()[0], 9)
-        link = Link(creation_timestamp=timezone.now().replace(day=1), guid="AAAA-AAAA", created_by=sponsored_user)
-        link.save()
-        self.assertEqual(sponsored_user.get_links_remaining()[0], 8)
-        link.move_to_folder_for_user(sponsored_user.sponsorships.first().folders.first(), sponsored_user)
-        self.assertEqual(sponsored_user.get_links_remaining()[0], 9)
 
 
     #


### PR DESCRIPTION
This makes pytests from unit tests for the remaining models tests that probe the action of moving bonus links around between folders.

I added this line: https://github.com/harvard-lil/perma/pull/3458/files#diff-7647024a9efc6c8bce2a3b02675bfd7410fb12302f16b7c4bd815391088ca407R446 to account for the fact that there was a 'Test Journal' in the JSON test fixtures that was no longer attached to the user.

I added these two lines: https://github.com/harvard-lil/perma/pull/3458/files#diff-fbe1ed0bfd6c4d106680862939ce3882594ac33091fba94e3263812b27bcd52aR1592 and https://github.com/harvard-lil/perma/pull/3458/files#diff-fbe1ed0bfd6c4d106680862939ce3882594ac33091fba94e3263812b27bcd52aR1568 to the test code rather than having it in the fixture to be able to pass the fixture into the test.