### PR TITLE
Pass custom jsonl file to js-wacz calls

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1267,7 +1267,7 @@ def create_wacz_path(input_guid):
     return file.name
 
 
-def create_jsonl(link_object):
+def create_pages_jsonl(link_object):
     """
     Creates pages.jsonl file to pass to js-wacz call
     """
@@ -1315,7 +1315,7 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
     exception_occurred = False
     custom_jsonl = False
     error_output = ''
-    jsonl_file_path = create_jsonl(warc_object)
+    jsonl_file_path = create_pages_jsonl(warc_object)
     subprocess_arguments = ["npx", "js-wacz", "create", "-f", warc_file, "-o", wacz_file_path]
 
     if jsonl_file_path:

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 this_module = sys.executable if hasattr(sys, "frozen") else __file__
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(this_module))))
 SERVICES_DIR = os.path.abspath(os.path.join(PROJECT_ROOT, '../services'))
+NODE_MODULES_DIR = os.path.abspath(os.path.join(PROJECT_ROOT, 'node_modules'))
 
 DATABASES = {
     'default': {

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1141,8 +1141,8 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=N
         raise ValueError("Either source file or WARC path needs to be passed.")
 
     log_file = os.path.abspath(benchmark_log)
-    csv_headers = ["file_name", "conversion_status", "warc_size", "raw_warc_size", "wacz_size", "raw_wacz_size",
-                   "duration", "raw_duration", "error"]
+    csv_headers = ["file_name", "conversion_status", "custom_jsonl", "warc_size", "raw_warc_size", "wacz_size",
+                   "raw_wacz_size", "duration", "raw_duration", "error"]
 
     with open(log_file, 'w') as lf:
         writer = csv.DictWriter(lf, fieldnames=csv_headers)

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1141,7 +1141,7 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=N
         raise ValueError("Either source file or WARC path needs to be passed.")
 
     log_file = os.path.abspath(benchmark_log)
-    csv_headers = ["file_name", "conversion_status", "custom_jsonl", "warc_size", "raw_warc_size", "wacz_size",
+    csv_headers = ["file_name", "conversion_status", "warc_size", "raw_warc_size", "wacz_size",
                    "raw_wacz_size", "duration", "raw_duration", "error"]
 
     with open(log_file, 'w') as lf:


### PR DESCRIPTION
ENG-786

- Pass conditional pages.jsonl files to js-wacz commands. If file is not created, we will be relying on the jsonl js-wacz produces.
- Run the conversion in a temp directory.
- For the [required ts field ](https://specs.webrecorder.net/wacz/1.1.1/#pages-jsonl)of all urls, I used the Link model's `creation_timestamp` field, let me know if that is ok. I can also add any additional attributes (id, text and size) to the urls as we wish.