### PR TITLE
Add button loaders

### DIFF
--- a/perma_web/frontend/components/ProgressBar.vue
+++ b/perma_web/frontend/components/ProgressBar.vue
@@ -1,7 +1,7 @@
 <script setup>
 
 defineProps({
-    progress: Number,
+    progress: String,
 })
 
 </script>

--- a/perma_web/frontend/components/ProgressBar.vue
+++ b/perma_web/frontend/components/ProgressBar.vue
@@ -1,6 +1,6 @@
 <script setup>
 
-defineProps({
+const props = defineProps({
     progress: String,
 })
 

--- a/perma_web/frontend/components/ProgressBar.vue
+++ b/perma_web/frontend/components/ProgressBar.vue
@@ -8,8 +8,8 @@ const props = defineProps({
 <template>
     <div position="relative" style="width: 100%; height: 0">
         <div class="progress" style="width: 100%; height: 0.3em; position: absolute; margin-bottom: 0">
-            <div class="progress-bar" role="progressbar" aria-valuenow="{{progress}}" aria-valuemin="0"
-                aria-valuemax="100" style="background-color: #2D76EE; width: 90%"
+            <div class="progress-bar" role="progressbar" :aria-valuenow="progress" aria-valuemin="0" aria-valuemax="100"
+                style="background-color: #2D76EE; width: 90%"
                 :style="{ 'background-color': '#2D76EE', width: progress }">
                 <span>{{ progress }} Complete</span>
             </div>

--- a/perma_web/frontend/components/ProgressBar.vue
+++ b/perma_web/frontend/components/ProgressBar.vue
@@ -1,0 +1,18 @@
+<script setup>
+
+defineProps({
+    progress: Number,
+})
+
+</script>
+<template>
+    <div position="relative" style="width: 100%; height: 0">
+        <div class="progress" style="width: 100%; height: 0.3em; position: absolute; margin-bottom: 0">
+            <div class="progress-bar" role="progressbar" aria-valuenow="{{progress}}" aria-valuemin="0"
+                aria-valuemax="100" style="background-color: #2D76EE; width: 90%"
+                :style="{ 'background-color': '#2D76EE', width: progress }">
+                <span>{{ progress }} Complete</span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -2,8 +2,9 @@
 import { ref, onMounted } from 'vue'
 import * as Spinner from 'spin.js'
 
-defineProps({
+const props = defineProps({
     top: String,
+    isDisabled: Boolean
 })
 
 let spinnerRef = ref(null)
@@ -11,8 +12,13 @@ let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 
 
 onMounted(() => {
     spinner.spin(spinnerRef.value)
+
+    if (!props.isDisabled) {
+        spinner.stop(spinnerRef.value)
+    }
 })
 </script>
 <template>
-    <div ref="spinnerRef"></div>
+    <div v-if="!isDisabled" ref="spinnerRef"></div>
+    <div v-if="isDisabled">Loading</div>
 </template>

--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import * as Spinner from 'spin.js'
+
+let spinnerRef = ref(null)
+let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 0, color: '#2D76EE', trail: 50, top: '-20px' })
+
+onMounted(() => {
+    spinner.spin(spinnerRef.value)
+})
+
+</script>
+<template>
+    <div ref="spinnerRef"></div>
+</template>

--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 })
 
 let spinnerRef = ref(null)
-let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 0, color: '#2D76EE', trail: 50, top: top })
+let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 0, color: '#2D76EE', trail: 50, top: props.top ? props.top : '-20px' })
 
 onMounted(() => {
     if (!props.isDisabled) {

--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -2,13 +2,16 @@
 import { ref, onMounted } from 'vue'
 import * as Spinner from 'spin.js'
 
+defineProps({
+    top: String,
+})
+
 let spinnerRef = ref(null)
-let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 0, color: '#2D76EE', trail: 50, top: '-20px' })
+let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 0, color: '#2D76EE', trail: 50, top: top })
 
 onMounted(() => {
     spinner.spin(spinnerRef.value)
 })
-
 </script>
 <template>
     <div ref="spinnerRef"></div>

--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -11,10 +11,8 @@ let spinnerRef = ref(null)
 let spinner = new Spinner({ lines: 15, length: 2, width: 2, radius: 9, corners: 0, color: '#2D76EE', trail: 50, top: top })
 
 onMounted(() => {
-    spinner.spin(spinnerRef.value)
-
     if (!props.isDisabled) {
-        spinner.stop(spinnerRef.value)
+        spinner.spin(spinnerRef.value)
     }
 })
 </script>


### PR DESCRIPTION
## What this does 
Adds two components, Spinner and ProgressBar, that can be added to submit buttons in the updated Perma dashboard. One quick additional note: 

- The process of creating the Spinner component ended up feeling difficult for my motion sensitivity. To alleviate this, I added an "isDisabled" prop that will render "Loading" instead of the spinner component. In the future, we can always finesse this if we want so that it is positioned and visually looks the same way as the actual spinner element. 

## Screenshots 
![Disabled spinner screenshot](https://github.com/harvard-lil/perma/assets/4039311/d09c651c-a24d-43ee-8554-5c5c69e6bbd8)
Disabled spinner

![Enabled spinner screenshot](https://github.com/harvard-lil/perma/assets/4039311/70232d2a-8c4e-4650-b6a4-c088778a8f9f)
Enabled spinner

## How to test
Without the context of  #3489, I tested this by adding the Spinner and Progress bar by themselves to `App.vue`:

```
<script setup>
import Spinner from './Spinner.vue';
import ProgressBar from './ProgressBar.vue';
</script>

<template>
    <Spinner top="-20px" isDisabled />
    <ProgressBar progress="90%" />
</template>
```

Additional testing notes: 

- In actual use, we will want to make sure to pass the progress percentage to `ProgressBar` as a dynamic value. We can do that easily with the ":" shortcut, for example: 

```
<ProgressBar :progress="someDynamicProgressState" />
```

- We'll need to use the same ":" syntax with the `Spinner` component if we want to explicitly define `isDisabled` as false, to tell Vue that we need the string to be cast as a boolean. Otherwise Vue will throw a console error that there is a prop type mismatch. For example:

```
<Spinner :isDisabled="false" />
```