### PR TITLE
Contact form for sponsored users should cc registrar users too.

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1020,7 +1020,7 @@ class LinkUser(CustomerModel, AbstractBaseUser, PermissionsMixin):
         if self.is_anonymous:
             return False
         return settings.CONTACT_REGISTRARS and \
-               self.is_organization_user
+               (self.is_organization_user or self.is_sponsored_user())
 
     ### link permissions ###
 

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -590,6 +590,21 @@ class CommonViewsTestCase(PermaTestCase):
         self.assertIn("Affiliations: Test Library (Registrar)", message.body)
         self.assertIn("Logged in: true", message.body)
 
+    @override_settings(REQUIRE_JS_FORM_SUBMISSIONS=False)
+    def test_contact_sponsored_user_affiliation_string(self):
+        '''
+            Verify registrar affiliations are printed correctly
+        '''
+        self.submit_form('contact',
+                          data = { 'email': self.from_email,
+                                   'box2': self.message_text,
+                                   'registrar': 1 },
+                          user='test_sponsored_user@example.com')
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn("Affiliations: Test Library", message.body)
+        self.assertIn("Logged in: true", message.body)
+
     #
     # Report form, as a bot
     #


### PR DESCRIPTION
See ENG-525.

Back when, we altered the contact form so that, when it is submitted by an org user, their registrar users are cc'ed. The idea was, this would encourage registrars to support their users :-)

A few years later, we introduced "sponsored users" to the mix. Sponsored users are affiliated directly with a registrar, without an org. We did not add anything to the contact form at the time.

This PR addresses the oversight.

I added a test for a sponsored user, but I did not replicate _all_ the existing styles of test we currently have for the contact form: these tests were some of the _first_ tests I had ever written, and they are not particularly well-designed 🤣. There is a lot of duplicative stuff. I think this test, by itself, is good enough, pending a refactor of the test suite :-).