### PR TITLE
Bugfix: don't force URL validation if a file is provided.

### DIFF
--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -639,6 +639,18 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
             self.assertRecordsInWarc(link, upload=True)
             self.assertEqual(link.primary_capture.user_upload, True)
 
+    def test_should_create_archive_from_jpg_file_with_invalid_url(self):
+        with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.jpg'), 'rb') as test_file:
+            obj = self.successful_post(self.list_url,
+                                       format='multipart',
+                                       data=dict(self.post_data.copy(), url='asdf', file=test_file),
+                                       user=self.org_user)
+
+            link = Link.objects.get(guid=obj['guid'])
+            self.assertEqual(link.submitted_url, 'http://asdf')
+            self.assertRecordsInWarc(link, upload=True)
+            self.assertEqual(link.primary_capture.user_upload, True)
+
     def test_should_reject_invalid_file(self):
         with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.html'), 'rb') as test_file:
             obj = self.rejected_post(self.list_url,


### PR DESCRIPTION
We recently made a change to Perma's URL validation behavior: we used to validate URLs locally, but now we send the URLs to the Scoop API for validation.

When I [added the new code](https://github.com/harvard-lil/perma/pull/3462), I missed [two important lines](https://github.com/harvard-lil/perma/commit/7c1eb0e75d60c2a79794bc4b06b040620da30aab#diff-10c7a6c469cb7c823f182d37a2c549793e3326a8f14559a8fc88af9026080bb7L242-L243). We are not supposed to validate the URL, if making a Perma Link from an upload instead of from a capture. 

It turns out that our tests of the upload-your-own functionality [use the same URL every time](https://github.com/harvard-lil/perma/blob/develop/perma_web/api/tests/test_link_resource.py#L356)... a valid one.

So, this PR does two thing:
- add back the missing ` if not uploaded_file:`, and
- add a regression test