### PR TITLE
Update form button appearance and label based on selection

### DIFF
--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -18,7 +18,13 @@ const loadingStates = ["isValidating", "isQueued", "isCapturing"]
 const isLoading = computed(() => { return loadingStates.includes(globalStore.captureStatus) })
 
 const submitButtonText = computed(() => {
-    return readyStates.includes(globalStore.captureStatus) ? 'Create Perma Link' : 'Creating your perma link'
+    if (readyStates.includes(globalStore.captureStatus) && globalStore.selectedFolder.isPrivate) {
+        return 'Create Private Perma Link'
+    }
+    else if (readyStates.includes(globalStore.captureStatus)) {
+        return 'Create Perma Link'
+    }
+    return 'Creating your Perma Link'
 })
 
 let progressInterval;
@@ -129,7 +135,7 @@ onBeforeUnmount(() => {
             <!-- debug only -->
         </div>
         <div class="container cont-full-bleed cont-sm-fixed">
-            <form class="form-priority" id="linker">
+            <form class="form-priority" :class="{ '_isPrivate': globalStore.selectedFolder.isPrivate }" id="linker">
                 <fieldset class="form-priority-fieldset">
                     <input v-model="userLink" id="rawUrl" name="url"
                         class="text-input select-on-click form-priority-input" type="text"
@@ -140,7 +146,8 @@ onBeforeUnmount(() => {
                         <button @click.prevent="handleArchiveRequest" class="btn btn-large btn-info _active-when-valid"
                             :class="{
                 '_isWorking': !readyStates.includes(globalStore.captureStatus),
-            }" id="addlink" type="submit">
+            }
+                " id="addlink" type="submit">
                             <Spinner v-if="isLoading" top="-20px" />
                             {{ submitButtonText }}
                             <ProgressBar v-if="globalStore.captureStatus === 'isCapturing'"


### PR DESCRIPTION
## What this does 
- Updates the button label and appearance in the updated Perma dashboard based on a user's folder selection: 
  - Selecting a private folder with update the button to display an orange background and the text "Create Private Perma Link"
 - Otherwise the button will display "Create Perma Link"
 - As usual, when a link is in the process of being created, the button will display the text "Creating your Perma Link". Previously, the copy wasn't sentence case — I noticed that it is in the legacy dashboard and updated it to match. 
 
 ## Screenshots for comparison
 Non-private folder selected
<img width="728" alt="Screenshot 2024-05-08 at 4 27 15 PM" src="https://github.com/harvard-lil/perma/assets/4039311/4f411100-f331-4fcc-8f8f-e437ec201602">

Private folder selected
<img width="769" alt="Screenshot 2024-05-08 at 4 27 21 PM" src="https://github.com/harvard-lil/perma/assets/4039311/d2ce64b7-a026-447d-b8f6-45e0a5ea175a">