### PR TITLE
Add celery tasks for fixing incorrect cached_path

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -441,6 +441,8 @@ CELERY_TASK_ROUTES = {
     'perma.celery_tasks.cache_playback_status': {'queue': 'background'},
     'perma.celery_tasks.populate_warc_size_fields': {'queue': 'background'},
     'perma.celery_tasks.populate_warc_size': {'queue': 'background'},
+    'perma.celery_tasks.fix_cached_folder_paths': {'queue': 'background'},
+    'perma.celery_tasks.fix_cached_folder_path': {'queue': 'background'},
     # the 'ia' queue is for tasks that alter or may alter Internet Archive's records
     'perma.celery_tasks.upload_link_to_internet_archive': {'queue': 'ia'},
     'perma.celery_tasks.delete_link_from_daily_item': {'queue': 'ia'},


### PR DESCRIPTION
As discussed in https://github.com/harvard-lil/perma/pull/3517, some of Perma's folder trees were found to have messed up metadata, due to concurrency issues.

We just fixed the current table of folders; we haven't yet made any moves to prevent future problems.

But, in the meantime, this makes it possible for us to correct the `cached_path` for about 15K folders for which that value is incorrect. The cached path is required to be correct for proper loading of the folder tree in the UI: updating it will fix navigation for all those 15K folders.

This PR updates all currently-broken `cached_path` fields using the background celery queue. On a local prod-like database, the entire table was fixed up in fewer than 5 minutes; I expect similar performance in production.

We would run:
```
In [1]: from perma.celery_tasks import fix_cached_folder_paths

In [2]: fix_cached_folder_paths.delay()
```
in the production Django shell to trigger the queuing of the repairing tasks, and then watch the background queue eat through the tasks. Locally, the background queue was often able to finish work faster than the queuing tasks was able to queue up more, but the pace varied.

Once everything finished, we could run `fix_cached_folder_paths.delay()` a second time, and observe it to be a no-op.

Pretty fun.