### PR TITLE
Store warc and wacz in separate buckets

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -219,14 +219,14 @@ In templates, use the `{% static %}` tag and MEDIA_URL:
 Using the `{% static %}` tag instead of `{{ STATIC_URL }}` ensures that cache-busting and
 pre-compressed versions of the files will be served on production.
 
-In code, use Django's default_storage to read and write user-generated files rather than accessing the filesystem directly:
+In code, use Django's `storage` to read and write user-generated files rather than accessing the filesystem directly:
 
-    from django.core.files.storage import default_storage
+    from django.core.files.storage import storages
 
-    with default_storage.open('some/path', 'rb') as image_file:
+    with storages['default'].open('some/path', 'rb') as image_file:
         do_stuff_with_image_file(image_file)
 
-Paths for default_storage are relative to MEDIA_ROOT.
+Paths for default storage are relative to MEDIA_ROOT.
 
 Further reading:
 

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -3,7 +3,7 @@ from glob import glob
 import os
 import dateutil.parser
 from django.conf import settings
-from django.core.files.storage import default_storage
+from django.core.files.storage import storages
 from django.urls import reverse
 from django.http import StreamingHttpResponse
 from django.test.utils import override_settings
@@ -124,7 +124,7 @@ class LinkResourceTestMixin():
         self.assertTrue(link.primary_capture.content_type, "Capture is missing a content type.")
 
         # create an index of the warc
-        with default_storage.open(link.warc_storage_file(), 'rb') as warc_file:
+        with storages[settings.WARC_STORAGE].open(link.warc_storage_file(), 'rb') as warc_file:
             index = index_warc_file(warc_file)
 
         # see if the index reports the content is in the warc

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -84,8 +84,10 @@ WEBPACK_LOADER = {
 # user-generated files / default_storage config
 MEDIA_URL = '/this-setting-is-not-in-use-in-any-deployments/'
 MEDIA_ROOT ='generated/'
+WARC_STORAGE = 'default'
 WARC_STORAGE_DIR = 'warcs'  # relative to MEDIA_ROOT
 WARC_PRESIGNED_URL_EXPIRES = 15 * 60
+WACZ_STORAGE = 'secondary'
 WACZ_STORAGE_DIR = 'waczs'
 WACZ_PRESIGNED_URL_EXPIRES = 15 * 60
 

--- a/perma_web/perma/tests/test_views_common.py
+++ b/perma_web/perma/tests/test_views_common.py
@@ -45,7 +45,7 @@ class CommonViewsTestCase(PermaTestCase):
     def assert_not_500(self, guid):
         # only makes sure the template renders without internal server error.
         # makes no claims about the contents of the iframe
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': guid}})
             self.assertIn(b"<iframe ", response.content)
             return response
@@ -106,7 +106,7 @@ class CommonViewsTestCase(PermaTestCase):
         self.assertFalse(link.default_to_screenshot_view)
         self.assertTrue(link.capture_job.status == 'completed')
         self.assertTrue(link.captures.count())
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'ABCD-0007'}}, request_kwargs={'follow': True})
             self.assertEqual(response.request.get('QUERY_STRING'), 'type=image')
             self.assertIn('memento-datetime', response.headers)
@@ -115,7 +115,7 @@ class CommonViewsTestCase(PermaTestCase):
     def test_capture_only_archive_default_to_screenshot_view_true(self):
         link = Link.objects.get(guid='N1N0-33DB')
         self.assertTrue(link.default_to_screenshot_view)
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'N1N0-33DB'}}, request_kwargs={'follow': True})
             self.assertFalse(b'Enhance screenshot playback' in response.content)
             self.assertEqual(response.request.get('QUERY_STRING'), 'type=standard')
@@ -124,7 +124,7 @@ class CommonViewsTestCase(PermaTestCase):
     def test_screenshot_only_archive_default_to_screenshot_view_true(self):
         link = Link.objects.get(guid='ABCD-0008')
         self.assertTrue(link.default_to_screenshot_view)
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'ABCD-0008'}}, request_kwargs={'follow': True})
             self.assertEqual(response.request.get('QUERY_STRING'), '')
 
@@ -132,7 +132,7 @@ class CommonViewsTestCase(PermaTestCase):
     def test_capture_only_archive_default_to_screenshot_view_false(self):
         link = Link.objects.get(guid='M1L0-87DB')
         self.assertFalse(link.default_to_screenshot_view)
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'M1L0-87DB'}}, request_kwargs={'follow': True})
             self.assertEqual(response.request.get('QUERY_STRING'), '')
 
@@ -140,7 +140,7 @@ class CommonViewsTestCase(PermaTestCase):
     def test_full_archive_default_to_screenshot_view_false(self):
         link = Link.objects.get(guid='UU32-XY8I')
         self.assertFalse(link.default_to_screenshot_view)
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'UU32-XY8I'}}, request_kwargs={'follow': True})
             self.assertFalse(b'Enhance screenshot playback' in response.content)
             self.assertEqual(response.request.get('QUERY_STRING'), '')
@@ -149,7 +149,7 @@ class CommonViewsTestCase(PermaTestCase):
     def test_full_archive_default_to_screenshot_view_true(self):
         link = Link.objects.get(guid='F1X1-LS24')
         self.assertTrue(link.default_to_screenshot_view)
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'F1X1-LS24'}}, request_kwargs={'follow': True})
             self.assertTrue(b'Enhance screenshot playback' in response.content)
             self.assertEqual(response.request.get('QUERY_STRING'), '')
@@ -157,14 +157,14 @@ class CommonViewsTestCase(PermaTestCase):
     def test_capture_only_default_to_screenshot_view_true(self):
         link = Link.objects.get(guid='N1N0-33DB')
         self.assertTrue(link.default_to_screenshot_view)
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'N1N0-33DB'}}, request_kwargs={'follow': True})
             self.assertFalse(b'Enhance screenshot playback' in response.content)
             self.assertEqual(response.request.get('QUERY_STRING'), 'type=standard')
 
     # patch default storage so that it returns a sample warc
     def test_dark_archive(self):
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             response = self.get('single_permalink', reverse_kwargs={'kwargs':{'guid': 'ABCD-0001'}}, require_status_code=403)
             self.assertIn(b"This record is private and cannot be displayed.", response.content)
             self.assertNotIn('memento-datetime', response.headers)
@@ -181,7 +181,7 @@ class CommonViewsTestCase(PermaTestCase):
     # Feature temporarily disabled
     """
     def test_redirect_to_download(self):
-        with patch('perma.models.default_storage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
+        with patch('perma.storage_backends.S3MediaStorage.open', lambda path, mode: open(os.path.join(settings.PROJECT_ROOT, 'perma/tests/assets/new_style_archive/archive.warc.gz'), 'rb')):
             # Give user option to download to view pdf if on mobile
             link = Link.objects.get(pk='7CF8-SS4G')
 

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -30,7 +30,7 @@ from django.urls import reverse
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponseForbidden, Http404, StreamingHttpResponse, HttpResponse
 from django.contrib.auth.decorators import login_required
-from django.core.files.storage import default_storage
+from django.core.files.storage import storages
 from django.utils import timezone
 from django.views.decorators.debug import sensitive_variables
 
@@ -458,7 +458,7 @@ def preserve_perma_warc(guid, timestamp, destination, warc_size):
         out.flush()
         warc_size.append(out.tell())
         out.seek(0)
-        default_storage.store_file(out, destination, overwrite=True)
+        storages[settings.WARC_STORAGE].store_file(out, destination, overwrite=True)
         out.close()
 
 def write_perma_warc_header(out_file, guid, timestamp):
@@ -546,7 +546,7 @@ def get_warc_stream(link, stream=True):
         }]
     )
 
-    warc_stream = FileWrapper(default_storage.open(link.warc_storage_file()))
+    warc_stream = FileWrapper(storages[settings.WARC_STORAGE].open(link.warc_storage_file()))
     warc_stream = itertools.chain([warcinfo], warc_stream)
     if stream:
         response = StreamingHttpResponse(warc_stream, content_type="application/gzip")

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -14,7 +14,7 @@ from django.http import (HttpResponse, HttpResponseRedirect, HttpResponsePermane
     JsonResponse, HttpResponseNotFound, HttpResponseBadRequest)
 from django.urls import reverse, NoReverseMatch
 from django.conf import settings
-from django.core.files.storage import default_storage
+from django.core.files.storage import storages
 from django.utils import timezone
 from django.views.generic import TemplateView
 from django.views.decorators.cache import cache_control
@@ -170,7 +170,7 @@ def single_permalink(request, guid):
         if new_record:
             logger.debug(f"Ensuring warc for {link.guid} has finished uploading.")
             def assert_exists(filename):
-                assert default_storage.exists(filename)
+                assert storages[settings.WARC_STORAGE].exists(filename)
             try:
                 retry_on_exception(assert_exists, args=[link.warc_storage_file()], exception=AssertionError, attempts=settings.WARC_AVAILABLE_RETRIES)
             except AssertionError:


### PR DESCRIPTION
See ENG-939.

We've been working on plans to start capturing and playing back WACZ-formatted archives, either in addition to or instead of WARC-formatted. We've also been experimenting with converting our existing archives to WACZ.

To experiment more safely, we'd like to keep WACZs in their own S3 bucket, one that we can feel comfortable messing around with, deleting artifacts from, etc... entirely separate from where we keep the WARCs for Perma's current collection, which, appropriately, has very strict rules.

Support for a secondary storage was added in https://github.com/harvard-lil/perma/pull/3520.

This PR introduces two new settings, `settings.WARC_STORAGE` and `settings.WACZ_STORAGE`.

`settings.WARC_STORAGE` is set to `default`, and every instance of `default_storage.open` or `default_storage.save` in the codebase that is operating on WARCs is changed to `storages["settings.WARC_STORAGE"].open` and `storages["settings.WARC_STORAGE"].save`. This is just an update in syntax: the two are exactly equivalent, and I just made the change for readability/clarity, as we go through this transition.

`settings.WACZ_STORAGE` is set to `secondary`, and every instance of `default_storage.open` or `default_storage.save` in the codebase that is operating on WACZs is changed to `storages["settings.WACZ_STORAGE"].open` and `storages["settings.WACZ_STORAGE"].save`. This is a change. 

This can be deployed safely, since we aren't actually doing anything with WACZ on our staging tier or in prod yet. But, before we do, we'll now have to do some configuring:

`option 1`: we could configure secondary storage to point to exactly the same bucket as primary, for convenience (which might be desirable for stage)

`option 2`: we could make a new S3 bucket, and configure secondary to point there (probably the right choice, right off the bat, for prod).

But, there's no rush on that.