### PR TITLE
Even longer validation timeout

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -268,7 +268,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                             method="post",
                             path="validate",
                             json={"url": Link.get_ascii_safe_url(data['submitted_url'])},
-                            timeout=settings.RESOURCE_LOAD_TIMEOUT + 15,
+                            timeout=settings.RESOURCE_LOAD_TIMEOUT,
                             valid_if=lambda code, data: code == 200 and "valid" in data,
                         )
                         if not response_data["valid"]:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -564,7 +564,9 @@ CAPTURE_HEADERS = {
     "Accept-Language": "*",
     "Connection": "keep-alive"
 }
-RESOURCE_LOAD_TIMEOUT = 45 # seconds to wait for website to respond during URL validation
+# Seconds to wait for website to respond during URL validation:
+# set to the Scoop API's own 502 threshold, currently 60s, plus two seconds for network conditions
+RESOURCE_LOAD_TIMEOUT = 60 + 2
 
 # We're finding that warcs aren't always available for download from S3
 # instantly, immediately after upload. How long do we want to wait for S3


### PR DESCRIPTION
Subsequent to seeing a very small number of validation timeouts over the weekend... I had another think about this.

We have the Scoop API configured such that its gunicorn will send us a 502 in 60s, if the app hasn't replied at that point. We should therefore wait the full 60s plus a small buffer here... because if we don't, then we aren't distinguishing between "Scoop API hit its limit" and "Scoop API is unresponsive".

I'd like to see them distinguished, so that I get a better sense of whether we need to try and enforce a timeout on [`gethostbyname`](https://docs.python.org/3/library/socket.html#socket.gethostname).