### PR TITLE
Validate the WACZ produced during the conversion

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1,3 +1,4 @@
+import hashlib
 import itertools
 
 import os
@@ -13,6 +14,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from celery.signals import task_failure
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from zipfile import ZipFile
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
@@ -1350,6 +1352,29 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
         wacz_size = 0
 
     formatted_wacz_size = format_filesize(wacz_size)
+    if wacz_size:
+        # retrieve S3's md5 hash of file it has
+        remote_hash = default_storage.connection.Object(
+            bucket_name=default_storage.bucket_name,
+            key=os.path.join(settings.MEDIA_ROOT, link.warc_storage_file())
+        ).e_tag.strip('"')
+
+        # calculate the same thing for the warc inside the wacz
+        blocksize = 2 ** 20
+        m = hashlib.md5()
+        with ZipFile(wacz_path) as zip_file:
+            with zip_file.open(f"archive/{link.guid}.warc.gz") as embedded_warc:
+                while True:
+                    buf = embedded_warc.read(blocksize)
+                    if not buf:
+                        break
+                    m.update(buf)
+
+        # see if they match
+        warc_checksums_match =  m.hexdigest() == remote_hash
+    else:
+        warc_checksums_match = None
+
     raw_total_duration = time.time() - start_time
     duration = seconds_to_minutes(raw_total_duration)
 
@@ -1366,21 +1391,29 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
             "raw_warc_save_duration": warc_save_duration,
             "raw_pages_write_duration": pages_write_duration,
             "raw_conversion_duration": conversion_duration,
-            "error": ''
+            "error": '',
+            "warc_checksums_match": warc_checksums_match
         }
-        writer = csv.DictWriter(log_file, fieldnames=row.keys())
-
         if conversion_error:
             row["conversion_status"] = "Failure"
             row["error"] = error_output
-            writer.writerow(row)
-        elif wacz_size == 0 or warc_size > wacz_size:
+        elif wacz_size == 0:
             row["conversion_status"] = "Failure"
-            row["error"] = "WACZ is smaller than WARC"
-            writer.writerow(row)
+            row["error"] = "No WACZ produced"
         else:
-            row["conversion_status"] = "Success"
-            writer.writerow(row)
+            if warc_size > wacz_size:
+                row["conversion_status"] = "Failure"
+                row["error"] = "WACZ is smaller than WARC"
+            elif not warc_checksums_match:
+                row["conversion_status"] = "Failure"
+                row["error"] = "The WARC embedded in the WACZ differs from the source WARC"
+            else:
+                row["conversion_status"] = "Success"
 
             with open(wacz_path, 'rb') as wacz_file:
                 default_storage.save(link.wacz_storage_file(), wacz_file)
+
+        writer = csv.DictWriter(log_file, fieldnames=row.keys())
+        writer.writerow(row)
+
+

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1360,6 +1360,7 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
         ).e_tag.strip('"')
 
         # calculate the same thing for the warc inside the wacz
+        # use a blocksize of 1MB because... it's LIL tradition
         blocksize = 2 ** 20
         m = hashlib.md5()
         with ZipFile(wacz_path) as zip_file:
@@ -1395,12 +1396,15 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
             "warc_checksums_match": warc_checksums_match
         }
         if conversion_error:
+            # No WACZ to save; error message from js-wacz
             row["conversion_status"] = "Failure"
             row["error"] = error_output
         elif wacz_size == 0:
+            # No WACZ to save; no error message from js-wacz
             row["conversion_status"] = "Failure"
             row["error"] = "No WACZ produced"
         else:
+            # A WACZ to save: keep broken ones around for study
             if warc_size > wacz_size:
                 row["conversion_status"] = "Failure"
                 row["error"] = "WACZ is smaller than WARC"

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1363,13 +1363,15 @@ def convert_warc_to_wacz(input_guid, benchmark_log):
         # use a blocksize of 1MB because... it's LIL tradition
         blocksize = 2 ** 20
         m = hashlib.md5()
-        with ZipFile(wacz_path) as zip_file:
-            with zip_file.open(f"archive/{link.guid}.warc.gz") as embedded_warc:
-                while True:
-                    buf = embedded_warc.read(blocksize)
-                    if not buf:
-                        break
-                    m.update(buf)
+        with (
+            ZipFile(wacz_path) as zip_file,
+            zip_file.open(f"archive/{link.guid}.warc.gz") as embedded_warc
+        ):
+            while True:
+                buf = embedded_warc.read(blocksize)
+                if not buf:
+                    break
+                m.update(buf)
 
         # see if they match
         warc_checksums_match =  m.hexdigest() == remote_hash

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1261,7 +1261,8 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, guid=None,
         "raw_warc_save_duration",
         "raw_jsonl_write_duration",
         "raw_conversion_duration",
-        "error"
+        "error",
+        "warc_checksums_match"
     ]
 
     with open(log_file, 'w') as lf:


### PR DESCRIPTION
This is a very basic check to make sure that the WACZ came out okay, during our test/benchmarking WARC -> WACZ conversion experiment.

Check the hash of the original WARC against the hash of the WARC inside the WACZ. This won't tell us whether the archive plays back, but will at least ensure that we didn't lose any valuable data.

To find the remote hash and calculate the new one, I tweaked the logic of Ben's awesome [check_s3_hashes](https://github.com/harvard-lil/perma/blob/develop/perma_web/tasks/dev.py#L401C1-L453C95) task, written back when to help us migrate from local filesystem storage to S3 ❤️. 

See ENG-929.