### PR TITLE
Add total pending WACZ conversion tasks to /manage/stats

### DIFF
--- a/perma_web/perma/templates/user_management/stats.html
+++ b/perma_web/perma/templates/user_management/stats.html
@@ -251,6 +251,10 @@
         <div class="col-sm-3">Tasks in IA readonly queue:</div>
         <div class="col-sm-9">{{ total_ia_readonly_queue }}</div>
       </div>
+      <div class="row">
+        <div class="col-sm-3">Tasks in WACZ conversion queue:</div>
+        <div class="col-sm-9">{{ total_wacz_conversion_queue }}</div>
+      </div>
     </script>
 
     <script id="celery-template" type="text/x-handlebars-template">

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -217,6 +217,7 @@ def stats(request, stat_type=None):
             'total_background_queue': r.llen('background'),
             'total_ia_queue': r.llen('ia'),
             'total_ia_readonly_queue': r.llen('ia-readonly'),
+            'total_wacz_conversion_queue': r.llen('wacz-conversion')
         }
 
     elif stat_type == "job_queue":


### PR DESCRIPTION
See ENG-969.

We have an internal page for monitoring the status of our celery queues.

This PR adds a running update of how many jobs are in the new WACZ conversion queue, next to the running updates on our other queues 🙂.

(The queue in question is defined here, in our [celery task-routing config](https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/settings/deployments/settings_common.py#L468))