### PR TITLE
Add multiple error formatting for batch captures

### DIFF
--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -9,9 +9,8 @@ import LinkCount from './LinkCount.vue';
 import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
 import CreateLinkBatch from './CreateLinkBatch.vue';
-import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse } from "../lib/errors"
+import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse, folderError, defaultError } from "../lib/errors"
 
-const defaultError = "We're sorry, we've encountered an error processing your request."
 const batchDialogRef = ref('')
 
 const batchDialogOpen = () => {
@@ -63,7 +62,7 @@ const handleArchiveRequest = async () => {
 
     try {
         if (!formData.folder) {
-            const errorMessage = 'Missing folder selection. Please select a folder.'
+            const errorMessage = folderError
             globalStore.updateCaptureErrorMessage(errorMessage)
             throw errorMessage
         }

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -100,13 +100,13 @@ const handleCaptureError = ({ error, errorType }) => {
         errorMessage = getErrorFromResponseStatus(error.status, error.response)
     }
 
+    else if (error?.status) {
+        errorMessage = `Error: ${error.status}`
+    }
+
     // Handle frontend-generated error messages
     else if (error.length) {
         errorMessage = error
-    }
-
-    else if (error?.status) {
-        errorMessage = `Error: ${error.status}`
     }
 
     // Handle uncaught errors
@@ -123,7 +123,7 @@ const handleCaptureStatus = async (guid) => {
         const response = await fetch(`/api/v1/user/capture_jobs/${guid}`)
 
         if (!response?.ok) {
-            throw new Error()
+            throw new Error(response.status)
         }
 
         const job = await response.json()

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -8,7 +8,7 @@ import { useFetch } from '../lib/data';
 import LinkBatchDetails from './LinkBatchDetails.vue'
 import Dialog from './Dialog.vue';
 import { validStates, transitionalStates } from '../lib/consts.js'
-import { folderError, getErrorFromNestedObject, getErrorFromResponseStatus, missingUrlError } from '../lib/errors';
+import { folderError, getErrorFromNestedObject, getErrorFromResponseStatus, missingUrlError, getErrorResponse } from '../lib/errors';
 import { useToast } from '../lib/notifications';
 import { defaultError } from '../lib/errors';
 
@@ -97,8 +97,8 @@ const handleBatchCaptureRequest = async () => {
             })
 
         if (!response?.ok) {
-            const errorResponse = await response.json()
-            throw { status: response.status, response: errorResponse }
+            const errorResponse = await getErrorResponse(response)
+            throw errorResponse
         }
 
         const data = await response.json()
@@ -128,6 +128,10 @@ const handleBatchError = ({ error, errorType }) => {
         errorMessage = getErrorFromResponseStatus(error.status, error.response)
     }
 
+    else if (error?.status) {
+        errorMessage = `Error: ${error.status}`
+    }
+
     // Handle frontend-generated error messages
     else if (error.length) {
         errorMessage = error
@@ -148,8 +152,8 @@ const handleBatchDetailsFetch = async () => {
 
     if (hasError.value || !data.value.capture_jobs) {
         console.log(errorMessage.value)
-
         /* Return nothing and continue to fetch details on an interval */
+        /* TODO: Implement maxFailedAttempts approach to error handling for failed details fetches */
         return
     }
 

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -144,10 +144,10 @@ const handleBatchError = ({ error, errorType }) => {
 }
 
 const handleBatchDetailsFetch = async () => {
-    const { data, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId.value.id}`)
+    const { data, hasError, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId.value.id}`)
 
-    if (errorMessage || !data?.value.capture_jobs) {
-        const loggedError = errorMessage ? errorMessage : defaultError
+    if (hasError || !data?.value.capture_jobs) {
+        const loggedError = errorMessage ?? defaultError
         console.log(loggedError)
 
         /* Return nothing and continue to fetch details on an interval */

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -162,7 +162,7 @@ const handleBatchFormatting = ((captureJobs) => {
     const steps = 6
     const allJobs = captureJobs.reduce((accumulatedJobs, currentJob) => {
         const includesError = !validStates.includes(currentJob.status)
-        const isCompleted = !transitionalStates.includes(currentJob.status)
+        const isCapturing = transitionalStates.includes(currentJob.status)
 
         let jobDetail = {
             ...currentJob,
@@ -171,7 +171,7 @@ const handleBatchFormatting = ((captureJobs) => {
             url: `${window.location.hostname}/${currentJob.guid}`
         };
 
-        if (isCompleted) {
+        if (isCapturing) {
             accumulatedJobs.completed = false;
         }
 

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -103,8 +103,6 @@ const handleBatchCaptureRequest = async () => {
 
         const data = await response.json()
 
-        // throw new Error()
-
         batchCaptureId.value = data // Triggers periodic polling
         globalStore.updateBatchCapture('isQueued')
 
@@ -149,8 +147,7 @@ const handleBatchDetailsFetch = async () => {
     const { data, error, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId.value.id}`)
 
     if (error || !data.value.capture_jobs) {
-        globalStore.updateBatchCapture('batchDetailsError')
-        globalStore.updateBatchCaptureErrorMessage(errorMessage)
+        handleBatchError({ error: errorMessage, errorType: "batchDetailsError" })
     }
 
     const { allJobs, progressSummary } = handleBatchFormatting(data.value.capture_jobs)

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -144,10 +144,14 @@ const handleBatchError = ({ error, errorType }) => {
 }
 
 const handleBatchDetailsFetch = async () => {
-    const { data, error, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId.value.id}`)
+    const { data, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId.value.id}`)
 
-    if (error || !data.value.capture_jobs) {
-        handleBatchError({ error: errorMessage, errorType: "batchDetailsError" })
+    if (errorMessage || !data?.value.capture_jobs) {
+        const loggedError = errorMessage ? errorMessage : defaultError
+        console.log(loggedError)
+
+        /* Return nothing and continue to fetch details on an interval */
+        return
     }
 
     const { allJobs, progressSummary } = handleBatchFormatting(data.value.capture_jobs)

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -146,9 +146,8 @@ const handleBatchError = ({ error, errorType }) => {
 const handleBatchDetailsFetch = async () => {
     const { data, hasError, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId.value.id}`)
 
-    if (hasError || !data?.value.capture_jobs) {
-        const loggedError = errorMessage ?? defaultError
-        console.log(loggedError)
+    if (hasError.value || !data.value.capture_jobs) {
+        console.log(errorMessage.value)
 
         /* Return nothing and continue to fetch details on an interval */
         return

--- a/perma_web/frontend/components/LinkBatchDetails.vue
+++ b/perma_web/frontend/components/LinkBatchDetails.vue
@@ -29,7 +29,7 @@ const props = defineProps({
           <div class="item-container" :class="{ '_isFailed': !validStates.includes(job.status) }">
             <div class="row">
               <div v-if="!validStates.includes(job.status)" class="link-desc col col-sm-6 col-md-60">
-                <div class="failed_header">{{ job.error_message }}</div>
+                <div class="failed_header">{{ job.message }}</div>
                 <div class="item-title">We're unable to create your Perma Link.</div>
                 <div class="item-date">submitted: {{ job.submitted_url }}</div>
               </div>

--- a/perma_web/frontend/components/Toast.vue
+++ b/perma_web/frontend/components/Toast.vue
@@ -9,6 +9,9 @@ const { toasts } = useToast();
         <div v-for="toast in toasts" :key="toast.id" :class="`alert alert-${toast.status} alert-dismissible
         popup-alert`" role="alert">
             {{ toast.message }}
+            <span v-if="toast.message.includes('logged out')">
+                Please <a href='/login' class="u-underline">log in</a> to continue.
+            </span>
             <button type="button" class="close"><span aria-hidden="true">&times;</span><span
                     class="sr-only">Close</span></button>
         </div>

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -24,7 +24,7 @@ export const useFetch = async (baseUrl, options) => {
 
     } catch (err) {
       state.hasError = true
-      state.errorMessage = err.message
+      state.errorMessage = err?.message ?? ''
     }
     state.isLoading = false
   }

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -16,7 +16,6 @@ export const useFetch = async (baseUrl, options) => {
 
     try {
       const response = await fetch(url); 
-           
       if (!response?.ok) {
         throw new Error(response.statusText) 
       }
@@ -25,7 +24,7 @@ export const useFetch = async (baseUrl, options) => {
 
     } catch (err) {
       state.hasError = true
-      state.errorMessage = err?.message ?? defaultError
+      state.errorMessage = err?.message.length ? err.message : defaultError
     }
     state.isLoading = false
   }

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -1,4 +1,5 @@
 import { reactive, toRefs } from "vue";
+import { defaultError } from './errors'
 
 export const useFetch = async (baseUrl, options) => {
   const state = reactive({
@@ -14,8 +15,8 @@ export const useFetch = async (baseUrl, options) => {
     state.isLoading = true;
 
     try {
-      const response = await fetch(url);
-      
+      const response = await fetch(url); 
+           
       if (!response?.ok) {
         throw new Error(response.statusText) 
       }
@@ -24,7 +25,7 @@ export const useFetch = async (baseUrl, options) => {
 
     } catch (err) {
       state.hasError = true
-      state.errorMessage = err?.message ?? ''
+      state.errorMessage = err?.message ?? defaultError
     }
     state.isLoading = false
   }

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -48,3 +48,7 @@ export const getErrorResponse = async (response) => {
       return { status: response.status };
   }
 };
+
+export const defaultError = "We're sorry, we've encountered an error processing your request."
+export const folderError = "Missing folder selection. Please select a folder."
+export const missingUrlError = "Missing urls. Please submit valid urls."

--- a/perma_web/static/bundles/global.css
+++ b/perma_web/static/bundles/global.css
@@ -12444,6 +12444,10 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
   padding-bottom: 1.125rem;
 }
 
+.u-underline {
+  text-decoration: underline;
+}
+
 .c-button {
   cursor: pointer;
 }


### PR DESCRIPTION
Note: this WIP PR is currently a fork of my single capture error PR because it relies on shared utility functions — when it is merged, I'll rebase on the develop branch and remove the additional commits. 

## What this does 
Adds error handling for the multiple batch captures features of perma.

## Screenshots

### 1. When a user attempts to create a batch capture job without submitting any urls: 
![image](https://github.com/harvard-lil/perma/assets/4039311/777f5dbc-ac75-45ac-87e8-0efa3c16b535)

### 2. When a user submits a url, but it's invalid:
![image](https://github.com/harvard-lil/perma/assets/4039311/2c9e93dd-e3d6-4764-ab3d-e66908fa6ada)

### 3. When a user submits multiple urls, and some of them are invalid: 
![image](https://github.com/harvard-lil/perma/assets/4039311/6245a5a8-cb40-43e6-822e-dd43775702c5)

### 4. When a user is out of perma links: 
![image](https://github.com/harvard-lil/perma/assets/4039311/56d2974a-7bdc-48a1-af0c-a35b0ea9b6ff)

### 5. When a user does not choose a folder destination for their perma link batch: 
![image](https://github.com/harvard-lil/perma/assets/4039311/9a5f2d15-f5b0-47de-9820-a5110d1e2973)

### 6. When a user does not appear logged in:
![image](https://github.com/harvard-lil/perma/assets/4039311/3a9c1426-bde8-48bc-a973-fed07b64524d)
Note: I tested this by commenting-out the POST logic and manually throwing an HTTP status code of 401

### 7. When a user attempts to create a link batch and Perma responds with an HTTP status code other than 400 or 401: 
![image](https://github.com/harvard-lil/perma/assets/4039311/5b02d410-97e5-46b7-878e-86ff0e03e93c)
Note: I tested this by manually throwing an HTTP status code of 500 instead of attempting a POST

### 8. When an unexpected error happens during the batch submission process, and a batch capture job is not created: 
![image](https://github.com/harvard-lil/perma/assets/4039311/dc42e12a-94c9-419c-bd3e-ad1252d2592a)
Note: I tested this by manually throwing `throw new Error()` instead of attempting a POST

### 9. When a url is valid, but the capture fails:
![image](https://github.com/harvard-lil/perma/assets/4039311/ab740059-0b51-4680-921f-36c54e026b7d)
