### PR TITLE
Update Scoop API version in dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -47,7 +47,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:70-b2dc624d292610757b536a0fbbdd7a7e
+    image: registry.lil.tools/harvardlil/scoop-rest-api:75-4adf6c40e688e5d6c7348dbe36ed0978
     init: true
     tty: true
     depends_on:

--- a/services/docker/scoop-rest-api/config.py
+++ b/services/docker/scoop-rest-api/config.py
@@ -111,9 +111,6 @@ PROCESSES_PROXY_PORT = 9000
 #
 # Scoop settings
 #
-DOWNGRADE_TO_WARC = True
-""" If True, Scoop will generate WARCs instead of WACZ files. """
-
 BANNED_IP_RANGES = [
     "0.0.0.0/8",
     "10.0.0.0/8",


### PR DESCRIPTION
This updates the Scoop API image used for dev and removes the (no longer used) config var `DOWNGRADE_TO_WARC`.