### PR TITLE
Use regular spaces, rather than non-breaking spaces, in formatted filenames

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1292,7 +1292,7 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
             return f"{math.ceil(seconds_val)} seconds"
 
     def format_filesize(i):
-        filesizeformat(i).replace("\xa0", " ")
+        return filesizeformat(i).replace("\xa0", " ")
 
     #
     # Launch the conversions

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1291,6 +1291,9 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
         else:
             return f"{math.ceil(seconds_val)} seconds"
 
+    def format_filesize(i):
+        filesizeformat(i).replace("\xa0", " ")
+
     #
     # Launch the conversions
     #
@@ -1354,13 +1357,13 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
     conversion_duration = time.time() - conversion_start_time
 
     warc_size = link.warc_size
-    formatted_warc_size = filesizeformat(warc_size)
+    formatted_warc_size = format_filesize(warc_size)
     try:
         wacz_size = os.path.getsize(wacz_path)
     except OSError:
         wacz_size = 0
 
-    formatted_wacz_size = filesizeformat(wacz_size)
+    formatted_wacz_size = format_filesize(wacz_size)
     raw_total_duration = time.time() - start_time
     duration = seconds_to_minutes(raw_total_duration)
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1268,16 +1268,6 @@ def conditionally_queue_internet_archive_uploads_for_date_range(start_date_strin
 
 # WACZ CONVERSION
 
-def seconds_to_minutes(seconds_val):
-    """
-    Converts seconds to minutes
-    """
-    if seconds_val >= 60:
-        return f"{round(seconds_val / 60, 1)} minutes"
-    else:
-        return f"{math.ceil(seconds_val)} seconds"
-
-
 @shared_task
 @tempdir.run_in_tempdir()
 def convert_warc_to_wacz(input_guid, benchmark_log):
@@ -1287,6 +1277,24 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
     Logs conversion metrics
     If successful, saves file in storage
     """
+
+    #
+    # Helper methods
+    #
+
+    def seconds_to_minutes(seconds_val):
+        """
+        Converts seconds to minutes
+        """
+        if seconds_val >= 60:
+            return f"{round(seconds_val / 60, 1)} minutes"
+        else:
+            return f"{math.ceil(seconds_val)} seconds"
+
+    #
+    # Launch the conversions
+    #
+
     start_time = time.time()
     link = Link.objects.get(guid=input_guid)
     cwd = os.getcwd()


### PR DESCRIPTION
This tweaks the output of two fields in our report about how things went, when converting a WARC to a WACZ.

The difference:
```
In [1]: from django.template.defaultfilters import filesizeformat

In [2]: filesizeformat(100)
Out[2]: '100\xa0bytes'

In [3]: filesizeformat(100).replace("\xa0", " ")
Out[3]: '100 bytes'
```

See ENG-923.