### PR TITLE
Optionally target user-uploaded Perma Links during WARC -> WACZ conversion testing.

### DIFF
--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1227,6 +1227,13 @@ def get_conversion_queryset(source_csv, guid,
     ):
         raise ValueError("If source CSV is specified, no other options may be configured.")
 
+    if guid and (
+        source_csv or
+        big_warcs or legacy_warcs or old_style_guids or user_uploads or
+        batch_guid_prefix or batch_range or batch_size
+    ):
+        raise ValueError("If GUID is specified, no other options may be configured.")
+
     if sum([big_warcs, legacy_warcs, old_style_guids, user_uploads]) > 1:
         raise ValueError("Only one of big_warcs, legacy_warcs, old_style_guids, or user_uploads may be specified.")
 

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1217,11 +1217,18 @@ def email_retained_users(ctx, reports_dir='.'):
 # WACZ CONVERSION
 
 def get_conversion_queryset(source_csv, guid,
-                            big_warcs, legacy_warcs, old_style_guids,
+                            big_warcs, legacy_warcs, old_style_guids, user_uploads,
                             batch_guid_prefix, batch_range, batch_size):
 
-    if source_csv and (guid or big_warcs or batch_guid_prefix or batch_range or batch_size):
+    if source_csv and (
+        guid or
+        big_warcs or legacy_warcs or old_style_guids or user_uploads or
+        batch_guid_prefix or batch_range or batch_size
+    ):
         raise ValueError("If source CSV is specified, no other options may be configured.")
+
+    if sum([big_warcs, legacy_warcs, old_style_guids, user_uploads]) > 1:
+        raise ValueError("Only one of big_warcs, legacy_warcs, old_style_guids, or user_uploads may be specified.")
 
     if batch_range and batch_size:
         raise ValueError("Cannot specify both a batch range and a batch size.")
@@ -1288,7 +1295,7 @@ def get_conversion_queryset(source_csv, guid,
 
 @task
 def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
-                              big_warcs=False, legacy_warcs=False, old_style_guids=False,
+                              big_warcs=False, legacy_warcs=False, old_style_guids=False, user_uploads=False,
                               batch_guid_prefix=None, batch_range=None, batch_size=None,
                               log_to_file=None):
     """
@@ -1307,7 +1314,7 @@ def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
     logger.info("Gathering benchmark conversion queryset.")
     guids = get_conversion_queryset(
         source_csv, guid,
-        big_warcs, legacy_warcs, old_style_guids,
+        big_warcs, legacy_warcs, old_style_guids, user_uploads,
         batch_guid_prefix, batch_range, batch_size
     )
 
@@ -1327,7 +1334,7 @@ def benchmark_wacz_conversion(ctx, source_csv=None, guid=None,
 @task
 def collect_conversion_logs(ctx, log_to_file,
                             source_csv=None, guid=None,
-                            big_warcs=False, legacy_warcs=False, old_style_guids=False,
+                            big_warcs=False, legacy_warcs=False, old_style_guids=False, user_uploads=False,
                             batch_guid_prefix=None, batch_range=None, batch_size=None):
     """
     Gathers the logged results of convert_warc_to_wacz() for a set of Perma Links.
@@ -1344,7 +1351,7 @@ def collect_conversion_logs(ctx, log_to_file,
     logger.info("Gathering benchmark conversion queryset.")
     guids = get_conversion_queryset(
         source_csv, guid,
-        big_warcs, legacy_warcs, old_style_guids,
+        big_warcs, legacy_warcs, old_style_guids, user_uploads,
         batch_guid_prefix, batch_range, batch_size
     )
 

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1270,6 +1270,9 @@ def get_conversion_queryset(source_csv, guid,
     elif batch_guid_prefix:
         links = links.filter(guid__startswith=batch_guid_prefix).order_by('guid')
 
+    elif user_uploads:
+        links = links.filter(captures__user_upload=True).order_by('guid')
+
     else:
         links = links.order_by('guid')
 


### PR DESCRIPTION
See ENG-959.

The invoke task for launching WARC -> WACZ benchmark testing can currently target various subsets of Perma's collection.

This PR adds another option: you can now specifically target WARCs constructed from user-uploaded images or PDFs. 

Since those WARCs were made using different software than the rest of our collection, and since they have a different internal structure, they might convert differently than other WARCs: this should make that easier to spot. 