### PR TITLE
Add TextInput component for archive uploads

### DIFF
--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -10,6 +10,7 @@ import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
 import CreateLinkBatch from './CreateLinkBatch.vue';
 import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse, folderError, defaultError } from "../lib/errors"
+import UploadForm from './UploadForm.vue';
 
 const batchDialogRef = ref('')
 
@@ -180,6 +181,7 @@ onBeforeUnmount(() => {
     <!-- regular link creation -->
     <div id="create-item-container" class="container cont-full-bleed">
         <div class="container cont-fixed">
+            <UploadForm />
             <h1 class="create-title">Create a new <span class="nobreak">Perma Link</span></h1>
             <p class="create-lede">Enter any URL to preserve it forever.</p>
         </div>

--- a/perma_web/frontend/components/TextInput.vue
+++ b/perma_web/frontend/components/TextInput.vue
@@ -1,0 +1,15 @@
+<script setup>
+const model = defineModel()
+</script>
+
+<template>
+    <div class="form-group" :class="{
+        'has-error': model.error
+    }">
+        <label class=" control-label" :for="model.value">{{ model.name }} <span v-if="model.description"
+                class="label-instruction">{{
+        model.description }}</span></label>
+        <input v-model="model.value" :id="model.name" :name="model.name" type="text" :placeholder="model.placeholder" />
+        <span v-if="model.error" class="help-block js-warning">{{ model.error }}</span>'
+    </div>
+</template>

--- a/perma_web/frontend/components/TextInput.vue
+++ b/perma_web/frontend/components/TextInput.vue
@@ -1,7 +1,8 @@
 <script setup>
 const model = defineModel()
 const props = defineProps({
-    error: String
+    error: String,
+    id: String
 })
 
 </script>
@@ -10,10 +11,10 @@ const props = defineProps({
     <div class="form-group" :class="{
         'has-error': props.error
     }">
-        <label class=" control-label" :for="model.value">{{ model.name }} <span v-if="model.description"
+        <label class=" control-label" :for="props.id">{{ model.name }} <span v-if="model.description"
                 class="label-instruction">{{
         model.description }}</span></label>
-        <input v-model="model.value" :id="model.name" :name="model.name" type="text" :placeholder="model.placeholder" />
+        <input v-model="model.value" :id="props.id" :name="props.id" type="text" :placeholder="model.placeholder" />
         <span v-if="props.error" class="help-block js-warning">{{ props.error }}</span>
     </div>
 </template>

--- a/perma_web/frontend/components/TextInput.vue
+++ b/perma_web/frontend/components/TextInput.vue
@@ -1,15 +1,19 @@
 <script setup>
 const model = defineModel()
+const props = defineProps({
+    error: String
+})
+
 </script>
 
 <template>
     <div class="form-group" :class="{
-        'has-error': model.error
+        'has-error': props.error
     }">
         <label class=" control-label" :for="model.value">{{ model.name }} <span v-if="model.description"
                 class="label-instruction">{{
         model.description }}</span></label>
         <input v-model="model.value" :id="model.name" :name="model.name" type="text" :placeholder="model.placeholder" />
-        <span v-if="model.error" class="help-block js-warning">{{ model.error }}</span>'
+        <span v-if="props.error" class="help-block js-warning">{{ props.error }}</span>
     </div>
 </template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -9,14 +9,15 @@ const formData = ref({
 })
 
 // Match backend format for errors, for example {file:"message",url:"message"},
-const errors = ref({
-    url: "",
-    title: ""
-})
+const errors = ref({})
 
 // Debug only
 const handleErrorToggle = () => {
     errors.value.url = "URL cannot be empty."
+}
+
+const handleErrorReset = () => {
+    errors.value = {}
 }
 
 </script>
@@ -30,6 +31,8 @@ const handleErrorToggle = () => {
                     <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]" />
                 </div>
                 <button @click.prevent="handleErrorToggle">Toggle Error</button>
+                <button @click.prevent="handleErrorReset">Reset Errors</button>
+
             </form>
         </div>
     </div>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { ref } from 'vue'
+import TextInput from './TextInput.vue';
+
+const formData = ref({
+    // Data is for debugging only right now
+    url: { name: 'New Perma Link URL', description: "The URL associated with this upload", placeholder: "Page URL", value: '' },
+    title: { name: "New Perma Link Title", description: "A test description for testing", placeholder: "Placeholder", value: '' },
+})
+
+// Match backend format for errors, for example {file:"message",url:"message"},
+const errors = ref({
+    url: "",
+    title: ""
+})
+
+// Debug only
+const handleErrorToggle = () => {
+    errors.value.url = "URL cannot be empty."
+}
+
+</script>
+
+<template>
+    <form @submit.prevent>
+        <div v-for="(input, key) in formData" :key="key">
+            {{ formData[key].value }} <!-- Testing only -->
+            <TextInput v-model="formData[key]" :error="errors[key]" />
+        </div>
+        <button @click.prevent="handleErrorToggle">Toggle Error</button>
+    </form>
+</template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -4,8 +4,8 @@ import TextInput from './TextInput.vue';
 
 const formData = ref({
     // Data is for debugging only right now
-    url: { name: 'New Perma Link URL', description: "The URL associated with this upload", placeholder: "Page URL", value: '' },
-    title: { name: "New Perma Link Title", description: "A test description for testing", placeholder: "Placeholder", value: '' },
+    url: { name: 'New Perma Link URL', type: "text", description: "The URL associated with this upload", placeholder: "Page URL", value: '' },
+    title: { name: "New Perma Link Title", type: "text", description: "A test description for testing", placeholder: "Placeholder", value: '' },
 })
 
 // Match backend format for errors, for example {file:"message",url:"message"},
@@ -25,7 +25,7 @@ const handleErrorToggle = () => {
     <form @submit.prevent>
         <div v-for="(input, key) in formData" :key="key">
             {{ formData[key].value }} <!-- Testing only -->
-            <TextInput v-model="formData[key]" :error="errors[key]" />
+            <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]" />
         </div>
         <button @click.prevent="handleErrorToggle">Toggle Error</button>
     </form>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -26,9 +26,10 @@ const handleErrorReset = () => {
     <div class="modal-content">
         <div class="modal-body">
             <form id="archive_upload_form" @submit.prevent>
-                <template v-for="(input, key) in formData" :key="key">
+                <template v-for="(_, key) in formData" :key="key">
                     {{ formData[key].value }} <!-- Testing only -->
-                    <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]" />
+                    <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]"
+                        :id="key" />
                 </template>
                 <button @click.prevent="handleErrorToggle">Toggle Error</button>
                 <button @click.prevent="handleErrorReset">Reset Errors</button>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -22,11 +22,15 @@ const handleErrorToggle = () => {
 </script>
 
 <template>
-    <form @submit.prevent>
-        <div v-for="(input, key) in formData" :key="key">
-            {{ formData[key].value }} <!-- Testing only -->
-            <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]" />
+    <div class="modal-content">
+        <div class="modal-body">
+            <form id="archive_upload_form" @submit.prevent>
+                <div v-for="(input, key) in formData" :key="key">
+                    {{ formData[key].value }} <!-- Testing only -->
+                    <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]" />
+                </div>
+                <button @click.prevent="handleErrorToggle">Toggle Error</button>
+            </form>
         </div>
-        <button @click.prevent="handleErrorToggle">Toggle Error</button>
-    </form>
+    </div>
 </template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -26,10 +26,10 @@ const handleErrorReset = () => {
     <div class="modal-content">
         <div class="modal-body">
             <form id="archive_upload_form" @submit.prevent>
-                <div v-for="(input, key) in formData" :key="key">
+                <template v-for="(input, key) in formData" :key="key">
                     {{ formData[key].value }} <!-- Testing only -->
                     <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]" />
-                </div>
+                </template>
                 <button @click.prevent="handleErrorToggle">Toggle Error</button>
                 <button @click.prevent="handleErrorReset">Reset Errors</button>
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -32,7 +32,6 @@ const handleErrorReset = () => {
                 </template>
                 <button @click.prevent="handleErrorToggle">Toggle Error</button>
                 <button @click.prevent="handleErrorReset">Reset Errors</button>
-
             </form>
         </div>
     </div>


### PR DESCRIPTION
## What this does 
- Adds two components, `UploadForm` and `TextInput`, as part of the broader effort to modernize the process for users to upload their own archive. 
- Upload Form is largely a placeholder for testing that `TextInput` works with a barebones parent form.

## PR Requirements
Create a text input component with the following styling:
![image](https://github.com/harvard-lil/perma/assets/4039311/e896dbe1-8a84-4dc5-beb3-f0a424635b39)

Component should be reusable, and  be able to be passed the following values:

- Name
- Id (for programmatic association of a label with an input)
- Description
- Placeholder text
- Value
- Error text

The component should be able to display errors if passed as props, but error validation will not be handled at this step of development.

## Reference Screenshot
![image](https://github.com/harvard-lil/perma/assets/4039311/b7603c95-1e3c-48f7-a641-e1878d31bb73)

### Notes 
- Buttons beneath form are for testing only. 
- Second input includes dummy content for testing purposes as well. 
- Input currently stretches to fill the width of its container, in the future this will be constrained when placed within a dialog. 

## How to test
### 1. Entering text into an input component should render the same text just above it, to demonstrate data binding between a parent component and the child input components:
![image](https://github.com/harvard-lil/perma/assets/4039311/00d2c5bb-18a3-4e3a-9210-a18d1573185c)

### 2. Clicking the "toggle error" button should trigger an error with the first input only: 
![image](https://github.com/harvard-lil/perma/assets/4039311/9338667e-023a-410b-8318-16a85607de36)

### 3. Clicking the "clear errors" button should reset the state of the input:
![image](https://github.com/harvard-lil/perma/assets/4039311/f55ca7c4-bd0e-42c2-90fb-8e454f0caeb3)

## Additional notes
No changes have been made to the styling, HTML, or accessibility of the text input. 