### PR TITLE
Update urllib3

### DIFF
--- a/perma_web/requirements.txt
+++ b/perma_web/requirements.txt
@@ -1011,9 +1011,9 @@ ua-parser==0.10.0 \
     --hash=sha256:46ab2e383c01dbd2ab284991b87d624a26a08f72da4d7d413f5bfab8b9036f8a \
     --hash=sha256:47b1782ed130d890018d983fac37c2a80799d9e0b9c532e734c67cf70f185033
     # via -r requirements.in
-urllib3==1.26.18 \
-    --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07 \
-    --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
+urllib3==2.0.7 \
+    --hash=sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84 \
+    --hash=sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e
     # via
     #   botocore
     #   internetarchive


### PR DESCRIPTION
Although this upgrade could have been to 1.26.19, 2.07 is what pip-compile did, suggesting that our dependencies that depend on it are happy with it.

https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#207-2023-10-17

See also https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html

I did not see any urllib3 deprecations when I ran the tests locally.

If the major version update seems iffy, I can redo this with 1.26.19.