### PR TITLE
Update Scoop REST API image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -48,7 +48,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:52-e3380f176e1e3860b6590e4cba87f714
+    image: registry.lil.tools/harvardlil/scoop-rest-api:70-b2dc624d292610757b536a0fbbdd7a7e
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This upgrades the Scoop REST API image to one that uses Scoop 0.6.13:

https://github.com/harvard-lil/scoop/releases/tag/0.6.13