### PR TITLE
Remove code for local URL validation.

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -17,7 +17,6 @@ import pytest
 from .utils import ApiResourceTestCase, ApiResourceTransactionTestCase, TEST_ASSETS_DIR, index_warc_file, raise_on_call, raise_after_call, return_on_call, MockResponse
 from perma.models import Link, LinkUser, Folder
 
-validation_api_calls = 0 if settings.VALIDATE_URL_LOCALLY else 1
 
 class LinkResourceTestMixin():
 
@@ -743,7 +742,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
 
         @patch('perma.utils.requests.request', autospec=True)
         def test_scoop_capture_request_initial_network_error(self, mockrequest):
-            mockrequest.side_effect = raise_on_call(orig_request, 1 + validation_api_calls, RequestException)
+            mockrequest.side_effect = raise_on_call(orig_request, 2, RequestException)
             obj = self.successful_post(self.list_url,
                                        data={
                                            'url': self.server_url + "/test.html"
@@ -757,7 +756,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
         @patch('perma.utils.requests.request', autospec=True)
         def test_scoop_capture_request_over_capacity(self, mockrequest):
             # https://github.com/harvard-lil/scoop-rest-api/blob/3115af8d6cb5eb623140f460b293e66a0c0d9b1e/scoop_rest_api/views/capture.py#L41
-            mockrequest.side_effect = return_on_call(orig_request, 1 + validation_api_calls, MockResponse(
+            mockrequest.side_effect = return_on_call(orig_request, 2, MockResponse(
                 {"error": "Capture server is over capacity."},
                 429
             ))
@@ -779,7 +778,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
 
         @patch('perma.utils.requests.request', autospec=True)
         def test_scoop_capture_request_transient_polling_error_handled(self, mockrequest):
-            mockrequest.side_effect = raise_on_call(orig_request, 3 + validation_api_calls, RequestException)
+            mockrequest.side_effect = raise_on_call(orig_request, 4, RequestException)
             obj = self.successful_post(self.list_url,
                                        data={
                                            'url': self.server_url + "/test.html"
@@ -792,7 +791,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
 
         @patch('perma.utils.requests.request', autospec=True)
         def test_scoop_capture_request_polling_error_limit_exceeded(self, mockrequest):
-            mockrequest.side_effect = raise_after_call(orig_request, 2 + validation_api_calls, RequestException)
+            mockrequest.side_effect = raise_after_call(orig_request, 3, RequestException)
             obj = self.successful_post(self.list_url,
                                        data={
                                            'url': self.server_url + "/test.html"
@@ -814,7 +813,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
         @patch('perma.utils.requests.request', autospec=True)
         def test_scoop_capture_hung(self, mockrequest):
             # from https://perma-stage.org/admin/perma/capturejob/2059/change/
-            mockrequest.side_effect = return_on_call(orig_request, 2 + validation_api_calls, MockResponse({
+            mockrequest.side_effect = return_on_call(orig_request, 3, MockResponse({
                 "url": "https://www.nytimes.com/",
                 "status": "failed",
                 "id_capture": "2ca5dad1-20fd-4550-9129-a0ce64ecc662",

--- a/perma_web/api/tests/utils.py
+++ b/perma_web/api/tests/utils.py
@@ -14,7 +14,6 @@ import json
 from io import StringIO
 from warcio.indexer import Indexer
 
-from django.test.utils import override_settings
 from django.conf import settings
 from django.test import LiveServerTestCase, TransactionTestCase, TestCase, SimpleTestCase
 from django.utils.functional import cached_property
@@ -205,7 +204,6 @@ class LoggingAPIClient(APIClient):
         return super(LoggingAPIClient, self).delete(*args, **kwargs, secure=True)
 
 
-@override_settings(BANNED_IP_RANGES=[])
 class ApiResourceTestCaseMixin(SimpleTestCase):
 
     # TODO: Using the regular ROOT_URLCONF avoids a problem where failing tests print useless error messages,

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -8,7 +8,6 @@ import os
 import logging
 import random
 import re
-import socket
 from urllib.parse import urlparse
 import simple_history
 import requests
@@ -44,7 +43,7 @@ from taggit.managers import TaggableManager
 from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
 
 from .exceptions import PermaPaymentsCommunicationException, InvalidTransmissionException
-from .utils import (Sec1TLSAdapter, tz_datetime,
+from .utils import (tz_datetime,
     prep_for_perma_payments, process_perma_payments_transmission,
     pp_date_from_post,
     first_day_of_next_month, today_next_year, preserve_perma_warc,
@@ -1567,46 +1566,6 @@ class Link(DeletableModel):
     @cached_property
     def url_details(self):
         return urlparse(self.ascii_safe_url)
-
-    @cached_property
-    def ip(self):
-        try:
-            return socket.gethostbyname(self.url_details.netloc.split(':')[0])
-        except socket.gaierror:
-            return False
-
-    @cached_property
-    def headers(self):
-        try:
-            with requests.Session() as s:
-                # Break noisily if requests mediates anything but http and https
-                assert list(s.adapters.keys()) == ['https://', 'http://']
-
-                # Lower our standards for the required TLS security level
-                s.mount('https://', Sec1TLSAdapter())
-                request = requests.Request(
-                    'GET',
-                    self.ascii_safe_url,
-                    headers={'User-Agent': settings.CAPTURE_USER_AGENT, **settings.CAPTURE_HEADERS}
-                )
-                response = s.send(
-                    request.prepare(),
-                    timeout=settings.RESOURCE_LOAD_TIMEOUT,
-                    stream=True  # we're only looking at the headers
-                )
-                response.close()
-                return response.headers
-        except (requests.ConnectionError, requests.Timeout, requests.exceptions.InvalidSchema, requests.exceptions.InvalidURL):
-            # ConectionError and Timeout are self-explanatory.
-            # InvalidSchema is raised if the retrieved URL uses a protocol not handled by
-            # requests' adapters (https://github.com/psf/requests/blob/master/requests/sessions.py#L419).
-            # While we can validate the target URL in advance, it may redirect to any arbitrary schema,
-            # for instance, file://, which will raise InvalidSchema.
-            # Similarly, InvalidURL is raised when requests cannot parse the target of a redirect.
-            # (https://github.com/psf/requests/blob/8149e9fe54c36951290f198e90d83c8a0498289c/requests/models.py#L383)
-            # We return False, to indicate in all cases that we did not successfully retrieve
-            # any headers, rather than propagating the exception.
-            return False
 
     def get_default_title(self):
         return self.url_details.netloc

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -512,7 +512,6 @@ PLAYBACK_HOST = 'rejouer.perma.test:8080'
 #
 # Capture
 #
-VALIDATE_URL_LOCALLY = True
 CAPTURE_ENGINE = 'scoop-api'  # perma|scoop-api
 PRIVATE_BY_POLICY_DOMAINS = []
 SCOOP_API_KEY = None
@@ -520,50 +519,9 @@ SCOOP_API_URL = None
 SCOOP_POLL_FREQUENCY = 0.5
 SCOOP_POLL_NETWORK_ERROR_LIMIT = 10
 
-# IP ranges we won't archive.
-# Via http://en.wikipedia.org/wiki/Reserved_IP_addresses
-BANNED_IP_RANGES = [
-    "0.0.0.0/8",
-    "10.0.0.0/8",
-    "100.64.0.0/10",
-    "127.0.0.0/8",
-    "169.254.0.0/16",
-    "172.16.0.0/12",
-    "192.0.0.0/29",
-    "192.0.2.0/24",
-    "192.88.99.0/24",
-    "192.168.0.0/16",
-    "198.18.0.0/15",
-    "198.51.100.0/24",
-    "203.0.113.0/24",
-    "224.0.0.0/4",
-    "240.0.0.0/4",
-    "255.255.255.255/32",
-    "::/128",
-    "::1/128",
-    "::ffff:0:0/96",
-    "100::/64",
-    "64:ff9b::/96",
-    "2001::/32",
-    "2001:10::/28",
-    "2001:db8::/32",
-    "2002::/16",
-    "fc00::/7",
-    "fe80::/10",
-    "ff00::/8",
-]
-
 # Max file size (for our downloads)
 MAX_ARCHIVE_FILE_SIZE = 1024 * 1024 * 100  # 100 MB
 
-# Used by requests, when validating submitted URLs
-CAPTURE_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.105 Safari/537.36"
-CAPTURE_HEADERS = {
-    "Accept": "*/*",
-    "Accept-Encoding": "*",
-    "Accept-Language": "*",
-    "Connection": "keep-alive"
-}
 # Seconds to wait for website to respond during URL validation:
 # set to the Scoop API's own 502 threshold, currently 60s, plus two seconds for network conditions
 RESOURCE_LOAD_TIMEOUT = 60 + 2

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -124,5 +124,3 @@ TIERS = {
         }
     ]
 }
-
-VALIDATE_URL_LOCALLY = False

--- a/perma_web/requirements.in
+++ b/perma_web/requirements.in
@@ -8,7 +8,7 @@ django-ratelimit                        # IP-based rate-limiting
 django-axes==5.27.0                     # limit login attempts
 django-waffle                           # feature flags
 invoke                                  # task automation
-netaddr                                 # to check archive IPs against banned ranges
+netaddr                                 # used to check for trusted proxies
 requests
 tqdm                                    # progress bar in dev invoke tasks
 Werkzeug


### PR DESCRIPTION
[URL validation via the Scoop API](https://github.com/harvard-lil/perma/pull/3462) seems to be going fine, subsequent to a few tweaks to various timeouts and web server settings.

This PR removes the code for local validation.