### PR TITLE
Validate and repair folder trees

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1332,7 +1332,7 @@ class Folder(MPTTModel):
 
 
     class MPTTMeta:
-        order_insertion_by = ['name']
+        order_insertion_by = ['name', 'id']
 
     def is_empty(self):
         return not self.children.exists() and not self.links.exists()

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -259,6 +259,7 @@ def delete_redundant_personal_links_folders(ctx, dry_run=False):
             assert user.root_folder_id in [folder.id for folder in folders]
             [redundant] = filter(lambda f: f.id != user.root_folder_id, folders)
             assert redundant.is_empty()
+            assert not redundant.contained_links().count()
         except AssertionError:
             print(f"Skipping user {user.id}: their situation isn't accounted for. Please investigate.")
             skipped = skipped + 1

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -141,6 +141,27 @@ def validate_folder_trees(ctx,
         print_errored_ids=False,
         print_exceptions=False,
         print_changed_nodes=False):
+    """
+    Report which folder trees would be altered during a rebuild.
+
+    If a tree is internally inconsistent, it is considered "invalid".
+
+    If a tree shares a tree_id with another tree, this report will classify the tree as "errored":
+    some trees like this can be repaired automatically by the full table rebuild utility, but some
+    trees need manual correction, and this report does not/cannot distinguish between the two.
+
+    Recommended usage:
+
+    1) Run first against the whole table, with minimal logging
+
+        docker compose exec web invoke dev.validate-folder-trees --print-invalid-ids --print-errored-ids
+
+    2) Then, run again with more detailed logging against particular trees or sets of trees
+
+        docker compose exec web invoke dev.validate-folder-trees --print-exceptions --tree-ids 100
+        docker compose exec web invoke dev.validate-folder-trees --print-changed-nodes --tree-ids 200
+
+    """
 
     def _reporting_rebuild_helper(self, node, left, tree_id, children, nodes_to_update, level):
         """
@@ -305,7 +326,9 @@ def delete_redundant_personal_links_folders(ctx, dry_run=False):
 
 @task
 def delete_redundant_org_folders(ctx, dry_run=False):
-
+    """
+    Clean up orgs with two top-level shared folders, due to an as-yet-undiagnosed timing issue.
+    """
     duplicated_folders = Folder.objects.filter(
         is_shared_folder=True
     ).order_by().values(
@@ -356,7 +379,6 @@ def delete_redundant_org_folders(ctx, dry_run=False):
     print(f"\nFixed up: {fixed_up}")
     print(f"Skipped: {skipped}")
     print(f"Mangled: {mangled}\n")
-
 
 
 @task

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -259,7 +259,6 @@ def delete_redundant_personal_links_folders(ctx, dry_run=False):
             assert user.root_folder_id in [folder.id for folder in folders]
             [redundant] = filter(lambda f: f.id != user.root_folder_id, folders)
             assert redundant.is_empty()
-            assert not redundant.contained_links().count()
         except AssertionError:
             print(f"Skipping user {user.id}: their situation isn't accounted for. Please investigate.")
             skipped = skipped + 1
@@ -315,7 +314,6 @@ def delete_redundant_org_folders(ctx, dry_run=False):
             assert org.shared_folder_id in [folder.id for folder in folders]
             [redundant] = filter(lambda f: f.id != org.shared_folder_id, folders)
             assert redundant.is_empty()
-            assert not redundant.contained_links().count()
         except AssertionError:
             print(f"Skipping org {org.id}: its situation isn't accounted for. Please investigate.")
             skipped = skipped + 1

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -157,7 +157,7 @@ def validate_folder_trees(ctx, tree_ids=None, limit=None):
                 changed_any = True
 
         if node.rght != right:
-           changed_any = True
+            changed_any = True
         if node.lft != left:
             changed_any = True
         if node.level != level:


### PR DESCRIPTION
Perma's folders are organized into a tree courtesy of [django-mptt](https://github.com/django-mptt/django-mptt). 

Every folder keeps track of its `parent` and has exactly one `tree_id`: a supposed-to-be-unique id associated with the parentless folder at the "top" of each root branch. For efficient lookups, each folder also has three fields, `lft`, `rght`, and `level`, that help make it easier to tell at a glance what the shape of the tree is.

The tree_ids, lfts, rghts, and levels of many of our trees have gotten messed up, because [it is the application's responsibility to ensure that two move operations are never run at the same time](https://django-mptt.readthedocs.io/en/latest/technical_details.html#concurrency)... something that goes beyond running in transactions... and we haven't been doing that, all this time.

This PR includes all the code I have written so far, while diagnosing and attempting to repair the current folder trees. See ENG-743 and its sub-issues for the full adventure :-)

It makes only one actual change to the codebase: everything else is just for reporting. 

It changes the sorting/insertion order of folders from just `name` to `name, id`, so that the order is deterministic, when a particular tree has folders with identical names: https://github.com/harvard-lil/perma/blob/7336c4bb9eb1259b6d0e1e8b03689f1f8354504c/perma_web/perma/models.py#L1335

That situation should be rare... but, because we know that sometimes folder insertion is extremely slow (another problem I'll be working to solve shortly), we know that people sometimes repeat their attempts, resulting in multiple folders.

I do not think that this change will have a negative effect on performance or anything else, but I could be failing to think of something.

We'll plan to run `delete_redundant_personal_links_folders` and `delete_redundant_org_folders` in production as part of a larger process to repair all the folder trees, a process we expect to take around 10 min.