### PR TITLE
Validate URL if the "upload your own" form is used.

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.validators import URLValidator
 import requests
 from rest_framework import serializers
 
@@ -229,9 +230,13 @@ class AuthenticatedLinkSerializer(LinkSerializer):
             if not data.get('submitted_url'):
                 errors['url'] = "URL cannot be empty."
             else:
-                # Don't force URL validation if a file is provided
-                if not uploaded_file:
-                    # Ask the Scoop API to validate the URL
+                if uploaded_file:
+                    # Validate, but don't force URL validation if a file is provided
+                    validate = URLValidator()
+                    temp_link = Link(submitted_url=data['submitted_url'])
+                    validate(temp_link.ascii_safe_url)
+                else:
+                    # Ask the Scoop API to validate and resolve the URL
                     try:
                         _, response_data = send_to_scoop(
                             method="post",

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -639,15 +639,24 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
             self.assertRecordsInWarc(link, upload=True)
             self.assertEqual(link.primary_capture.user_upload, True)
 
-    def test_should_create_archive_from_jpg_file_with_invalid_url(self):
+    def test_should_reject_jpg_file_with_invalid_url(self):
         with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.jpg'), 'rb') as test_file:
-            obj = self.successful_post(self.list_url,
+            obj = self.rejected_post(self.list_url,
                                        format='multipart',
                                        data=dict(self.post_data.copy(), url='asdf', file=test_file),
                                        user=self.org_user)
 
+            self.assertIn(b'Enter a valid URL', obj.content)
+
+    def test_should_should_create_archive_from_jpg_file_with_nonloading_url(self):
+        with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.jpg'), 'rb') as test_file:
+            obj = self.successful_post(self.list_url,
+                                       format='multipart',
+                                       data=dict(self.post_data.copy(), url='asdf.asdf', file=test_file),
+                                       user=self.org_user)
+
             link = Link.objects.get(guid=obj['guid'])
-            self.assertEqual(link.submitted_url, 'http://asdf')
+            self.assertEqual(link.submitted_url, 'http://asdf.asdf')
             self.assertRecordsInWarc(link, upload=True)
             self.assertEqual(link.primary_capture.user_upload, True)
 


### PR DESCRIPTION
Fixes ENG-652.

This restores the behavior the upload-your-own form had before we migrated URL validation from the Perma application over to the Scoop API. 

During that process, we accidentally removed _all_ URL validation from the upload-your-own form, making it possible to upload links with `submitted_url` set to arbitrary strings. In addition to that being just plain undesirable, if certain strings were provided, it caused downstream errors, for instance, when the submitted URL was converted to a surt.

Now, you will once again see a validation error:

![image](https://github.com/harvard-lil/perma/assets/11020492/68623132-bbcc-4493-a1c5-2c19ad74bda2)

I adjusted the test suite accordingly.