### PR TITLE
Add file input

### DIFF
--- a/perma_web/frontend/components/FileInput.vue
+++ b/perma_web/frontend/components/FileInput.vue
@@ -16,10 +16,13 @@ const handleFileChange = (event) => {
 </script>
 
 <template>
-    <div class="form-group">
+    <div class="form-group" :class="{
+        'has-error': props.error
+    }">
         <label class="control-label" :for="props.id">{{ model.name }} <span class="label-instruction">{{
-            model.description }}</span></label>
-        <input v-on:change="handleFileChange " :id="props.id" class="file" :name="props.id" type="file"
+        model.description }}</span></label>
+        <input v-on:change="handleFileChange" :id="props.id" class="file" :name="props.id" type="file"
             accept=".png,.jpg,.jpeg,.gif,.pdf">
+        <span v-if="props.error" class="help-block js-warning">{{ props.error }}</span>
     </div>
 </template>

--- a/perma_web/frontend/components/FileInput.vue
+++ b/perma_web/frontend/components/FileInput.vue
@@ -1,0 +1,25 @@
+<script setup>
+const model = defineModel()
+const props = defineProps({
+    error: String,
+    id: String
+})
+
+const handleFileChange = (event) => {
+    const file = event.target.files[0];
+    model.value = {
+        ...model.value,
+        value: file
+    }
+};
+
+</script>
+
+<template>
+    <div class="form-group">
+        <label class="control-label" :for="props.id">{{ model.name }} <span class="label-instruction">{{
+            model.description }}</span></label>
+        <input v-on:change="handleFileChange " :id="props.id" class="file" :name="props.id" type="file"
+            accept=".png,.jpg,.jpeg,.gif,.pdf">
+    </div>
+</template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { ref } from 'vue'
 import TextInput from './TextInput.vue';
+import FileInput from './FileInput.vue';
 
 const formData = ref({
     // Data is for debugging only right now
     url: { name: 'New Perma Link URL', type: "text", description: "The URL associated with this upload", placeholder: "Page URL", value: '' },
-    title: { name: "New Perma Link Title", type: "text", description: "A test description for testing", placeholder: "Placeholder", value: '' },
+    file: { name: "Choose a file", type: "file", description: ".gif, .jpg, .pdf, and .png allowed, up to 100 MB", value: '' },
 })
 
 // Match backend format for errors, for example {file:"message",url:"message"},
@@ -22,6 +23,7 @@ const handleErrorReset = () => {
 
 </script>
 
+
 <template>
     <div class="modal-content">
         <div class="modal-body">
@@ -29,6 +31,8 @@ const handleErrorReset = () => {
                 <template v-for="(_, key) in formData" :key="key">
                     {{ formData[key].value }} <!-- Testing only -->
                     <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]"
+                        :id="key" />
+                    <FileInput v-if="formData[key].type === 'file'" v-model="formData[key]" :error="errors[key]"
                         :id="key" />
                 </template>
                 <button @click.prevent="handleErrorToggle">Toggle Error</button>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -14,7 +14,11 @@ const errors = ref({})
 
 // Debug only
 const handleErrorToggle = () => {
-    errors.value.url = "URL cannot be empty."
+    const mockedErrors = {
+        url: "URL cannot be empty.",
+        file: "File is too large."
+    }
+    errors.value = mockedErrors
 }
 
 const handleErrorReset = () => {


### PR DESCRIPTION
## What this does 
Adds a new component, `FileInput`, to provide a file chooser that allows users to choose a file to upload as part of their own static archive. 

## Implementation Requirements

Main Goals:
- Add a reusable component that accepts a file in the formats of .gif, .jpg, .pdf, and .png
- The component will be used in the archive upload component, and look like this: 

![image](https://github.com/harvard-lil/perma/assets/4039311/a9a946b0-4c77-4d6e-ac23-53dc96386c86)

- Reuse as much existing HTML and CSS as possible 
- Rewrite file handling logic using modern JavaScript
- File validation (to check if the file is larger than 100MB) will be handled by the backend 
- If an error exists, it can be passed to the component and displayed in a way that matches the above screenshot

## Screenshots

### File chosen
![Screenshot 2024-06-17 at 8 24 16 AM](https://github.com/harvard-lil/perma/assets/4039311/33e43045-c1b5-49c0-8da1-610644b5d252)
Note: The visible, stringified `File` object shown above the screenshot is for debugging purposes only

### File validation error
![image](https://github.com/harvard-lil/perma/assets/4039311/e1073477-a932-447c-b7ce-9b640541df2e)

## How to Test
- Try to choose a file. Only valid file formats should be selectable in the file input UI.
- Try to toggle input errors. The chosen file should still be visible, for now. (It shouldn't be overwritten)
- Try to reset the input errors. 