### PR TITLE
Fix Folder admin

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -648,7 +648,7 @@ class LinkAdmin(SimpleHistoryAdmin):
 class FolderAdmin(admin.ModelAdmin):
     list_display = ['id', 'name', 'tree_root_id', 'cached_path', 'owned_by', 'organization', 'sponsored_by', 'read_only']
     list_filter = [NameFilter, OwnerFilter, OrgFilter, RootFilter]
-    raw_id_fields = ['parent', 'created_by', 'owned_by', 'organization', 'sponsored_by']
+    raw_id_fields = ['tree_root', 'parent', 'created_by', 'owned_by', 'organization', 'sponsored_by']
     ordering = ('cached_path',)
 
     paginator = FasterAdminPaginator


### PR DESCRIPTION
This PR adds 'tree_root' to the Folder admin's list of [raw id fields](https://docs.djangoproject.com/en/5.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields), so that, when a folder's detail page renders, Django doesn't offer a `select` with every single Perma folder as an option 😂... which is a big enough request that the page doesn't currently load. 