### PR TITLE
Add toast component

### DIFF
--- a/perma_web/frontend/components/App.vue
+++ b/perma_web/frontend/components/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import CreateLink from './CreateLink.vue';
+import Toast from './Toast.vue';
 import { onBeforeMount, watchEffect } from 'vue'
 import { getLinksRemainingStatus, getUserTypes, getUserOrganizations, getSponsoredFolders } from '../lib/store'
 import { globalStore } from '../stores/globalStore';
@@ -23,5 +24,6 @@ watchEffect(() => {
 </script>
 
 <template>
+    <Toast />
     <CreateLink />
 </template>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -126,7 +126,7 @@ const { addToast } = useToast();
 
 const toggleToast = () => {
     const date = Date.now();
-    addToast(`State changed on ${date}"!`, 'success');
+    addToast(`Toast notification ${date}`, 'success');
 }
 
 watch(userLinkGUID, () => {

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -7,6 +7,7 @@ import Spinner from './Spinner.vue';
 import LinkCount from './LinkCount.vue';
 import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
+import { useToast } from '../lib/notifications';
 
 const userLink = ref('')
 const userLinkGUID = ref('')
@@ -121,6 +122,13 @@ const handleProgressUpdate = async () => {
     }
 }
 
+const { addToast } = useToast();
+
+const toggleToast = () => {
+    const date = Date.now();
+    addToast(`State changed on ${date}"!`, 'success');
+}
+
 watch(userLinkGUID, () => {
     handleProgressUpdate()
     progressInterval = setInterval(handleProgressUpdate, 2000);
@@ -138,6 +146,7 @@ onBeforeUnmount(() => {
         <div class="container cont-fixed">
             <h2>Capture status: {{ globalStore.captureStatus }}</h2> <!-- debug only -->
             <h2 v-if="globalStore.captureStatus === 'isCapturing'">Capture progress: {{ userLinkProgressBar }}</h2>
+            <button @click="toggleToast">Toggle toast</button>
             <!-- debug only -->
 
         </div>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -144,7 +144,9 @@ onBeforeUnmount(() => {
     <!-- regular link creation -->
     <div id="create-item-container" class="container cont-full-bleed">
         <div class="container cont-fixed">
-            <h2>Capture status: {{ globalStore.captureStatus }}</h2> <!-- debug only -->
+
+            <!-- debug only -->
+            <h2>Capture status: {{ globalStore.captureStatus }}</h2>
             <h2 v-if="globalStore.captureStatus === 'isCapturing'">Capture progress: {{ userLinkProgressBar }}</h2>
             <button @click="toggleToast">Toggle toast</button>
             <!-- debug only -->

--- a/perma_web/frontend/components/Toast.vue
+++ b/perma_web/frontend/components/Toast.vue
@@ -5,11 +5,12 @@ const { toasts } = useToast();
 </script>
 
 <template>
-    <template v-for="toast in toasts" :key="toast.id">
-        <div :class="`alert alert-${toast.status} alert-dismissible popup-alert`" role="alert">
+    <TransitionGroup name="fade">
+        <div v-for="toast in toasts" :key="toast.id" :class="`alert alert-${toast.status} alert-dismissible
+        popup-alert`" role="alert">
             {{ toast.message }}
-            <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span
+            <button type="button" class="close"><span aria-hidden="true">&times;</span><span
                     class="sr-only">Close</span></button>
         </div>
-    </template>
+    </TransitionGroup>
 </template>

--- a/perma_web/frontend/components/Toast.vue
+++ b/perma_web/frontend/components/Toast.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { useToast } from '../lib/notifications'
+
+const { toasts } = useToast();
+</script>
+
+<template>
+    <div>
+        <div v-for="toast in toasts" :key="toast.id">
+            {{ toast.message }}
+        </div>
+    </div>
+</template>

--- a/perma_web/frontend/components/Toast.vue
+++ b/perma_web/frontend/components/Toast.vue
@@ -5,9 +5,11 @@ const { toasts } = useToast();
 </script>
 
 <template>
-    <div>
-        <div v-for="toast in toasts" :key="toast.id">
+    <template v-for="toast in toasts" :key="toast.id">
+        <div :class="`alert alert-${toast.status} alert-dismissible popup-alert`" role="alert">
             {{ toast.message }}
+            <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span
+                    class="sr-only">Close</span></button>
         </div>
-    </div>
+    </template>
 </template>

--- a/perma_web/frontend/lib/notifications.js
+++ b/perma_web/frontend/lib/notifications.js
@@ -1,0 +1,20 @@
+import { ref } from 'vue';
+import { useTimeoutFn } from '@vueuse/core';
+
+const toasts = ref([]);
+
+export const useToast = () => {
+  const addToast = (message, status) => {
+    const id = Date.now();
+    toasts.value.push({ id, message, status });
+    
+    useTimeoutFn(() => {
+      toasts.value = toasts.value.filter(toast => toast.id !== id);
+    }, 3000);
+  };
+  
+  return {
+    toasts,
+    addToast
+  };
+}

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -5863,3 +5863,14 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
 .u-pb-150 {
   padding-bottom: calc(18rem / 16);
 }
+
+/* CSS transition classes automatically added/removed by Vue */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}


### PR DESCRIPTION
## What this does 
Adds a component and composable hook for displaying toast notifications. The component currently supports the following: 

- Toast notification message 
- Toast state (For example "success" or "error") 

It's somewhat common in web applications for one or more toast notifications to be visible on the page at one time. For this reason, the toast component is structured to support rendering more than one unique toast notification at a time.

The current Perma CSS styling for a toast will simply stack the most recent toast on top of a previous one. However, if this is redesigned in the future, and we have a need for "stacked" toast notification, we will have the capability for it.

The legacy toast additionally features a subtle animation when it is added to the page. I recreated a subtle fade-in transition for the new component using Vue's built-in `TransitionGroup` wrapper and namespaced css style so Vue can programmatically pick them up. 

## Screenshots 
For the purpose of testing, I added a button to the debug area of the new dashboard: 
![image](https://github.com/harvard-lil/perma/assets/4039311/b30e940d-04e0-4fb2-b7e9-a37813911eb8)

Clicking it will trigger a toast with dummy text that includes a unique id generated from a timestamp: 
![image](https://github.com/harvard-lil/perma/assets/4039311/ef958f91-9776-4f8e-82e1-098bdad57f29)

## Future notes 
- Like with other UI work, there's definitely more that can be done to improve accessibility with this element during a future redesign. 
