### PR TITLE
Account for (certain) multipart uploads, when calculating etags during WARC -> WACZ conversion

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1,4 +1,3 @@
-import hashlib
 from io import StringIO
 import itertools
 import json

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1379,7 +1379,8 @@ def convert_warc_to_wacz(input_guid):
         # and if it doesn't, come up with a better strategy
         MB = 2 ** 20
         blocksize = 16 * MB
-        if '-' in remote_hash:
+        multipart_format = '-' in remote_hash
+        if multipart_format:
             parts = int(remote_hash.split('-')[-1])
             if 8 * MB * parts >= warc_size:
                 blocksize = 8 * MB
@@ -1389,7 +1390,7 @@ def convert_warc_to_wacz(input_guid):
             ZipFile(wacz_path) as zip_file,
             zip_file.open(f"archive/{link.guid}.warc.gz") as embedded_warc
         ):
-            wacz_hash = calculate_s3_etag(embedded_warc, blocksize)
+            wacz_hash = calculate_s3_etag(embedded_warc, blocksize, multipart_format)
 
         # see if they match
         warc_checksums_match =  wacz_hash == remote_hash

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -570,6 +570,28 @@ def stream_warc_if_permissible(link, user, stream=True):
     return HttpResponseForbidden('Private archive.')
 
 
+def calculate_s3_etag(fp, chunk_size):
+    """
+    Adapted from https://stackoverflow.com/a/43819225
+    """
+    md5s = []
+
+    while True:
+        data = fp.read(chunk_size)
+        if not data:
+            break
+        md5s.append(hashlib.md5(data))
+
+    if len(md5s) < 1:
+        return '{}'.format(hashlib.md5().hexdigest())
+
+    if len(md5s) == 1:
+        return '{}'.format(md5s[0].hexdigest())
+
+    digests = b''.join(m.digest() for m in md5s)
+    digests_md5 = hashlib.md5(digests)
+    return '{}-{}'.format(digests_md5.hexdigest(), len(md5s))
+
 #
 # Internet Archive
 #


### PR DESCRIPTION
See ENG-970.

We want to do a very basic check to make sure that no data was lost or corrupted, during the WARC -> WACZ conversion process. 

So, we've been [comparing an MD5 hash of the WARC inside the WACZ with the "etag"](https://github.com/harvard-lil/perma/pull/3536) of the WARC in storage.

The [code I picked up this technique from](https://github.com/harvard-lil/perma/blob/develop/perma_web/tasks/dev.py#L543C1-L544C66) noted, "etags are not always md5sums, but should be in these cases; we can rewrite or replace md5hash if necessary".

Well, I did not notice initially but, with my local minio, all WARCs bigger than 16 MB have a different style of etag, one that is not merely the MD5 hash of the file, but instead, has a composite style: 
- these files were uploaded in chunks, 
- each chunk was hashed, and then the concatenation of those hashes was hashed
- the etag is that plus a suffix of "-" and the number of parts.

Oof!

I do not know what we'll find in prod. Stackoverflow suggests that this is common... but, I don't know why we wouldn't have run into it in the 2016 code I based this on. Though I note that the 2016 code was written in support of our initial migration to S3, which means the bucket was not at that point populated by boto via django-storages.

I think this PR gets us closer: this works locally, where many WARCs were uploaded in 16 MB chunks. (By us, in an unusual process, whereby we ingested a sample of WARCs from prod into dev for easier testing.) 

If a multipart-style etag is found, it takes an informed guess at the likely chunk size and attempts a comparison with an etag made that way.

If a regular md5 hash is found, it compares with a plain md5 hash as before.

Hopefully, that covers both the, "the world has changed since 2016 code, and now we need composite etags" possibility, and the, "you are only seeing this because of how we ingested things to minio, or because of minio in general" situation.

Though, if it turns out we _do_ have composite etags in prod, my code for guessing the chunk size might need some fine-tuning. I think we'll just have to see.