### PR TITLE
Use new wacz_size field

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -606,16 +606,16 @@ class LinkUserAdmin(UserAdmin):
 
 
 class LinkAdmin(SimpleHistoryAdmin):
-    list_display = ['guid', 'submitted_url', 'created_by', 'creation_timestamp', 'organization_id', 'tag_list', 'is_private', 'user_deleted', 'cached_can_play_back', 'captured_by_software', 'internet_archive_upload_status', 'file_size']
+    list_display = ['guid', 'submitted_url', 'created_by', 'creation_timestamp', 'organization_id', 'tag_list', 'is_private', 'user_deleted', 'cached_can_play_back', 'captured_by_software', 'internet_archive_upload_status', 'formatted_warc_size', 'formatted_wacz_size']
     list_filter = [GUIDFilter, CreatedByFilter, SubmittedURLFilter, OrganizationFilter, TagFilter, 'cached_can_play_back', 'internet_archive_upload_status']
     fieldsets = (
-        (None, {'fields': ('guid', 'capture_job', 'submitted_url', 'submitted_url_surt','submitted_title', 'submitted_description', 'created_by', 'creation_timestamp', 'captured_by_software', 'captured_by_browser', 'file_size', 'replacement_link', 'tags')}),
+        (None, {'fields': ('guid', 'capture_job', 'submitted_url', 'submitted_url_surt','submitted_title', 'submitted_description', 'created_by', 'creation_timestamp', 'captured_by_software', 'captured_by_browser', 'formatted_warc_size', 'formatted_wacz_size', 'replacement_link', 'tags')}),
         ('Visibility', {'fields': ('is_private', 'private_reason', 'is_unlisted',)}),
         ('User Delete', {'fields': ('user_deleted', 'user_deleted_timestamp',)}),
         ('Organization', {'fields': ('folders', 'notes')}),
         ('Mirroring', {'fields': ('archive_timestamp', 'internet_archive_upload_status', 'cached_can_play_back')}),
     )
-    readonly_fields = ['guid', 'capture_job', 'folders', 'creation_timestamp', 'file_size', 'captured_by_software', 'captured_by_browser', 'archive_timestamp']
+    readonly_fields = ['guid', 'capture_job', 'folders', 'creation_timestamp', 'formatted_warc_size', 'formatted_wacz_size', 'captured_by_software', 'captured_by_browser', 'archive_timestamp']
     inlines = [
         new_class("CaptureInline", admin.TabularInline, model=Capture,
                   fields=['role', 'status', 'url', 'content_type', 'record_type', 'user_upload'],
@@ -639,10 +639,17 @@ class LinkAdmin(SimpleHistoryAdmin):
     def tag_list(self, obj):
         return ", ".join(o.name for o in obj.tags.all())
 
-    def file_size(self, obj):
+    def formatted_warc_size(self, obj):
         return filesizeformat(obj.warc_size)
 
-    file_size.admin_order_field = 'warc_size'
+    formatted_warc_size.admin_order_field = 'warc_size'
+    formatted_warc_size.short_description = 'warc size'
+
+    def formatted_wacz_size(self, obj):
+        return filesizeformat(obj.wacz_size)
+
+    formatted_wacz_size.admin_order_field = 'wacz_size'
+    formatted_wacz_size.short_description = 'wacz size'
 
 
 class FolderAdmin(admin.ModelAdmin):

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1475,6 +1475,9 @@ def convert_warc_to_wacz(input_guid):
         else:
             data["conversion_status"] = "Success"
 
+        link.wacz_size = wacz_size
+        link.save(update_fields=['wacz_size'])
+
         with open(wacz_path, 'rb') as wacz_file:
             storages[settings.WACZ_STORAGE].save(link.wacz_storage_file(), wacz_file)
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -495,6 +495,17 @@ def populate_warc_size(link_guid):
     link.save(update_fields=['warc_size'])
 
 
+
+@shared_task(acks_late=True)
+def populate_wacz_size(link_guid):
+    """
+    One-time task, to populate the wacz_size field for links converted before that field was added.
+    """
+    link = Link.objects.get(guid=link_guid)
+    link.wacz_size = storages[settings.WACZ_STORAGE].size(link.wacz_storage_file())
+    link.save(update_fields=['wacz_size'])
+
+
 ###                  ###
 ### INTERNET ARCHIVE ###
 ###                  ###

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1841,8 +1841,7 @@ class Link(DeletableModel):
         return f'{parsed.path}?{parsed.query}'.lstrip('/')
 
     def has_wacz_version(self):
-        wacz = self.wacz_storage_file()
-        return storages[settings.WACZ_STORAGE].exists(wacz)
+        return bool(self.wacz_size)
 
     def delete_related_captures(self):
         Capture.objects.filter(link_id=self.pk).delete()

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -455,6 +455,7 @@ CELERY_TASK_ROUTES = {
     'perma.celery_tasks.cache_playback_status': {'queue': 'background'},
     'perma.celery_tasks.populate_warc_size_fields': {'queue': 'background'},
     'perma.celery_tasks.populate_warc_size': {'queue': 'background'},
+    'perma.celery_tasks.populate_wacz_size': {'queue': 'background'},
     'perma.celery_tasks.fix_cached_folder_paths': {'queue': 'background'},
     'perma.celery_tasks.fix_cached_folder_path': {'queue': 'background'},
     # the 'ia' queue is for tasks that alter or may alter Internet Archive's records


### PR DESCRIPTION
See ENG-976 and ENG-966.

A `wacz_size` field was added to `Link` in https://github.com/harvard-lil/perma/pull/3548.

This PR:
- adds that field to the Django admin
- tweaks the WARC -> WACZ conversion code to populate it
- adds a quick one-time task to populate `wacz_size` for the WACZs made during our benchmark testing.

The task should be invoked with the `all-conversion-logs.csv` that Ben produced during benchmark testing. (See ENG-963)

`invoke dev.populate-benchmarked-wacz-sizes --source-csv all-conversion-logs.csv`