### PR TITLE
Add a secondary storage to support wacz experiments.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - MINIO_ROOT_PASSWORD=secretkey
       - DATA_DIR=/data
       - BUCKET=perma-storage
+      - SECONDARY_BUCKET=perma-secondary-storage
       - MINIO_API_CORS_ALLOW_ORIGIN=https://replay.perma.test:8000
     volumes:
       - ./services/docker/minio/entrypoint.sh:/entrypoint.sh

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -108,14 +108,15 @@ def cleanup_storage():
     Empty the configured storage after each test, so that it's fresh each time.
     """
     yield
-    storage = boto3.resource(
-        's3',
-        endpoint_url=settings.STORAGES["default"]["OPTIONS"]["endpoint_url"],
-        aws_access_key_id=settings.STORAGES["default"]["OPTIONS"]["access_key"],
-        aws_secret_access_key=settings.STORAGES["default"]["OPTIONS"]["secret_key"],
-        verify=False
-    ).Bucket(settings.STORAGES["default"]["OPTIONS"]["bucket_name"])
-    storage.objects.delete()
+    for storage_option in ['default', 'secondary']:
+        storage = boto3.resource(
+            's3',
+            endpoint_url=settings.STORAGES[storage_option]["OPTIONS"]["endpoint_url"],
+            aws_access_key_id=settings.STORAGES[storage_option]["OPTIONS"]["access_key"],
+            aws_secret_access_key=settings.STORAGES[storage_option]["OPTIONS"]["secret_key"],
+            verify=False
+        ).Bucket(settings.STORAGES[storage_option]["OPTIONS"]["bucket_name"])
+        storage.objects.delete()
 
 
 URL_MAP = {

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -16,7 +16,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-from django.core.files.storage import default_storage
+from django.core.files.storage import default_storage, storages
 from django.core.mail import mail_admins
 from django.db.models import F
 from django.db.models.functions import Greatest, Now
@@ -90,7 +90,7 @@ def inc_progress(capture_job, inc, description):
 
 ### CAPTURE COMPLETION ###
 
-def save_scoop_capture(link, capture_job, data):
+def save_scoop_capture(link, capture_job, data, storage='default'):
 
     inc_progress(capture_job, 1, "Saving metadata")
 
@@ -196,7 +196,7 @@ def save_scoop_capture(link, capture_job, data):
         tmp_file.seek(0)
 
         inc_progress(capture_job, 1, "Saving web archive file")
-        default_storage.store_file(tmp_file, link.warc_storage_file(), overwrite=True)
+        storages[storage].store_file(tmp_file, link.warc_storage_file(), overwrite=True)
 
     capture_job.mark_completed()
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -47,6 +47,13 @@ STORAGES = {
             "default_acl": 'private'
         }
     },
+    "secondary": {
+        "BACKEND": 'perma.storage_backends.S3MediaStorage',
+        "OPTIONS": {
+            "signature_version": 's3v4',
+            "default_acl": 'private'
+        }
+    },
     "staticfiles": {
         "BACKEND": 'perma.storage_backends.StaticStorage',
     },

--- a/perma_web/perma/settings/deployments/settings_dev.py
+++ b/perma_web/perma/settings/deployments/settings_dev.py
@@ -18,6 +18,12 @@ STORAGES["default"]["OPTIONS"]["secret_key"] = 'secretkey'
 STORAGES["default"]["OPTIONS"]["bucket_name"] = 'perma-storage'
 STORAGES["default"]["OPTIONS"]["verify"] = False
 
+STORAGES["secondary"]["OPTIONS"]["endpoint_url"] = 'https://perma.minio.test:9000'
+STORAGES["secondary"]["OPTIONS"]["access_key"] = 'accesskey'
+STORAGES["secondary"]["OPTIONS"]["secret_key"] = 'secretkey'
+STORAGES["secondary"]["OPTIONS"]["bucket_name"] = 'perma-secondary-storage'
+STORAGES["secondary"]["OPTIONS"]["verify"] = False
+
 # static files
 STATIC_ROOT = os.path.join(SERVICES_DIR, 'django/static_assets/')
 

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -25,6 +25,7 @@ ADMINS = (
 )
 
 STORAGES["default"]["OPTIONS"]["bucket_name"] += '-test'
+STORAGES["secondary"]["OPTIONS"]["bucket_name"] += '-test'
 
 ###############
 # Speed Hacks #

--- a/services/docker/minio/entrypoint.sh
+++ b/services/docker/minio/entrypoint.sh
@@ -5,6 +5,8 @@ set -e
 # Initialize default buckets
 mkdir -p "$DATA_DIR/$BUCKET"
 mkdir -p "$DATA_DIR/$BUCKET-test"
+mkdir -p "$DATA_DIR/$SECONDARY_BUCKET"
+mkdir -p "$DATA_DIR/$SECONDARY_BUCKET-test"
 
 # Pass the Docker CMD to the image's original entrypoint script.
 exec su -c "/usr/bin/docker-entrypoint.sh $*"


### PR DESCRIPTION
We've been working on plans to start capturing and playing back WACZ-formatted archives, either in addition to or instead of WARC-formatted. We've also been experimenting with converting our existing archives to WACZ.

To experiment more safely, we'd like to have another S3 bucket available, one that we can feel comfortable messing around with, deleting artifacts from, etc... entirely separate from where we keep the WARCs for Perma's actual collection, which, appropriately, has very strict rules.

This PR adds config for an additional "secondary" storage, and locally wires it up to minio.

It should be safe to deploy without changing stage or prod config, and without creating any additional cloud storage: we can do that in the future, if we have any code that actually uses the secondary storage that we want to try out in stage or prod.

