### PR TITLE
Add error handling for individual captures

### DIFF
--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -28,7 +28,7 @@ watch(
             showGeneric.value = false;
         }
 
-        else if (errorMessage.includes("Error 0")) {
+        else if (errorMessage.includes("Error 0") || errorMessage.includes("folder")) {
             showUploadLink.value = false;
         }
     }

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -39,7 +39,7 @@ watch(
     <div class="container cont-fixed">
         <div v-if="globalStore.captureErrorMessage" id="error-container">
             <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
-                    Please <a href='/login'>login</a> to continue.
+                    Please <a href='/login'>log in</a> to continue.
                 </span></p>
             <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
             <p v-if="showUploadLink">You can <button id="upload-form-button">upload your own archive</button> or <a

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -1,0 +1,50 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { globalStore } from '../stores/globalStore';
+
+const showUploadLink = ref()
+const showGeneric = ref()
+const showLoginLink = ref()
+
+watch(
+    () => globalStore.captureErrorMessage,
+    (errorMessage) => {
+        showUploadLink.value = true
+        showGeneric.value = true
+        showLoginLink.value = false
+
+        if (errorMessage.includes("logged out")) {
+            showLoginLink.value = true;
+            showUploadLink.value = false;
+        }
+
+        else if (errorMessage.includes("limit")) {
+            globalStore.updateLinksRemaining(0);
+            showUploadLink.value = false;
+        }
+
+        else if (errorMessage.includes("subscription")) {
+            showUploadLink.value = false;
+            showGeneric.value = false;
+        }
+
+        else if (errorMessage.includes("Error 0")) {
+            showUploadLink.value = false;
+        }
+    }
+);
+</script>
+
+<template>
+    <div class="container cont-fixed">
+        <div v-if="globalStore.captureErrorMessage" id="error-container">
+            <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
+                    Please <a href='/login'>login</a> to continue.
+                </span></p>
+            <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
+            <p v-if="showUploadLink">You can <button id="upload-form-button">upload your own archive</button> or <a
+                    href="/contact">contact us
+                    about this error.</a></p>
+        </div>
+    </div>
+</template>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -121,7 +121,7 @@ const handleCaptureStatus = async (guid) => {
 
         if (!response?.ok) {
             const errorResponse = await response.json()
-            throw { status: response.status, response: errorResponse }
+            throw { errorResponse }
         }
 
         const jobStatus = await response.json()

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -62,7 +62,7 @@ const handleArchiveRequest = async () => {
 
     try {
         if (!formData.folder) {
-            const errorMessage = 'Missing folder selection'
+            const errorMessage = 'Missing folder selection.'
             globalStore.updateCaptureErrorMessage(errorMessage)
             throw errorMessage
         }

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -124,12 +124,12 @@ const handleCaptureStatus = async (guid) => {
             throw { errorResponse }
         }
 
-        const jobStatus = await response.json()
+        const job = await response.json()
 
         return {
-            step_count: jobStatus.step_count,
-            status: jobStatus.status,
-            error: jobStatus.status === 'failed' ? jobStatus.message : ''
+            step_count: job.step_count,
+            status: job.status,
+            error: job.status === 'failed' ? job.message : ''
         }
 
     } catch (errorData) {

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -4,6 +4,7 @@ import { globalStore } from '../stores/globalStore'
 import { getCookie } from '../../static/js/helpers/general.helpers'
 import ProgressBar from './ProgressBar.vue';
 import Spinner from './Spinner.vue';
+import CaptureError from './CaptureError.vue'
 import LinkCount from './LinkCount.vue';
 import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
@@ -25,10 +26,6 @@ const isReady = computed(() => { readyStates.includes(globalStore.captureStatus)
 
 const loadingStates = ["isValidating", "isQueued", "isCapturing"]
 const isLoading = computed(() => { return loadingStates.includes(globalStore.captureStatus) })
-
-const showUploadLink = ref(true)
-const showGeneric = ref(true)
-const showLoginLink = ref(false)
 
 const submitButtonText = computed(() => {
     if (readyStates.includes(globalStore.captureStatus) && globalStore.selectedFolder.isPrivate) {
@@ -167,32 +164,6 @@ watch(userLinkGUID, () => {
     progressInterval = setInterval(handleProgressUpdate, 2000);
 })
 
-watchEffect(() => {
-    const errorMessage = globalStore.captureErrorMessage.value;
-
-    if (!errorMessage) {
-        return;
-    }
-
-    if (errorMessage.includes("logged out")) {
-        showLoginLink.value = true;
-    }
-
-    if (errorMessage.includes("limit")) {
-        globalStore.updateLinksRemaining(0);
-        showUploadLink.value = false;
-    }
-
-    if (errorMessage.includes("subscription")) {
-        showUploadLink.value = false;
-        showGeneric.value = false;
-    }
-
-    if (errorMessage.includes("Error 0")) {
-        showUploadLink.value = false;
-    }
-});
-
 onBeforeUnmount(() => {
     clearInterval(progressInterval)
 });
@@ -246,17 +217,7 @@ onBeforeUnmount(() => {
         </div><!-- cont-full-bleed cont-sm-fixed -->
     </div><!-- container cont-full-bleed -->
 
-    <div class="create-errors container cont-fixed">
-        <div v-if="globalStore.captureErrorMessage" id="error-container">
-            <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
-                    Please <a href='/login'>login</a> to continue.
-                </span></p>
-            <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
-            <p v-if="showUploadLink">You can <button id="upload-form-button">upload your own archive</button> or <a
-                    href="/contact">contact us
-                    about this error.</a></p>
-        </div>
-    </div>
+    <CaptureError />
 
     <CreateLinkBatch ref="batchDialogRef" />
 </template>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -121,7 +121,7 @@ const handleCaptureStatus = async (guid) => {
 
         if (!response?.ok) {
             const errorResponse = await response.json()
-            throw { errorResponse }
+            throw { status: response.status, response: errorResponse }
         }
 
         const job = await response.json()

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -123,7 +123,7 @@ const handleCaptureStatus = async (guid) => {
     try {
         const response = await fetch(`/api/v1/user/capture_jobs/${guid}`)
 
-        if (!response.ok) {
+        if (!response?.ok) {
             throw new Error()
         }
 

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -62,7 +62,7 @@ const handleArchiveRequest = async () => {
 
     try {
         if (!formData.folder) {
-            const errorMessage = 'Missing folder selection.'
+            const errorMessage = 'Missing folder selection. Please select a folder.'
             globalStore.updateCaptureErrorMessage(errorMessage)
             throw errorMessage
         }

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -195,10 +195,10 @@ onBeforeUnmount(() => {
                 '_isWorking': !readyStates.includes(globalStore.captureStatus),
             }
                 " id="addlink" type="submit">
-                            <!-- <Spinner v-if="isLoading" top="-20px" /> -->
+                            <Spinner v-if="isLoading" top="-20px" />
                             {{ submitButtonText }}
-                            <!-- <ProgressBar v-if="globalStore.captureStatus === 'isCapturing'"
-                                :progress="userLinkProgressBar" /> -->
+                            <ProgressBar v-if="globalStore.captureStatus === 'isCapturing'"
+                                :progress="userLinkProgressBar" />
                         </button>
                         <p id="create-batch-links">or <button @click.prevent="batchDialogOpen" class="c-button"
                                 :class="globalStore.selectedFolder.isPrivate ? 'c-button--privateLink' : 'c-button--link'">create

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -123,9 +123,8 @@ const handleCaptureStatus = async (guid) => {
     try {
         const response = await fetch(`/api/v1/user/capture_jobs/${guid}`)
 
-        if (!response?.ok) {
-            const errorResponse = await response.json()
-            throw { status: response.status, response: errorResponse }
+        if (!response.ok) {
+            throw new Error()
         }
 
         const job = await response.json()
@@ -136,12 +135,10 @@ const handleCaptureStatus = async (guid) => {
             error: job.status === 'failed' ? job.message : ''
         }
 
-    } catch (errorData) {
-        return {
-            step_count: errorData?.step_count ?? 0,
-            status: 'failed',
-            error: errorData?.message ?? ''
-        };
+    } catch (error) {
+        // TODO: Implement maxFailedAttempts logic here
+        console.log(error)
+        return
     }
 }
 

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -102,7 +102,7 @@ const handleCaptureError = ({ error, errorType }) => {
     }
 
     // Handle frontend-generated error messages
-    else if (!!error) {
+    else if (error.length) {
         errorMessage = error
     }
 
@@ -156,7 +156,7 @@ const handleProgressUpdate = async () => {
     }
 
     if (status === 'failed') {
-        const errorMessage = error.length ? getErrorFromNestedObject(JSON.parse(errorMessage)) : defaultError
+        const errorMessage = error.length ? getErrorFromNestedObject(JSON.parse(error)) : defaultError
 
         clearInterval(progressInterval)
 

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -97,14 +97,17 @@ const handleArchiveRequest = async () => {
 const handleCaptureError = ({ error, errorType }) => {
     let errorMessage
 
+    // Handle API-generated error messages
     if (error?.response) {
         errorMessage = getErrorFromResponseStatus(error.status, error.response)
     }
 
+    // Handle frontend-generated error messages
     else if (!!error) {
         errorMessage = error
     }
 
+    // Handle uncaught errors
     else {
         errorMessage = "We're sorry, we've encountered an error processing your request."
     }

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -9,7 +9,7 @@ import LinkCount from './LinkCount.vue';
 import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
 import CreateLinkBatch from './CreateLinkBatch.vue';
-import { getErrorFromNestedObject, getErrorFromResponseStatus } from "../lib/errors"
+import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse } from "../lib/errors"
 
 const defaultError = "We're sorry, we've encountered an error processing your request."
 const batchDialogRef = ref('')
@@ -80,8 +80,8 @@ const handleArchiveRequest = async () => {
             })
 
         if (!response?.ok) {
-            const errorResponse = await response.json()
-            throw { status: response.status, response: errorResponse }
+            const errorResponse = await getErrorResponse(response)
+            throw errorResponse
         }
 
         const { guid } = await response.json()
@@ -104,6 +104,10 @@ const handleCaptureError = ({ error, errorType }) => {
     // Handle frontend-generated error messages
     else if (error.length) {
         errorMessage = error
+    }
+
+    else if (error?.status) {
+        errorMessage = `Error: ${error.status}`
     }
 
     // Handle uncaught errors

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -135,7 +135,7 @@ const handleCaptureStatus = async (guid) => {
     } catch (errorData) {
         return {
             step_count: errorData?.step_count ?? 0,
-            status: errorData?.status ? errorData?.status : 'failed',
+            status: 'failed',
             error: errorData?.message ?? ''
         };
     }

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -39,3 +39,12 @@ export const getErrorFromNestedObject = (object) => {
 
     return errorMessage
 }
+
+export const getErrorResponse = async (response) => {
+  try {
+      const errorBody = await response.json();
+      return { status: response.status, response: errorBody }
+  } catch (error) {
+      return { status: response.status };
+  }
+};

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -1,0 +1,19 @@
+// Returns the first error string nested within an API error response object
+// For example, passing {"url":["URL cannot be empty."]} would return "URL cannot be empty."
+export const getErrorFromNestedObject = (object) => {
+    const getString = (obj) => {
+      if (typeof obj === 'string') {
+        return obj;
+      }
+  
+      if (typeof obj === 'object' && obj !== null) {
+        return Object.keys(obj)
+          .map(key => getString(obj[key]))
+          .find(result => result !== undefined);
+      }
+  
+      return undefined;
+    };
+  
+    return getString(object) || null;
+  }

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -17,3 +17,25 @@ export const getErrorFromNestedObject = (object) => {
   
     return getString(object) || null;
   }
+
+ export const getErrorFromResponseStatus = (status, response) => {
+    let errorMessage
+
+    switch (status) {
+        case 400:
+            errorMessage = getErrorFromNestedObject(response)
+            break;
+        case 401:
+            errorMessage = "You appear to be logged out."
+            break;
+        default:
+            errorMessage = `Error: ${status}`
+            break;
+    }
+
+    if (errorMessage.includes("Error 0")) {
+        errorMessage = "Perma.cc Temporarily Unavailable"
+    }
+
+    return errorMessage
+}


### PR DESCRIPTION
## What this does 
This update renders formatted errors for attempts to capture a perma link that fail, for multiple reasons. 

Most notably, it adds a `CaptureError` component, as well as additional utility functions.

## Implementation requirements

I scoped out these error handling requirements for single link capture failures:

### Generic Error Handling
- If capture fails, but there is no `jqXHR` response: `(typeof jqXHR == 'undefined')`
  - Set "Capture Failed" as the message
- If API status is 400, and there is a `responseText`
  - Set the message from response text using `stringFromNestedObject` helper
- If API status is a 401
  - Set the message to <a href='/login'>You appear to be logged out. Please click here to log back in</a>
- Otherwise, if there is another status
  - Set the message to "Error" plus the actual error status
- If none of these situations apply to the error, set the message to "We're sorry, we've encountered an error processing your request."

### Special Error Handling
- If error message string includes "limit"
  - `updateLinksRemaining(0)`
  - `offer_upload = false` (Show the link to that allows someone to toggle an upload modal)
 - If error message string includes "subscription"
   - `offer_upload = false`
   - `show_generic = false`  
- If error message string includes "Error 0"
  - `offer_upload = false`
  -   Set the error message to "Perma.cc Temporarily Unavailable"
 
## Intentional changes

### Jquery -> async/await
The biggest change in implementation is the shift from Jquery error handling to more modern async/ await. In legacy jQuery (JQXHR) error handling, it's my understanding you deal with error handling for asynchronous operations using callbacks. The JQXHR object is used to handle the response and error callbacks. Specifically: 

- Developers need to handle success and error in separate callback functions.
- It's often necessary to check if a jqXHR object exists before accessing properties (with async/await, developers can work directly with the response object.)
- If the jqXHR object is present, it will have a status property indicating the HTTP status code of the response

With async/await, error handling is typically a lot simpler to reason about, requires less manual checks, and is done using try/catch blocks. For example: 

- If an API response is returned within a `try/catch`, it should always include a status code. 
- It should also return a `ok` property that indicates if the status code is one associated with errors. 
- If no viable response is returned as a result of an API call (a timeout, for example or some other unhandled or unpredictable situation) and a generic error is thrown, that should be caught by the `catch` block. 

In implementation: 
- If an API response indicates a capture has failed, parse and display the error message provided by the backend. There are specific cases where the visible, public message differs based on either the status code or the contents of the API-provided error message. 
- If there is no `response` object returned from the API, display a default  "We're sorry, we've encountered an error processing your request."
- If a user doesn't choose a folder, or another clientside-only error situation, errors are generated as a single error string that is then displayed to users. Previously this was handled by disabling the submit button. 
- There is notably no place in the code where we are manually check if the jqXHR object exists (although we do check if there is an `error.response`). That previously triggered a generic "Capture failed." message, which will now only be displayed if the backend directly shares that message as part of a response. For all situations where there is no error response, and there is no frontend-generated error, this code displays the generic "We're sorry, we've encountered an error processing your request."

### Renamed variables 
I did rename some variables for readability. One of the things I renamed for clarity and readability is `offer_upload`. This has been renamed to `showUploadLink`.

### Revised error message
For an error that is thrown with a 401, there was a requirement to set the error message to `<a href='/login'>You appear to be logged out. Please click here to log back in</a>`. I rephrased this slightly, per common accessibility recommendations to avoid using language that says "click here". The updated phrasing includes a link with link text that reads login. 

### API error handling separated from UI updates
There is a component, `CaptureError` that handles hiding or showing specific help text and/or links based on the specific error associated with a capture attempt. This is kept completely separate from the async/await and try/catch logic associated with API handling. Previously, functions colocated attempting to handle API-related errors and handle the logic of what UI to display as a result of those errors. 

## Screenshots 
These are all the many errors that should be possible.

### 1. When a user is out of perma links: 
![image](https://github.com/harvard-lil/perma/assets/4039311/f914f498-8db2-4052-abee-424ec5d4dd52)

### 2. When a user inputs an invalid url: 
![Screenshot 2024-06-04 at 2 12 44 PM](https://github.com/harvard-lil/perma/assets/4039311/8a5cd3cd-c878-4294-b799-72c31d12aceb)

### 3. When user hasn't chosen a destination folder: 
![image](https://github.com/harvard-lil/perma/assets/4039311/561dea52-e9d8-4168-b776-e27ac62a6a71)

### 4. When a request to start a capture fails with a response code of 400 and the API-provided error response message includes "Error 0":
![Screenshot 2024-06-04 at 2 20 53 PM](https://github.com/harvard-lil/perma/assets/4039311/9b5563a5-4e04-49a6-ab35-b731cb8cc3d3)

### 5. When a request to start a capture fails with a response code of 401: 
![image](https://github.com/harvard-lil/perma/assets/4039311/56a43bf4-3918-43e3-a415-e917a0f07793)

### 6. When a request to start a capture fails with a proper API response, with a response code that is not 400 or 401. In this case, the error message includes the numerical status of the response: 
![image](https://github.com/harvard-lil/perma/assets/4039311/c62db994-307e-4af4-9ad8-7418f1124613)

### 7. When a request to start a capture succeeds. But at some point after Scoop attempts to begin capture, the API response about the status of the capture indicates that it has failed.
![image](https://github.com/harvard-lil/perma/assets/4039311/bd1a68f9-fb14-466b-a6e2-751dc57e8c8f)

Note: I tested this by adding `poll_data['status'] = 'failure'`  to line 314 of `celery_tasks.py`, so that I could see perma url submission work, and then see capture polling initially begin to work, and then quickly fail. 

### 8. When there is an unspecified error that happens either during the url submission process or the url capture process. (For example, a request times out, and there isn't a proper API response):
![image](https://github.com/harvard-lil/perma/assets/4039311/920a1341-9c8e-4b16-8dd6-3f926aacb612)

Note: I tested this out by commenting-out the API request logic within the try block in `handleCaptureStatus` and including `throw new Error()` instead, to test-out what would happen if there was an error but no API response. 

## Outstanding Questions
- Is it important to deduce the API error status (400, 401) of an error that is thrown after a job is already in the capture progress? 
   - Right now, if an error is thrown while a job is in progress, this code will either display the error directly from the API response object (if it exists) or display a generic error. It doesn't check if the API status is 400, 401, or another status like 500. Should we be doing that? 
  -  I don't have a sense if that is entirely meaningful information to deduce. So I wanted to ask before refactoring logic to return both the status of a job ("failed", "success", etc) and the numerical status of the API response (400, 500, etc).
- If an unspecified error happens during the capturing process (eg, a response timed out and there was no specific error returned by the API), should we assume it's possible that the capture did succeed (we just can't confirm it) and not display the secondary "We were unable to create your perma link error" error beneath the main error message?