### PR TITLE
Update sqlparse

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,4 @@
 # overrides for local development, not used in CI
-version: '3'
 services:
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   #
   # Perma

--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -966,9 +966,9 @@ soupsieve==2.3.2 \
     --hash=sha256:0bcc6d7432153063e3df09c3ac9442af3eba488715bfcad6a4c38ccb2a523124 \
     --hash=sha256:a714129d3021ec17ce5be346b1007300558b378332c289a1a20e7d4de6ff18a5
     # via beautifulsoup4
-sqlparse==0.4.4 \
-    --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
-    --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
+sqlparse==0.5.0 \
+    --hash=sha256:714d0a4932c059d16189f58ef5411ec2287a4360f17cdd0edd2d09d4c5087c93 \
+    --hash=sha256:c204494cd97479d0e39f28c93d46c0b2d5959c7b9ab904762ea6c7af211c8663
     # via
     #   django
     #   django-debug-toolbar


### PR DESCRIPTION
https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG

This PR also removes `version` from the docker compose files; after seeing `'version' is obsolete`, I found [this](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements).