### PR TITLE
Tweak /manage/organizations page for efficiency

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -506,6 +506,19 @@ def manage_organization(request):
     """
 
     is_admin = request.user.is_staff
+    if is_admin:
+        form = OrganizationWithRegistrarForm(get_form_data(request), prefix = "a")
+    else:
+        form = OrganizationForm(get_form_data(request), prefix = "a")
+
+    if request.method == 'POST':
+        if form.is_valid():
+            new_org = form.save(commit=False)
+            if not is_admin:
+                new_org.registrar_id = request.user.registrar_id
+            new_org.save()
+            return HttpResponseRedirect(reverse('user_management_manage_organization'))
+
     orgs = Organization.objects.accessible_to(request.user).select_related('registrar')
 
     # add annotations
@@ -531,20 +544,6 @@ def manage_organization(request):
 
     # handle pagination
     orgs = apply_pagination(request, orgs)
-
-    if is_admin:
-        form = OrganizationWithRegistrarForm(get_form_data(request), prefix = "a")
-    else:
-        form = OrganizationForm(get_form_data(request), prefix = "a")
-
-    if request.method == 'POST':
-        if form.is_valid():
-            new_org = form.save(commit=False)
-            if not is_admin:
-                new_org.registrar_id = request.user.registrar_id
-            new_org.save()
-
-            return HttpResponseRedirect(reverse('user_management_manage_organization'))
 
     return render(request, 'user_management/manage_orgs.html', {
         'orgs': orgs,


### PR DESCRIPTION
As written, the [`manage_organization`](https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/views/user_management.py#L503) view function handles both GET and POST. 

POST is simpler than GET; POST just processes a form, while GET retrieves a bunch of data about all the orgs visible to the user.

If we redesign this view (which we probably will), or if I were really refactoring, I'd split these out into separate view functions.

But, for now, almost as good: this PR just reorders the logic, quickly handling the form and `return`ing if this is a POST, instead of collecting the data regardless of method.

This should speed up `POST`, and potentially ward off a weird edge case where, if a user submits multiple POSTs at exactly the right moments, instead of just successfully creating multiple orgs, the database gets itself in a bind.