### PR TITLE
add additional ways to select sample warcs

### DIFF
--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1129,11 +1129,14 @@ def save_warc_for_conversion(warc, warcs_dir, file_name):
 
 
 @task
-def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=None, batch_size=1000):
+def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=None, batch_size=1000, batch_range=None,
+                              big_warcs=False, prefix=None):
     """
     Creates log file
     Invokes convert_warc_to_wacz() with WARC guid
     Defaults to batch_size if source_csv or single_warc isn't passed
+    big_warcs can be passed along with batch_size
+    prefix can be passed along with batch_size
     """
     if source_csv and single_warc:
         raise ValueError("Cannot pass source file and WARC path at the same time.")
@@ -1170,6 +1173,41 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=N
                 convert_warc_to_wacz.delay(line[0], log_file)
     elif single_warc:
         convert_warc_to_wacz.delay(single_warc.split('.')[0], log_file)
+    elif batch_range:
+        batch_range_start, batch_range_end = batch_range.split(':')
+        batch_range_start = int(batch_range_start)
+        batch_range_end = int(batch_range_end)
+
+        if batch_range_start >= batch_range_end:
+            raise ValueError("Starting index must be smaller than ending index.")
+
+        links = Link.objects.filter(
+            is_private=False,
+            is_unlisted=False,
+            cached_can_play_back=True
+        ).values_list('guid', flat=True).order_by('guid')[batch_range_start:batch_range_end]
+
+        for link in links.iterator():
+            convert_warc_to_wacz.delay(link, log_file)
+    elif big_warcs:
+        links = Link.objects.filter(
+            is_private=False,
+            is_unlisted=False,
+            cached_can_play_back=True
+        ).order_by('-warc_size').values_list('guid')[:batch_size]
+
+        for link in links.iterator():
+            convert_warc_to_wacz.delay(link, log_file)
+    elif prefix:
+        links = Link.objects.filter(
+            is_private=False,
+            is_unlisted=False,
+            cached_can_play_back=True,
+            guid__startswith=prefix
+        ).values_list('guid', flat=True).order_by('guid')[:batch_size]
+
+        for link in links.iterator():
+            convert_warc_to_wacz.delay(link, log_file)
     else:
         links = Link.objects.filter(
             is_private=False,

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1201,6 +1201,5 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, single_warc=N
     else:
         links = base_links_query.order_by('guid')[:batch_size]
 
-    if links:
-        for link in links.iterator():
-            convert_warc_to_wacz.delay(link, log_file)
+    for link in links.iterator():
+        convert_warc_to_wacz.delay(link, log_file)


### PR DESCRIPTION
Add the below features so we can mix up the sample selection:

- Add batch range
- Add selection by prefix
- Add selecting big warcs

Sample usage:

`docker compose exec web invoke dev.benchmark-wacz-conversion --benchmark-log='perma/wacz_experiment/benchmark.csv' --batch-range=3000:4000`
`docker compose exec web invoke dev.benchmark-wacz-conversion --benchmark-log='perma/wacz_experiment/benchmark.csv' --prefix=A2`
`docker compose exec web invoke dev.benchmark-wacz-conversion --benchmark-log='perma/wacz_experiment/benchmark.csv' --big-warcs`
