### PR TITLE
Add reactivity experiment

### DIFF
--- a/perma_web/frontend/components/App.vue
+++ b/perma_web/frontend/components/App.vue
@@ -1,7 +1,9 @@
 <script setup>
 import HelloWorld from './HelloWorld.vue'
+import HelloWorldB from './HelloWorldB.vue';
 </script>
 
 <template>
     <HelloWorld />
+    <HelloWorldB />
 </template>

--- a/perma_web/frontend/components/HelloWorld.vue
+++ b/perma_web/frontend/components/HelloWorld.vue
@@ -4,7 +4,7 @@ import { globalStore } from '../stores/globalStore'
 </script>
 
 <template>
-    The current count for component A: {{ globalStore.count }}
+    <p>The current count for component A: {{ globalStore.count }}</p>
 
     <button @click="globalStore.increment()">
         Increment Counter

--- a/perma_web/frontend/components/HelloWorldB.vue
+++ b/perma_web/frontend/components/HelloWorldB.vue
@@ -3,7 +3,7 @@ import { globalStore } from '../stores/globalStore'
 </script>
 
 <template>
-    The current count for component B: {{ globalStore.count }}
+    <p>The current count for component B: {{ globalStore.count }}</p>
 
     <button @click="globalStore.increment()">
         Increment Counter

--- a/perma_web/frontend/components/HelloWorldB.vue
+++ b/perma_web/frontend/components/HelloWorldB.vue
@@ -1,10 +1,9 @@
 <script setup>
 import { globalStore } from '../stores/globalStore'
-
 </script>
 
 <template>
-    The current count for component A: {{ globalStore.count }}
+    The current count for component B: {{ globalStore.count }}
 
     <button @click="globalStore.increment()">
         Increment Counter

--- a/perma_web/frontend/pages/dashboard.js
+++ b/perma_web/frontend/pages/dashboard.js
@@ -20,6 +20,7 @@ watch(
 const handleDispatch = (name) => {
     switch (name) {
         case "increment":
+        default:
             globalStore.increment()
         break;
     }

--- a/perma_web/frontend/pages/dashboard.js
+++ b/perma_web/frontend/pages/dashboard.js
@@ -1,3 +1,39 @@
 import { createApp } from 'vue'
 import App from '../components/App.vue'
+import { watch } from 'vue';
+import { globalStore } from '../stores/globalStore';
+
 createApp(App).mount('#vue-app')
+
+const dashboardTestDiv = document.getElementsByClassName("vanilla-div")[0]
+
+// Track updates our Vue app makes to the store
+watch(
+    () => globalStore.count,
+    (count) => {
+        dashboardTestDiv.innerHTML = `Vanilla JavaScript count: ${count}`
+    },
+    { immediate: true }
+)
+
+// Handle updates the legacy application makes to the store
+const handleDispatch = (name) => {
+    switch (name) {
+        case "increment":
+            globalStore.increment()
+        break;
+    }
+}
+
+const increment = new CustomEvent("vueDispatch", {
+    bubbles: true,
+    detail: { name: 'increment' },
+})
+
+// One event listener for all vueDispatch custom events
+document.addEventListener("vueDispatch", (e) => handleDispatch(e.detail.name));
+
+const vanillaButton = document.getElementsByClassName('vanilla-button')[0]
+vanillaButton.addEventListener("click", function () {
+    this.dispatchEvent(increment)
+});

--- a/perma_web/frontend/stores/globalStore.js
+++ b/perma_web/frontend/stores/globalStore.js
@@ -1,0 +1,8 @@
+import { reactive } from 'vue'
+
+export const globalStore = reactive({
+  count: 0,
+  increment() {
+    this.count++
+  }
+})

--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -150,6 +150,8 @@
 
 {% if request.user.is_staff %}
   {% flag "vue-dashboard" %}
+    <div class="vanilla-div">Vanilla JavaScript Count: None</div>
+    <button class="vanilla-button">Increment Counter</button>
     <div id="vue-app"></div>
   {% endflag %}
 {% endif %}


### PR DESCRIPTION
## What this does 
This update adds a global vue store to test out cross-island interactivity between legacy code and new Vue components. Notable updates: 

- Added an additional test component, `HelloWorldB` to make sure that updates to Vue's store are shared across components. 
- Added JavaScript to `dashboard.js` to test out that we can listen to updates to the Vue store outside of Vue — and similarly make calls to update it as well.
- Added a POC for how we might handle multiple types of updates to the Vue store. Right now, we're only handling dispatches to increment the store's count.

## Screenshot 
This small experiment provides three different buttons to increment the store's count (one Vanilla JS, two rendered by Vue)
![Screenshot 2024-03-27 at 11 53 43 AM](https://github.com/harvard-lil/perma/assets/4039311/00c2028a-eae2-47e7-b658-1e87aeb686c5)

Clicking any of the buttons should update all three counts:
![Screenshot 2024-03-27 at 11 53 56 AM](https://github.com/harvard-lil/perma/assets/4039311/673a522d-88e2-44b4-9958-3ba29f2949ac)
