### PR TITLE
More detailed logs for Scoop-related 403s

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -778,5 +778,8 @@ def send_to_scoop(method, path, valid_if, json=None, stream=False, timeout=10):
             data = safe_get_response_json(response)
         assert valid_if(response.status_code, data)
     except AssertionError:
+        if response.status_code == 403:
+            cleaned_content = response.content.replace(b'\n', b' ').strip()
+            logger.warning(f"Unexpected {response.status_code}: {response.headers}: {cleaned_content}.")
         raise ScoopAPIException(f"{response.status_code}: {str(data)}")
     return response, data


### PR DESCRIPTION
We are seeing sporadic 403s, and we aren't sure where they are coming from.

This PR adds detailed logging, so we can track them down.