### PR TITLE
Longer validation timeout

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -268,7 +268,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                             method="post",
                             path="validate",
                             json={"url": Link.get_ascii_safe_url(data['submitted_url'])},
-                            timeout=settings.RESOURCE_LOAD_TIMEOUT + 2,
+                            timeout=settings.RESOURCE_LOAD_TIMEOUT + 15,
                             valid_if=lambda code, data: code == 200 and "valid" in data,
                         )
                         if not response_data["valid"]:


### PR DESCRIPTION
We are sometimes seeing `ScoopAPINetworkException` during validation that don't seem like actual network problems... they seem like Perma is giving up before the Scoop API is ready. 

Let's give it some more time.

We can rethink this, and other timeouts, as we see how things pan out over time.