### PR TITLE
Use a dedicated queue for warc -> wacz conversion.

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -449,6 +449,7 @@ CELERY_TASK_ROUTES = {
     'perma.celery_tasks.confirm_file_deleted_from_daily_item': {'queue': 'ia-readonly'},
     'perma.celery_tasks.conditionally_queue_internet_archive_uploads_for_date_range': {'queue': 'ia-readonly'},
     'perma.celery_tasks.queue_internet_archive_deletions': {'queue': 'ia-readonly'},
+    'perma.celery_tasks.convert_warc_to_wacz': {'queue': 'wacz-conversion'}
 }
 
 # Schedule celerybeat jobs.

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -49,7 +49,7 @@ def run(ctx, port="0.0.0.0:8000", cert_file='perma-test.crt', key_file='perma-te
               "to create new batches you should run with settings.CELERY_TASK_ALWAYS_EAGER = False\n")
     else:
         print("\nStarting background celery process.")
-        commands.append("watchmedo auto-restart -d ./ -p '*.py' -R -- celery -A perma worker --loglevel=info -Q celery,background,ia,ia-readonly -B -n w1@%h")
+        commands.append("watchmedo auto-restart -d ./ -p '*.py' -R -- celery -A perma worker --loglevel=info -Q celery,background,ia,ia-readonly,wacz-conversion -B -n w1@%h")
 
     # Only run the webpack background process in debug mode -- with debug False, dev server uses static assets,
     # and running webpack just messes up the webpack stats file.


### PR DESCRIPTION
We are experimenting with converting Perma's WARCs to WACZ using a Celery task:
- https://github.com/harvard-lil/perma/pull/3488
- https://github.com/harvard-lil/perma/pull/3493

This PR adds config so that these celery tasks will be routed to a dedicated queue, for maximum flexibility: we can use a dedicated worker minion with js-wacz installed on it if we want, or not, we can configure concurrency exactly as desired, we don't have to worry about these jobs intermingling with capture jobs (unless we want them to), etc.