### PR TITLE
Tweak pages.jsonl produced when converting WARC -> WACZ

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -39,7 +39,6 @@ logger = logging.getLogger('celery.django')
 import csv
 import subprocess
 import math
-import json
 
 ### ERROR REPORTING ###
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1294,6 +1294,11 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
     wacz_path = f"{link.guid}.wacz"
     pages_path = "pages.jsonl"
 
+    # confirm this Link has a warc that should be converted
+    if not link.cached_can_play_back:
+        logger.error(f"{link.guid} is ineligible for conversion.")
+        return
+
     # save a local copy of the warc file
     warc_save_start_time = time.time()
     with open(warc_path, "wb") as file:
@@ -1301,28 +1306,10 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
     warc_save_duration = time.time() - warc_save_start_time
 
     # prepare our custom pages.jsonl file
-    jsonl_prep_start_time = time.time()
-    jsonl_rows = [
-        {"format": "json-pages-1.0", "id": "pages", "title": "All Pages"}
-    ]
-    ts = str(link.creation_timestamp)
-    if link.primary_capture:
-        jsonl_rows.append(
-            {"title": "primary capture url", "url": link.primary_capture.url, "ts": ts}
-        )
-    if link.screenshot_capture:
-        jsonl_rows.append(
-            {"title": "screenshot url", "url": link.screenshot_capture.url, "ts": ts}
-        )
-    if link.provenance_summary_capture:
-        jsonl_rows.append(
-            {"title": "provenance summary url", "url": link.provenance_summary_capture.url, "ts": ts}
-        )
-    assert len(jsonl_rows) > 1, f"{link.guid} has neither a primary nor a screenshot capture!"
+    pages_prep_start_time = time.time()
     with open(pages_path, 'w') as file:
-        for item in jsonl_rows:
-            file.write(json.dumps(item) + '\n')
-    jsonl_write_duration = time.time() - jsonl_prep_start_time
+        file.write(link.get_pages_jsonl() + '\n')
+    pages_write_duration = time.time() - pages_prep_start_time
 
     # call js-wacz in a subprocess
     conversion_start_time = time.time()
@@ -1367,7 +1354,7 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
             "duration": duration,
             "raw_duration": raw_total_duration,  # seconds
             "raw_warc_save_duration": warc_save_duration,
-            "raw_jsonl_write_duration": jsonl_write_duration,
+            "raw_pages_write_duration": pages_write_duration,
             "raw_conversion_duration": conversion_duration,
             "error": ''
         }

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1874,6 +1874,26 @@ class Link(DeletableModel):
     def provenance_summary_capture(self):
         return self.captures.filter(role='provenance_summary').first()
 
+    def get_pages_jsonl(self):
+        if self.cached_can_play_back:
+            jsonl_rows = [
+                {"format": "json-pages-1.0", "id": "pages", "title": "All Pages"}
+            ]
+            ts = str(self.creation_timestamp)
+            if self.primary_capture:
+                jsonl_rows.append(
+                    {"title": "primary capture url", "url": self.primary_capture.url, "ts": ts}
+                )
+            if self.screenshot_capture:
+                jsonl_rows.append(
+                    {"title": "screenshot url", "url": self.screenshot_capture.url, "ts": ts}
+                )
+            if self.provenance_summary_capture:
+                jsonl_rows.append(
+                    {"title": "provenance summary url", "url": self.provenance_summary_capture.url, "ts": ts}
+                )
+            return "\n".join([json.dumps(row) for row in jsonl_rows])
+
     def write_uploaded_file(self, uploaded_file, cache_break=False):
         """
             Given a file uploaded by a user, create a Capture record and warc.

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1880,17 +1880,17 @@ class Link(DeletableModel):
                 {"format": "json-pages-1.0", "id": "pages", "title": "All Pages"}
             ]
             ts = str(self.creation_timestamp)
-            if self.primary_capture:
+            if self.provenance_summary_capture:
                 jsonl_rows.append(
-                    {"title": "primary capture url", "url": self.primary_capture.url, "ts": ts}
+                    {"url": self.provenance_summary_capture.url, "title": "Provenance Summary", "ts": ts}
                 )
             if self.screenshot_capture:
                 jsonl_rows.append(
-                    {"title": "screenshot url", "url": self.screenshot_capture.url, "ts": ts}
+                    {"url": self.screenshot_capture.url, "title": f"Capture Time Screenshot of {self.ascii_safe_url}", "ts": ts}
                 )
-            if self.provenance_summary_capture:
+            if self.primary_capture:
                 jsonl_rows.append(
-                    {"title": "provenance summary url", "url": self.provenance_summary_capture.url, "ts": ts}
+                    {"url": self.primary_capture.url, "title": f"High-Fidelity Web Capture of {self.ascii_safe_url}", "ts": ts}
                 )
             return "\n".join([json.dumps(row) for row in jsonl_rows])
 


### PR DESCRIPTION
WACZ files include, zipped inside them, a file called pages.jsonl, which helps replay software know what the "entrypoint" URLs are for a given archive.

This PR makes the pages.jsonl produced during the conversion process more closely match the pages.jsonl produced during a Scoop WACZ capture of a target URL.

Before:
```
{"format": "json-pages-1.0", "id": "pages", "title": "All Pages"}
{"title": "primary capture url", "url": "http://example.com/", "ts": "2024-05-22 21:49:28.701508+00:00"}
{"title": "screenshot url", "url": "file:///screenshot.png", "ts": "2024-05-22 21:49:28.701508+00:00"}
{"title": "provenance summary url", "url": "file:///provenance-summary.html", "ts": "2024-05-22 21:49:28.701508+00:00"}
```

After:
```
{"format": "json-pages-1.0", "id": "pages", "title": "All Pages"}
{"url": "file:///provenance-summary.html", "title": "Provenance Summary", "ts": "2024-05-22 21:49:28.701508+00:00"}
{"url": "file:///screenshot.png", "title": "Capture Time Screenshot of http://example.com/", "ts": "2024-05-22 21:49:28.701508+00:00"}
{"url": "http://example.com/", "title": "High-Fidelity Web Capture of http://example.com/", "ts": "2024-05-22 21:49:28.701508+00:00"}
```

(We decided NOT to include the optional "id" field since it IS optional, and since it is primarily there to optimize performance when you have thousands or millions of pages... as opposed to 1-3, like us.)

See ENG-922.