### PR TITLE
Rek test link mgmt

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -503,22 +503,24 @@ def perma_client():
     session_key = settings.SESSION_COOKIE_NAME
 
     class UserClient(Client):
-        def request(self, *args, **kwargs):
+        def generic(self, *args, **kwargs):
             as_user = kwargs.pop("as_user", None)
+            kwargs['secure'] = True
+
             if as_user:
                 # If as_user is provided, store the current value of the session cookie, call force_login, and then
                 # reset the current value after the request is over.
                 previous_session = self.cookies.get(session_key)
                 self.force_login(as_user)
                 try:
-                    return super().request(*args, **kwargs)
+                    return super().generic(*args, **kwargs)
                 finally:
                     if previous_session:
                         self.cookies[session_key] = previous_session
                     else:
                         self.cookies.pop(session_key)
             else:
-                return super().request(*args, **kwargs)
+                return super().generic(*args, **kwargs)
 
     return UserClient()
 

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -236,7 +236,6 @@ class RegistrarFactory(DjangoModelFactory):
     )
 
 
-
 @register_factory
 class PendingRegistrarFactory(RegistrarFactory):
     status = 'pending'
@@ -491,6 +490,37 @@ def org_user_factory(link_user, organization):
 @pytest.fixture
 def org_user(org_user_factory):
     return org_user_factory()
+
+
+@pytest.fixture
+def perma_client():
+    """
+    A version of the Django test client that allows us to specify a user login for a particular request with an
+    `as_user` parameter, like `client.get(url, as_user=user).
+    """
+    from django.test.client import Client
+
+    session_key = settings.SESSION_COOKIE_NAME
+
+    class UserClient(Client):
+        def request(self, *args, **kwargs):
+            as_user = kwargs.pop("as_user", None)
+            if as_user:
+                # If as_user is provided, store the current value of the session cookie, call force_login, and then
+                # reset the current value after the request is over.
+                previous_session = self.cookies.get(session_key)
+                self.force_login(as_user)
+                try:
+                    return super().request(*args, **kwargs)
+                finally:
+                    if previous_session:
+                        self.cookies[session_key] = previous_session
+                    else:
+                        self.cookies.pop(session_key)
+            else:
+                return super().request(*args, **kwargs)
+
+    return UserClient()
 
 
 @pytest.fixture

--- a/perma_web/perma/tests/test_views_link_management.py
+++ b/perma_web/perma/tests/test_views_link_management.py
@@ -10,22 +10,22 @@ from perma.views.link_management import Link
 
 ### create_link function ###
 
-def test_display_after_delete_real_link(perma_client, link_user):
+def test_display_after_delete_real_link(perma_client, link_factory, link_user):
+    new_link = link_factory(created_by=link_user)
     response = perma_client.get(reverse('create_link'),
                             as_user=link_user,
-                            data={'deleted':'ABCD-0003'})
+                            data={'deleted': new_link.guid})
     messages = list(response.context['messages'])
     assert len(messages) == 1
-    assert str(messages[0]) == "Deleted - Wikipedia"
-    assert 200 == response.status_code
+    assert str(messages[0]) == f"Deleted - {new_link.submitted_title}"
 
 def test_display_after_delete_fake_link(perma_client, link_user):
+    assert not Link.objects.filter(guid='ZZZZ-ZZZZ').exists()
     response = perma_client.get(reverse('create_link'),
                                 as_user=link_user,
                                 data={'deleted': 'ZZZZ-ZZZZ'})
     messages = list(response.context['messages'])
     assert len(messages) == 0
-    assert 200 == response.status_code
 
 def test_reminder(perma_client, link_user):
     response_content = perma_client.get(reverse('create_link'),
@@ -38,22 +38,22 @@ def test_no_reminder_when_refered_from_bookmarklet(perma_client, link_user):
                                 data = {'url':'some-url-here'}).content
     assert b"browser-tools-message" not in response_content
 
-def test_no_reminder_when_suppression_cookie_present(perma_client, client, link_user):
-    # client.cookies.load({'suppress_reminder': 'true'})
+def test_no_reminder_when_suppression_cookie_present(perma_client, link_user):
+    perma_client.cookies.load({'suppress_reminder': 'true'})
     response = perma_client.get(reverse('create_link'),
                                 as_user=link_user)
     assert b"browser-tools-message" not in response
-    assert 200 == response.status_code
 
 
 ### user_delete_link function ###
 
-def test_confirm_delete_unpermitted_link(perma_client, link_user):
-    response = perma_client.get(reverse('user_delete_link', args=['7CF8-SS4G']),
+def test_confirm_delete_unpermitted_link(perma_client, link, link_user):
+    response = perma_client.get(reverse('user_delete_link', args=[link.guid]),
                                 as_user=link_user)
     assert 404 == response.status_code
 
 def test_confirm_delete_nonexistent_link(perma_client, link_user):
+    assert not Link.objects.filter(guid='ZZZZ-ZZZZ').exists()
     response = perma_client.get(reverse('user_delete_link', args=['ZZZZ-ZZZZ']),
                                 as_user=link_user)
     assert 404 == response.status_code
@@ -61,7 +61,7 @@ def test_confirm_delete_nonexistent_link(perma_client, link_user):
 # only brand new links can be deleted,
 # so we have to mock Link.is_permanent to always return false
 @patch.object(Link, 'is_permanent', lambda x: False)
-def test_confirm_delete_permitted_link(perma_client, link_user):
-    response = perma_client.get(reverse('user_delete_link', args=['JJ3S-2Q5N']),
+def test_confirm_delete_permitted_link(perma_client, link_factory, link_user):
+    new_link = link_factory(created_by=link_user)
+    perma_client.get(reverse('user_delete_link', args=[new_link.guid]),
                 as_user=link_user)
-    assert 404 == response.status_code

--- a/perma_web/perma/tests/test_views_link_management.py
+++ b/perma_web/perma/tests/test_views_link_management.py
@@ -13,60 +13,55 @@ from perma.views.link_management import Link
 def test_display_after_delete_real_link(perma_client, link_user):
     response = perma_client.get(reverse('create_link'),
                             as_user=link_user,
-                            secure=True,
                             data={'deleted':'ABCD-0003'})
     messages = list(response.context['messages'])
     assert len(messages) == 1
     assert str(messages[0]) == "Deleted - Wikipedia"
+    assert 200 == response.status_code
 
 def test_display_after_delete_fake_link(perma_client, link_user):
     response = perma_client.get(reverse('create_link'),
                                 as_user=link_user,
-                                secure=True,
                                 data={'deleted': 'ZZZZ-ZZZZ'})
     messages = list(response.context['messages'])
     assert len(messages) == 0
+    assert 200 == response.status_code
 
 def test_reminder(perma_client, link_user):
-    response = perma_client.get(reverse('create_link'),
-                                as_user=link_user,
-                                secure=True).content
-    assert b"browser-tools-message" in response
+    response_content = perma_client.get(reverse('create_link'),
+                                as_user=link_user).content
+    assert b"browser-tools-message" in response_content
 
 def test_no_reminder_when_refered_from_bookmarklet(perma_client, link_user):
-    response = perma_client.get(reverse('create_link'),
+    response_content = perma_client.get(reverse('create_link'),
                                 as_user=link_user,
-                                secure=True,
                                 data = {'url':'some-url-here'}).content
-    assert b"browser-tools-message" not in response
+    assert b"browser-tools-message" not in response_content
 
 def test_no_reminder_when_suppression_cookie_present(perma_client, client, link_user):
     # client.cookies.load({'suppress_reminder': 'true'})
     response = perma_client.get(reverse('create_link'),
-                                as_user=link_user,
-                                secure=True)
+                                as_user=link_user)
     assert b"browser-tools-message" not in response
+    assert 200 == response.status_code
 
 
 ### user_delete_link function ###
 
 def test_confirm_delete_unpermitted_link(perma_client, link_user):
     response = perma_client.get(reverse('user_delete_link', args=['7CF8-SS4G']),
-                                as_user=link_user,
-                                secure=True)
+                                as_user=link_user)
     assert 404 == response.status_code
 
 def test_confirm_delete_nonexistent_link(perma_client, link_user):
     response = perma_client.get(reverse('user_delete_link', args=['ZZZZ-ZZZZ']),
-                                as_user=link_user,
-                                secure=True)
+                                as_user=link_user)
     assert 404 == response.status_code
 
 # only brand new links can be deleted,
 # so we have to mock Link.is_permanent to always return false
 @patch.object(Link, 'is_permanent', lambda x: False)
 def test_confirm_delete_permitted_link(perma_client, link_user):
-    perma_client.get(reverse('user_delete_link', args=['JJ3S-2Q5N']),
-                as_user=link_user,
-                secure=True)
-    # Is this supposed to have an assertion here?
+    response = perma_client.get(reverse('user_delete_link', args=['JJ3S-2Q5N']),
+                as_user=link_user)
+    assert 404 == response.status_code

--- a/perma_web/perma/tests/test_views_link_management.py
+++ b/perma_web/perma/tests/test_views_link_management.py
@@ -3,7 +3,6 @@ from django.urls import reverse
 
 from mock import patch
 
-# from .utils import PermaTestCase
 
 from perma.views.link_management import Link
 

--- a/perma_web/perma/tests/test_views_link_management.py
+++ b/perma_web/perma/tests/test_views_link_management.py
@@ -1,71 +1,72 @@
 # -*- coding: utf-8 -*-
+from django.urls import reverse
+
 from mock import patch
 
-from .utils import PermaTestCase
+# from .utils import PermaTestCase
 
 from perma.views.link_management import Link
 
 
-class LinkManagementViewsTestCase(PermaTestCase):
+### create_link function ###
 
-    ### create_link function ###
+def test_display_after_delete_real_link(perma_client, link_user):
+    response = perma_client.get(reverse('create_link'),
+                            as_user=link_user,
+                            secure=True,
+                            data={'deleted':'ABCD-0003'})
+    messages = list(response.context['messages'])
+    assert len(messages) == 1
+    assert str(messages[0]) == "Deleted - Wikipedia"
 
-    def test_display_after_delete_real_link(self):
-        response = self.get('create_link',
-                             user= 'test_user@example.com',
-                             request_kwargs={'data':{'deleted':'ABCD-0003'}})
-        messages = list(response.context['messages'])
-        self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Deleted - Wikipedia")
+def test_display_after_delete_fake_link(perma_client, link_user):
+    response = perma_client.get(reverse('create_link'),
+                                as_user=link_user,
+                                secure=True,
+                                data={'deleted': 'ZZZZ-ZZZZ'})
+    messages = list(response.context['messages'])
+    assert len(messages) == 0
 
-    def test_display_after_delete_fake_link(self):
-        response = self.get('create_link',
-                             user = 'test_user@example.com',
-                             request_kwargs={'data':{'deleted':'ZZZZ-ZZZZ'}})
-        messages = list(response.context['messages'])
-        self.assertEqual(len(messages), 0)
+def test_reminder(perma_client, link_user):
+    response = perma_client.get(reverse('create_link'),
+                                as_user=link_user,
+                                secure=True).content
+    assert b"browser-tools-message" in response
 
-    def test_reminder(self):
-        response = self.get('create_link',
-                             user = 'test_user@example.com').content
-        self.assertIn(b"browser-tools-message", response)
+def test_no_reminder_when_refered_from_bookmarklet(perma_client, link_user):
+    response = perma_client.get(reverse('create_link'),
+                                as_user=link_user,
+                                secure=True,
+                                data = {'url':'some-url-here'}).content
+    assert b"browser-tools-message" not in response
 
-    def test_no_reminder_when_refered_from_bookmarklet(self):
-        response = self.get('create_link',
-                             user = 'test_user@example.com',
-                             request_kwargs={'data':{'url':'some-url-here'}}).content
-        self.assertNotIn(b"browser-tools-message", response)
-
-    def test_no_reminder_when_suppression_cookie_present(self):
-        self.client.cookies.load({'suppress_reminder': 'true'})
-        response = self.get('create_link',
-                             user = 'test_user@example.com')
-        self.assertNotIn(b"browser-tools-message", response)
-
-    ### user_delete_link function ###
-
-    def test_confirm_delete_unpermitted_link(self):
-        self.get('user_delete_link',
-                  reverse_kwargs={'args':['7CF8-SS4G']},
-                  user = 'test_user@example.com',
-                  require_status_code = 404)
-
-    def test_confirm_delete_nonexistent_link(self):
-        self.get('user_delete_link',
-                  reverse_kwargs={'args':['ZZZZ-ZZZZ']},
-                  user = 'test_user@example.com',
-                  require_status_code = 404)
-
-    # only brand new links can be deleted,
-    # so we have to mock Link.is_permanent to always return false
-    @patch.object(Link, 'is_permanent', lambda x: False)
-    def test_confirm_delete_permitted_link(self):
-        self.get('user_delete_link',
-                  reverse_kwargs={'args':['JJ3S-2Q5N']},
-                  user = 'test_user@example.com')
+def test_no_reminder_when_suppression_cookie_present(perma_client, client, link_user):
+    # client.cookies.load({'suppress_reminder': 'true'})
+    response = perma_client.get(reverse('create_link'),
+                                as_user=link_user,
+                                secure=True)
+    assert b"browser-tools-message" not in response
 
 
+### user_delete_link function ###
 
+def test_confirm_delete_unpermitted_link(perma_client, link_user):
+    response = perma_client.get(reverse('user_delete_link', args=['7CF8-SS4G']),
+                                as_user=link_user,
+                                secure=True)
+    assert 404 == response.status_code
 
+def test_confirm_delete_nonexistent_link(perma_client, link_user):
+    response = perma_client.get(reverse('user_delete_link', args=['ZZZZ-ZZZZ']),
+                                as_user=link_user,
+                                secure=True)
+    assert 404 == response.status_code
 
-
+# only brand new links can be deleted,
+# so we have to mock Link.is_permanent to always return false
+@patch.object(Link, 'is_permanent', lambda x: False)
+def test_confirm_delete_permitted_link(perma_client, link_user):
+    perma_client.get(reverse('user_delete_link', args=['JJ3S-2Q5N']),
+                as_user=link_user,
+                secure=True)
+    # Is this supposed to have an assertion here?


### PR DESCRIPTION
Two things:

1. I am doing this: https://github.com/harvard-lil/perma/compare/develop...kilbergr:perma:rek-test-link-mgmt?expand=1#diff-7647024a9efc6c8bce2a3b02675bfd7410fb12302f16b7c4bd815391088ca407R508 because I can't pass `secure=True` into `super().generic(*args, **kwargs)` because it is already set in kwargs (so I get this error: TypeError: django.test.client.RequestFactory.generic() got multiple values for keyword argument 'secure'). Lmk if this is objectionable.
2. I added a response.status_code check to the last test, which didn't have one: https://github.com/harvard-lil/perma/compare/develop...kilbergr:perma:rek-test-link-mgmt?expand=1#diff-3d65703d1dab85c7f9193746596fd9d55e3dd667ebe8a10aede02e538ae68ec1R67. However, I can't tell from the test's name whether I should be expecting a different response (i.e. does permitted mean you're allowed to delete this link, and therefore this should be a 200 or is permitted a link type?). Do you know? It passes on a 404, which from this: https://github.com/harvard-lil/perma/blob/f5e43c21a39e61bf7b9dd1b63a925acbfc387678/perma_web/perma/views/link_management.py#L45 suggests this is a not deletable link (`request.user.can_delete(link) returns False`.