### PR TITLE
Add dismissable perma tools info

### DIFF
--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -158,7 +158,7 @@ onBeforeUnmount(() => {
                     <FolderSelect v-if="!globalStore.userTypes.includes('individual')" />
                 </fieldset>
                 <p v-if="!isToolsReminderSuppressed" id="browser-tools-message" class="u-pb-150"
-                    :class="globalStore.userTypes === 'individual' ? 'limit-true' : 'limit-false'">
+                    :class="globalStore.userTypes === 'individual' && 'limit-true'">
                     To make Perma links more quickly, try our <a href="/settings/tools">browser tools</a>.
                     <button @click.prevent="handleSuppressToolsReminder" type="button"
                         class="close-browser-tools btn-link">

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -6,6 +6,7 @@ import ProgressBar from './ProgressBar.vue';
 import Spinner from './Spinner.vue';
 import LinkCount from './LinkCount.vue';
 import FolderSelect from './FolderSelect.vue';
+import { useStorage } from '@vueuse/core'
 
 const userLink = ref('')
 const userLinkGUID = ref('')
@@ -22,6 +23,11 @@ const submitButtonText = computed(() => {
 })
 
 let progressInterval;
+
+const isToolsReminderSuppressed = useStorage('perma_tools_reminder', false)
+const handleSuppressToolsReminder = () => {
+    isToolsReminderSuppressed.value = true
+}
 
 const handleArchiveRequest = async () => {
     if (!isReady) {
@@ -127,6 +133,7 @@ onBeforeUnmount(() => {
             <h2>Capture status: {{ globalStore.captureStatus }}</h2> <!-- debug only -->
             <h2 v-if="globalStore.captureStatus === 'isCapturing'">Capture progress: {{ userLinkProgressBar }}</h2>
             <!-- debug only -->
+
         </div>
         <div class="container cont-full-bleed cont-sm-fixed">
             <form class="form-priority" id="linker">
@@ -150,6 +157,15 @@ onBeforeUnmount(() => {
                     <LinkCount v-if="globalStore.userTypes.includes('individual')" />
                     <FolderSelect v-if="!globalStore.userTypes.includes('individual')" />
                 </fieldset>
+                <p v-if="!isToolsReminderSuppressed" id="browser-tools-message" class="u-pb-150"
+                    :class="globalStore.userTypes === 'individual' ? 'limit-true' : 'limit-false'">
+                    To make Perma links more quickly, try our <a href="/settings/tools">browser tools</a>.
+                    <button @click.prevent="handleSuppressToolsReminder" type="button"
+                        class="close-browser-tools btn-link">
+                        <span aria-hidden="true">&times;</span>
+                        <span class="sr-only">Close</span>
+                    </button>
+                </p>
             </form><!--/#linker-->
         </div><!-- cont-full-bleed cont-sm-fixed -->
     </div><!-- container cont-full-bleed -->

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -5857,3 +5857,9 @@ li[data-read_only="true"] {
     content: "\1F512";
   }
 }
+
+/* Measurements use calc so rem measurements are 1:1 with px size
+Example: calc(4rem / 16) is equal to 4px or 0.25rem */
+.u-pb-150 {
+  padding-bottom: calc(18rem / 16);
+}


### PR DESCRIPTION
## What this does 
- Adds dismissible information about the Perma Browser Tools. 
- Adds a css utility class, following the spacing tokens scale previously defined in the CAP static project. 

## Screenshots
Paragraph is visible by default, unless a user has previously clicked the close icon.
![Screenshot 2024-05-09 at 3 27 12 PM](https://github.com/harvard-lil/perma/assets/4039311/176cff1a-f0d7-4e24-bf7c-c9ab8298846b)

The position of the message shifts slightly for individual users: 
![Screenshot 2024-05-09 at 3 39 21 PM](https://github.com/harvard-lil/perma/assets/4039311/20750e1f-517b-4896-aae9-5a85c96ae45e)

The visibility of the content depends on the "perma_tools_reminder" key, which follows the naming pattern of the local storage object, "perma_selection"
![Screenshot 2024-05-09 at 3 27 30 PM](https://github.com/harvard-lil/perma/assets/4039311/8f342c95-00db-487b-94c3-921b205a74e6)

## Notes 
- We were previously relying on a cookie to determine if this text is visible. Because this is a user preference that is exclusively used client-side in the browser, and doesn't need to be included in API requests, it felt like it might make more sense to include it in local storage, which we were also already using for other client-side UI preferences. 
- There was some overlap between the legacy "Create a New Perma Link" header and the dismissible content that was preventing pointer events from being recognized on the close button. The easiest way to avoid this without introducing unnecessary changes to the legacy application seemed to be to introduce a utility CSS class, that we could easily add and remove if needed.