### PR TITLE
add batch_size arg, time different steps

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1257,15 +1257,11 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
     warc_path = f"{link.guid}.warc.gz"
     wacz_path = f"{link.guid}.wacz"
     pages_path = "pages.jsonl"
-    warc_not_found_error = False
 
     # save a local copy of the warc file
     warc_save_start_time = time.time()
-    try:
-        with open(warc_path, "wb") as file:
-            copy_file_data(default_storage.open(link.warc_storage_file()), file)
-    except FileNotFoundError:
-        warc_not_found_error = True
+    with open(warc_path, "wb") as file:
+        copy_file_data(default_storage.open(link.warc_storage_file()), file)
     warc_save_duration = time.time() - warc_save_start_time
 
     # prepare our custom pages.jsonl file
@@ -1344,10 +1340,6 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
         if conversion_error:
             row["conversion_status"] = "Failure"
             row["error"] = error_output
-            writer.writerow(row)
-        elif warc_not_found_error:
-            row["conversion_status"] = "Failure"
-            row["error"] = "WARC is not found in storage"
             writer.writerow(row)
         elif wacz_size == 0 or warc_size > wacz_size:
             row["conversion_status"] = "Failure"

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1133,7 +1133,7 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=N
     """
     Creates log file
     Invokes convert_warc_to_wacz() with WARC guid
-    source_csv or single_warc argument is required
+    Defaults to batch_size if source_csv or single_warc isn't passed
     """
     if source_csv and single_warc:
         raise ValueError("Cannot pass source file and WARC path at the same time.")

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1175,8 +1175,8 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=N
             is_private=False,
             is_unlisted=False,
             cached_can_play_back=True
-        ).order_by('guid')[:batch_size]
+        ).values_list('guid', flat=True).order_by('guid')[:batch_size]
 
-        for link in links:
-            convert_warc_to_wacz.delay(link.guid, log_file)
+        for link in links.iterator():
+            convert_warc_to_wacz.delay(link, log_file)
 


### PR DESCRIPTION
- Add the optional `batch-size` flag to invoke command. If not passed, it will default to 1000. This is so that we can run the job without a guids CSV or a single WARC guid. Now we can run the job with `docker compose exec web invoke dev.benchmark-wacz-conversion --benchmark-log='perma/wacz_experiment/benchmark.csv'` or `docker compose exec web invoke dev.benchmark-wacz-conversion --benchmark-log='perma/wacz_experiment/benchmark.csv' --batch-size=500`
- Time the different steps of the conversion for granularity.