### PR TITLE
Add a global feature flag to toggle URL validation strategy

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -264,7 +264,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                     # What might that look like?
                     #
                     # {"valid": False, "message": "Not a valid URL."}
-                    # {"valid": False, "message": ""URL caused a redirect loop."."}
+                    # {"valid": False, "message": "URL caused a redirect loop."}
                     # {"valid": False, "message": "Not a valid URL."}"Couldn't resolve domain."
                     # {"valid": False, "message": "Not a valid IP."}
                     # {"valid": False, "message": "Couldn't load URL."}

--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -230,7 +230,9 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                 errors['url'] = "URL cannot be empty."
             else:
                 if settings.VALIDATE_URL_LOCALLY:
+                    #
                     # Validate the URL using Perma's own logic
+                    #
                     try:
                         validate = URLValidator()
                         temp_link = Link(submitted_url=data['submitted_url'])
@@ -257,7 +259,34 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                     except requests.TooManyRedirects:
                         errors['url'] = "URL caused a redirect loop."
                 else:
+                    #
                     # Delegate validation to the Scoop API
+                    # What might that look like?
+                    #
+                    # {"valid": False, "message": "Not a valid URL."}
+                    # {"valid": False, "message": ""URL caused a redirect loop."."}
+                    # {"valid": False, "message": "Not a valid URL."}"Couldn't resolve domain."
+                    # {"valid": False, "message": "Not a valid IP."}
+                    # {"valid": False, "message": "Couldn't load URL."}
+                    #
+                    # {"valid": True}
+                    # {"valid": True, "content_length": 1000}
+                    #
+                    # try:
+                    #     _, response_data = send_to_scoop(
+                    #         method="get",
+                    #         path="validate",
+                    #         json={"url": target_url},
+                    #         valid_if=lambda code, data: code == 200 and "valid" in data,
+                    #     )
+                    #     if not response_data["valid"]:
+                    #         errors['url'] = response_data["message"]
+                    #     elif content_length := response["data"].get('content_length'):
+                    #         if content_length > settings.MAX_ARCHIVE_FILE_SIZE:
+                    #             errors['url'] = f"Target page is too large (max size {settings.MAX_ARCHIVE_FILE_SIZE / 1024 / 1024}MB)."
+                    # except ScoopAPIException:
+                    #     logger.exception(f"Scoop validation attempt failed.")
+                    #     errors['url'] = "We encountered a network error: please try again."
                     raise NotImplementedError()
 
         # check uploaded file

--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -265,7 +265,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                     #
                     # {"valid": False, "message": "Not a valid URL."}
                     # {"valid": False, "message": "URL caused a redirect loop."}
-                    # {"valid": False, "message": "Not a valid URL."}"Couldn't resolve domain."
+                    # {"valid": False, "message": "Couldn't resolve domain."}
                     # {"valid": False, "message": "Not a valid IP."}
                     # {"valid": False, "message": "Couldn't load URL."}
                     #

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -512,6 +512,7 @@ PLAYBACK_HOST = 'rejouer.perma.test:8080'
 #
 # Capture
 #
+VALIDATE_URL_LOCALLY = True
 CAPTURE_ENGINE = 'scoop-api'  # perma|scoop-api
 PRIVATE_BY_POLICY_DOMAINS = []
 SCOOP_API_KEY = None


### PR DESCRIPTION
We are planning to delegate submitted URL validation to the Scoop API.

This is a no-op PR to preemptively add a global feature flag setting to let us experiment with that easily.

I sketched in what a possible implementation could look like, in a comment, to guide the development of that Scoop API route.

See ENG-502.
