### PR TITLE
Produce a persistent logfile for each warc -> wacz conversion, and a task to aggregate

### DIFF
--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1814,6 +1814,9 @@ class Link(DeletableModel):
     def wacz_storage_file(self):
         return os.path.join(settings.WACZ_STORAGE_DIR, self.guid_as_path(), f'{self.guid}.wacz')
 
+    def warc_to_wacz_conversion_log_file(self):
+        return os.path.join(settings.WACZ_STORAGE_DIR, self.guid_as_path(), f'{self.guid}-conversion-log.json')
+
     def warc_presigned_url(self):
         # Specify that warcs should have content-type 'application/gzip' so that archives are fetched correctly by the playback service worker.
         # (All warcs from before summer 2022 were uploaded with content-type 'application/octet-stream' and content-encoding 'gzip')

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -399,6 +399,10 @@ LOGGING['loggers'] = {
         app_name: {'level': 'INFO'}
         for app_name in ('api', 'perma',)
     },
+    # show info for our invoke tasks
+    'tasks': {
+        'level': 'INFO'
+    }
 }
 LOGGING['formatters'] = {
     **LOGGING['formatters'],

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1229,11 +1229,10 @@ def save_warc_for_conversion(warc, warcs_dir, file_name):
 
 
 @task
-def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, guid=None,
+def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
                               big_warcs=False, legacy_warcs=False, old_style_guids=False,
                               batch_guid_prefix=None, batch_range=None, batch_size=None):
     """
-    Creates log file
     Invokes convert_warc_to_wacz() for a set of Perma Links.
     Specify "big_warcs" to restrict queryset to Links with large filesize.
     Specify "legacy_warcs" to restrict the queryset to Links that were originally produced with wget.
@@ -1247,27 +1246,6 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, guid=None,
 
     if batch_range and batch_size:
         raise ValueError("Cannot specify both a batch range and a batch size.")
-
-    log_file = os.path.abspath(benchmark_log)
-    csv_headers = [
-        "file_name",
-        "conversion_status",
-        "warc_size",
-        "raw_warc_size",
-        "wacz_size",
-        "raw_wacz_size",
-        "duration",
-        "raw_duration",
-        "raw_warc_save_duration",
-        "raw_jsonl_write_duration",
-        "raw_conversion_duration",
-        "error",
-        "warc_checksums_match"
-    ]
-
-    with open(log_file, 'w') as lf:
-        writer = csv.DictWriter(lf, fieldnames=csv_headers)
-        writer.writeheader()
 
     # Adding this here in case we want to compare it against the CSV file's last updated ts
     # for a rough estimate of how long all jobs took to be processed by celery
@@ -1286,10 +1264,10 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, guid=None,
         with open(sample_data_guids, mode='r') as file:
             csv_file = csv.reader(file)
             for line in csv_file:
-                convert_warc_to_wacz.delay(line[0], log_file)
+                convert_warc_to_wacz.delay(line[0])
         return
     if guid:
-        convert_warc_to_wacz.delay(guid, log_file)
+        convert_warc_to_wacz.delay(guid)
         return
 
     if big_warcs:
@@ -1320,4 +1298,4 @@ def benchmark_wacz_conversion(ctx, benchmark_log, source_csv=None, guid=None,
         links = links[:int(batch_size)]
 
     for link in links.iterator():
-        convert_warc_to_wacz.delay(link, log_file)
+        convert_warc_to_wacz.delay(link)

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1304,14 +1304,14 @@ def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
     Specify "log_to_file" to write the list of enqueued GUIDs to a given path. Appends.
     """
     start = time.time()
-    logger.info(f"Gathering benchmark conversion queryset.")
+    logger.info("Gathering benchmark conversion queryset.")
     guids = get_conversion_queryset(
         source_csv, guid,
         big_warcs, legacy_warcs, old_style_guids,
         batch_guid_prefix, batch_range, batch_size
     )
 
-    logger.info(f"Start launching benchmark conversions.")
+    logger.info("Start launching benchmark conversions.")
     queued = []
     for guid in guids.iterator():
         queued.append(guid)
@@ -1341,14 +1341,14 @@ def collect_conversion_logs(ctx, log_to_file,
     Or, provide a file with the desired GUIDs, one per line.
     """
     start = time.time()
-    logger.info(f"Gathering benchmark conversion queryset.")
+    logger.info("Gathering benchmark conversion queryset.")
     guids = get_conversion_queryset(
         source_csv, guid,
         big_warcs, legacy_warcs, old_style_guids,
         batch_guid_prefix, batch_range, batch_size
     )
 
-    logger.info(f"Start gathering benchmark conversion logs.")
+    logger.info("Start gathering benchmark conversion logs.")
     gathered = []
     with open(log_to_file, mode='w') as csv_file:
         fieldnames = [

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1303,20 +1303,21 @@ def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
 
     Specify "log_to_file" to write the list of enqueued GUIDs to a given path.
     """
-    logger.info(f"Gathering benchmark conversion queryset: {datetime.now()}.")
+    start = time.time()
+    logger.info(f"Gathering benchmark conversion queryset.")
     links = get_conversion_queryset(
         source_csv, guid,
         big_warcs, legacy_warcs, old_style_guids,
         batch_guid_prefix, batch_range, batch_size
     )
 
-    logger.info(f"Start launching benchmark conversions: {datetime.now()}.")
+    logger.info(f"Start launching benchmark conversions.")
     guids = []
     for link in links.iterator():
         guids.append(link)
         convert_warc_to_wacz.delay(link)
 
-    logger.info(f"Done launching benchmark conversions ({len(guids)}): {datetime.now()}.")
+    logger.info(f"Done launching benchmark conversions ({len(guids)} in {time.time() - start}s).")
     if log_to_file:
         with open(log_to_file, mode='a') as file:
             for guid in guids:

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1301,7 +1301,7 @@ def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
     Specify "batch_range" or "batch_size" to slice the queryset.
     Or, provide a file with the desired GUIDs, one per line.
 
-    Specify "log_to_file" to write the list of enqueued GUIDs to a given path.
+    Specify "log_to_file" to write the list of enqueued GUIDs to a given path. Appends.
     """
     start = time.time()
     logger.info(f"Gathering benchmark conversion queryset.")

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1305,21 +1305,21 @@ def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
     """
     start = time.time()
     logger.info(f"Gathering benchmark conversion queryset.")
-    links = get_conversion_queryset(
+    guids = get_conversion_queryset(
         source_csv, guid,
         big_warcs, legacy_warcs, old_style_guids,
         batch_guid_prefix, batch_range, batch_size
     )
 
     logger.info(f"Start launching benchmark conversions.")
-    guids = []
-    for link in links.iterator():
-        guids.append(link)
-        convert_warc_to_wacz.delay(link)
+    queued = []
+    for guid in guids.iterator():
+        queued.append(guid)
+        convert_warc_to_wacz.delay(guid)
 
-    logger.info(f"Done launching benchmark conversions ({len(guids)} in {time.time() - start}s).")
+    logger.info(f"Done launching benchmark conversions ({len(queued)} in {time.time() - start}s).")
     if log_to_file:
         with open(log_to_file, mode='a') as file:
-            for guid in guids:
+            for guid in queued:
                 file.write(f"{guid}\n")
 


### PR DESCRIPTION
See ENG-919.

### Background

Currently, the benchmarking task [creates a CSV](https://github.com/harvard-lil/perma/blob/8d70dc16678c95f1a9f586e2ab5bce3bf8a0b3c6/perma_web/tasks/dev.py#L1260C1-L1262C29) before queuing jobs, [passes that filename](https://github.com/harvard-lil/perma/blob/8d70dc16678c95f1a9f586e2ab5bce3bf8a0b3c6/perma_web/tasks/dev.py#L1281) to each celery task that converts a warc to a wacz, and then each task [opens the file and appends a line](https://github.com/harvard-lil/perma/blob/8d70dc16678c95f1a9f586e2ab5bce3bf8a0b3c6/perma_web/perma/celery_tasks.py#L1359C1-L1386C33) with info about how the conversion process went.

That limits our ability to experiment in a multi-server setup: if multiple worker minions are involved, they will necessarily write their results to different CSVs that will need to be combined, and, only the machine where the invoke task is run will get the headers.

We are also pretty sure it's fine to have lots of processes appending to the same CSV at the same time… but we're not certain.

We also think that this information would be nice to have as an artifact, during the actual conversion of the corpus, outside the context of a benchmarking experiment.

### This PR

I refactored things so that each conversion produces a JSON file with the info inside, stored next to the WACZ, and then wrote a task for aggregating that info into a CSV.

To make that more convenient: 

- I tweaked the task for enqueuing conversions, so that it optionally logs to a file, in append mode, so, if you are queuing up lots of links to experiment with, you have a record of which links' logs to aggregate afterwards.

- I extracted the logic for gathering querysets of links to look at, so that I could reuse it in the log aggregation task.

### Reviewing

The unified diff is kind of hard to read; it might be easier to just compare the files side-by-side.
