### PR TITLE
Basic WACZ tests

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -178,10 +178,9 @@ def user() -> User:
     return User("functional_test_user@example.com", "pass")
 
 
-# TODO: if this login fails, the fixture should error out,
-# and it's weird that a fixture called "logged in user" returns a page object
+# TODO: if this login fails, the fixture should error out
 @pytest.fixture
-def logged_in_user(page, urls, user):
+def page_with_logged_in_user(page, urls, user):
     """Actually log in the desired user"""
     page.goto(urls.login)
     username = page.locator('#id_username')

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -178,19 +178,21 @@ def user() -> User:
     return User("functional_test_user@example.com", "pass")
 
 
-# TODO: if this login fails, the fixture should error out
 @pytest.fixture
-def page_with_logged_in_user(page, urls, user):
-    """Actually log in the desired user"""
-    page.goto(urls.login)
-    username = page.locator('#id_username')
-    username.focus()
-    username.type(user.username)
-    password = page.locator('#id_password')
-    password.focus()
-    password.type(user.password)
-    page.locator("button.btn.login").click()
-    return page
+@pytest.fixture
+def log_in_user(urls):
+    """A utility to log in the desired user"""
+    # TODO: if this login fails, the fixture should error out
+    def f(page, user):
+        page.goto(urls.login)
+        username = page.locator('#id_username')
+        username.focus()
+        username.type(user.username)
+        password = page.locator('#id_password')
+        password.focus()
+        password.type(user.password)
+        page.locator("button.btn.login").click()
+    return f
 
 
 ###              ###

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 import os
 from random import choice
 import subprocess
+from waffle import get_waffle_flag_model
+
 from django.db.models import OuterRef, Exists
 from django.conf import settings
 from django.core.management import call_command
@@ -179,6 +181,14 @@ def user() -> User:
 
 
 @pytest.fixture
+def wacz_user() -> User:
+    """For this user, the 'wacz-playback' flag is True"""
+    u = LinkUser.objects.get(email="wacz_functional_test_user@example.com")
+    flag, _created = get_waffle_flag_model().objects.get_or_create(name="wacz-playback")
+    flag.users.add(u.id)
+    return User(u.email, "pass")
+
+
 @pytest.fixture
 def log_in_user(urls):
     """A utility to log in the desired user"""

--- a/perma_web/fixtures/folders.json
+++ b/perma_web/fixtures/folders.json
@@ -703,5 +703,20 @@
       "is_root_folder": true,
       "cached_path": "67"
     }
+  },
+  {
+    "model": "perma.folder",
+    "pk": 68,
+    "fields": {
+      "name": "Personal Links",
+      "parent": null,
+      "creation_timestamp": "2002-02-28T00:00:00Z",
+      "created_by": 26,
+      "owned_by": 26,
+      "organization": null,
+      "is_shared_folder": false,
+      "is_root_folder": true,
+      "cached_path": "67"
+    }
   }
 ]

--- a/perma_web/fixtures/users.json
+++ b/perma_web/fixtures/users.json
@@ -831,5 +831,31 @@
       "unlimited": false,
       "in_trial": true
     }
+  },
+  {
+    "model": "perma.linkuser",
+    "pk": 26,
+    "fields": {
+      "password": "pbkdf2_sha256$10000$gtsGKyK7FARJ$MdCKh7SZhd6uDz1enPxcNAn3fM0L7o5OAKd1/VjXiqk=",
+      "last_login": "2002-02-28T00:00:00Z",
+      "email": "wacz_functional_test_user@example.com",
+      "raw_email": "wacz_functional_test_user@example.com",
+      "registrar": null,
+      "pending_registrar": null,
+      "is_active": true,
+      "is_confirmed": true,
+      "is_staff": false,
+      "date_joined": "2002-02-28T00:00:00Z",
+      "first_name": "WACZ Functional Test",
+      "last_name": "User",
+      "root_folder": 68,
+      "requested_account_type": null,
+      "requested_account_note": null,
+      "link_count": 0,
+      "link_limit": 10,
+      "organizations": [],
+      "nonpaying": true,
+      "unlimited": true
+    }
   }
 ]

--- a/perma_web/functional_tests/test_auth.py
+++ b/perma_web/functional_tests/test_auth.py
@@ -1,5 +1,5 @@
 
-def test_log_out(logged_in_user):
-    logged_in_user.locator(".dropdown-toggle").click()
-    logged_in_user.locator("button", has_text="Log out").click()
-    assert logged_in_user.locator("h1", has_text="You have been logged out")
+def test_log_out(page_with_logged_in_user):
+    page_with_logged_in_user.locator(".dropdown-toggle").click()
+    page_with_logged_in_user.locator("button", has_text="Log out").click()
+    assert page_with_logged_in_user.locator("h1", has_text="You have been logged out")

--- a/perma_web/functional_tests/test_auth.py
+++ b/perma_web/functional_tests/test_auth.py
@@ -1,5 +1,6 @@
 
-def test_log_out(page_with_logged_in_user):
-    page_with_logged_in_user.locator(".dropdown-toggle").click()
-    page_with_logged_in_user.locator("button", has_text="Log out").click()
-    assert page_with_logged_in_user.locator("h1", has_text="You have been logged out")
+def test_log_out(page, user, log_in_user):
+    log_in_user(page, user)
+    page.locator(".dropdown-toggle").click()
+    page.locator("button", has_text="Log out").click()
+    assert page.locator("h1", has_text="You have been logged out")

--- a/perma_web/functional_tests/test_contact.py
+++ b/perma_web/functional_tests/test_contact.py
@@ -44,19 +44,21 @@ def test_contact_no_js(page, urls, mailoutbox, caplog) -> None:
     assert len(mailoutbox) == 0
 
 
-def test_contact_no_js_logged_in(page_with_logged_in_user, urls, mailoutbox, caplog) -> None:
+def test_contact_no_js_logged_in(page, user, log_in_user, urls, mailoutbox, caplog) -> None:
     """The Contact form should submit, and not be rejected despite no JS."""
     msg = "I've got important things to say."
 
-    page_with_logged_in_user.goto(urls.contact)
-    # Remove the form's submit event listener
-    page_with_logged_in_user.evaluate('() => {let elem = document.querySelector(".contact-form"); elem.innerHTML = elem.innerHTML;}')
+    log_in_user(page, user)
 
-    message_field = page_with_logged_in_user.locator('#id_box2')
+    page.goto(urls.contact)
+    # Remove the form's submit event listener
+    page.evaluate('() => {let elem = document.querySelector(".contact-form"); elem.innerHTML = elem.innerHTML;}')
+
+    message_field = page.locator('#id_box2')
     message_field.focus()
     message_field.type(msg)
 
-    page_with_logged_in_user.locator('.contact-form button[type=submit]').click()
+    page.locator('.contact-form button[type=submit]').click()
 
     assert len(mailoutbox) == 1
     m = mailoutbox[0]

--- a/perma_web/functional_tests/test_contact.py
+++ b/perma_web/functional_tests/test_contact.py
@@ -44,19 +44,19 @@ def test_contact_no_js(page, urls, mailoutbox, caplog) -> None:
     assert len(mailoutbox) == 0
 
 
-def test_contact_no_js_logged_in(logged_in_user, urls, mailoutbox, caplog) -> None:
+def test_contact_no_js_logged_in(page_with_logged_in_user, urls, mailoutbox, caplog) -> None:
     """The Contact form should submit, and not be rejected despite no JS."""
     msg = "I've got important things to say."
 
-    logged_in_user.goto(urls.contact)
+    page_with_logged_in_user.goto(urls.contact)
     # Remove the form's submit event listener
-    logged_in_user.evaluate('() => {let elem = document.querySelector(".contact-form"); elem.innerHTML = elem.innerHTML;}')
+    page_with_logged_in_user.evaluate('() => {let elem = document.querySelector(".contact-form"); elem.innerHTML = elem.innerHTML;}')
 
-    message_field = logged_in_user.locator('#id_box2')
+    message_field = page_with_logged_in_user.locator('#id_box2')
     message_field.focus()
     message_field.type(msg)
 
-    logged_in_user.locator('.contact-form button[type=submit]').click()
+    page_with_logged_in_user.locator('.contact-form button[type=submit]').click()
 
     assert len(mailoutbox) == 1
     m = mailoutbox[0]

--- a/perma_web/functional_tests/test_folders.py
+++ b/perma_web/functional_tests/test_folders.py
@@ -1,27 +1,30 @@
 import pytest
 
-def test_create_folder(page_with_logged_in_user, urls):
+def test_create_folder(page, user, log_in_user, urls):
     """Clicking the add button should create a new folder"""
-    page_with_logged_in_user.goto(urls.folders)
-    folder_count = page_with_logged_in_user.locator('.jstree-last').count()
-    page_with_logged_in_user.locator('.new-folder').click()
-    page_with_logged_in_user.locator(f":nth-match(.jstree-last, {folder_count + 1})").wait_for()
+    log_in_user(page, user)
+
+    page.goto(urls.folders)
+    folder_count = page.locator('.jstree-last').count()
+    page.locator('.new-folder').click()
+    page.locator(f":nth-match(.jstree-last, {folder_count + 1})").wait_for()
 
 
 @pytest.mark.xfail(reason="Needs more work to be reliable")
-def test_delete_folder(page_with_logged_in_user, urls):
+def test_delete_folder(page, user, log_in_user, urls):
     """Clicking the folder delete button should delete an existing empty folder"""
-    page_with_logged_in_user.goto(urls.folders)
+    log_in_user(page, user)
+    page.goto(urls.folders)
 
     # Create a new folder and wait for it to exist
-    folder_count = page_with_logged_in_user.locator('.jstree-last').count()
-    page_with_logged_in_userr.locator('.new-folder').click()
-    new_folder = page_with_logged_in_user.locator(f":nth-match(.jstree-last, {folder_count + 1})")
+    folder_count = page.locator('.jstree-last').count()
+    page.locator('.new-folder').click()
+    new_folder = page.locator(f":nth-match(.jstree-last, {folder_count + 1})")
     new_folder.wait_for()
 
     # Now delete it
     new_folder.click(button="right")
-    with page_with_logged_in_user.expect_navigation():
-        page_with_logged_in_user.click("text=Delete")
+    with page.expect_navigation():
+        page.click("text=Delete")
 
     new_folder.wait_for(state="hidden")

--- a/perma_web/functional_tests/test_folders.py
+++ b/perma_web/functional_tests/test_folders.py
@@ -1,27 +1,27 @@
 import pytest
 
-def test_create_folder(logged_in_user, urls):
+def test_create_folder(page_with_logged_in_user, urls):
     """Clicking the add button should create a new folder"""
-    logged_in_user.goto(urls.folders)
-    folder_count = logged_in_user.locator('.jstree-last').count()
-    logged_in_user.locator('.new-folder').click()
-    logged_in_user.locator(f":nth-match(.jstree-last, {folder_count + 1})").wait_for()
+    page_with_logged_in_user.goto(urls.folders)
+    folder_count = page_with_logged_in_user.locator('.jstree-last').count()
+    page_with_logged_in_user.locator('.new-folder').click()
+    page_with_logged_in_user.locator(f":nth-match(.jstree-last, {folder_count + 1})").wait_for()
 
 
 @pytest.mark.xfail(reason="Needs more work to be reliable")
-def test_delete_folder(logged_in_user, urls):
+def test_delete_folder(page_with_logged_in_user, urls):
     """Clicking the folder delete button should delete an existing empty folder"""
-    logged_in_user.goto(urls.folders)
+    page_with_logged_in_user.goto(urls.folders)
 
     # Create a new folder and wait for it to exist
-    folder_count = logged_in_user.locator('.jstree-last').count()
-    logged_in_user.locator('.new-folder').click()
-    new_folder = logged_in_user.locator(f":nth-match(.jstree-last, {folder_count + 1})")
+    folder_count = page_with_logged_in_user.locator('.jstree-last').count()
+    page_with_logged_in_userr.locator('.new-folder').click()
+    new_folder = page_with_logged_in_user.locator(f":nth-match(.jstree-last, {folder_count + 1})")
     new_folder.wait_for()
 
     # Now delete it
     new_folder.click(button="right")
-    with logged_in_user.expect_navigation():
-        logged_in_user.click("text=Delete")
+    with page_with_logged_in_user.expect_navigation():
+        page_with_logged_in_user.click("text=Delete")
 
     new_folder.wait_for(state="hidden")

--- a/perma_web/functional_tests/test_links.py
+++ b/perma_web/functional_tests/test_links.py
@@ -3,6 +3,14 @@ import re
 two_minutes = 120 * 1000
 
 def create_link(page):
+    """
+    A helper:
+    clicks into the "Create a link" input,
+    submits a link creation request,
+    and waits for the page to redirect playback.
+
+    Expect timeouts on failed attempt.
+    """
     url_field = page.locator('#rawUrl')
     url_field.focus()
     url_field.type("https://example.com/")
@@ -17,7 +25,11 @@ def create_link(page):
 
 
 def test_create_link_warc_playback(page, user, log_in_user) -> None:
-    """It should be possible to successfully create a link from a URL"""
+    """
+    It should be possible to successfully create a link from a URL.
+
+    This user (no feature flag) should see a WARC playback.
+    """
     log_in_user(page, user)
     create_link(page)
 
@@ -27,7 +39,11 @@ def test_create_link_warc_playback(page, user, log_in_user) -> None:
 
 
 def test_create_link_wacz_playback(page, wacz_user, log_in_user) -> None:
-    """It should be possible to successfully create a link from a URL"""
+    """
+    It should be possible to successfully create a link from a URL.
+
+    This user (with feature flag set) should see a WACZ playback.
+    """
     log_in_user(page, wacz_user)
     create_link(page)
 

--- a/perma_web/functional_tests/test_links.py
+++ b/perma_web/functional_tests/test_links.py
@@ -3,34 +3,47 @@ import re
 two_minutes = 120 * 1000
 
 
-def test_create_link_warc_playback(page_with_logged_in_user) -> None:
+def test_create_link_warc_playback(page, user, log_in_user) -> None:
     """It should be possible to successfully create a link from a URL"""
-    url_field = page_with_logged_in_user.locator('#rawUrl')
+    log_in_user(page, user)
+
+    url_field = page.locator('#rawUrl')
     url_field.focus()
     url_field.type("https://example.com/")
-    page_with_logged_in_user.locator('#addlink').click()
-    page_with_logged_in_user.wait_for_url(re.compile('/[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$'), timeout=two_minutes)
-    assert page_with_logged_in_user.title() == 'Perma | Example Domain'
-    assert"Example Domain" in page_with_logged_in_user \
+    page.locator('#addlink').click()
+    page.wait_for_url(re.compile('/[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$'), timeout=two_minutes)
+    assert page.title() == 'Perma | Example Domain'
+    assert"Example Domain" in page \
         .frame_locator('.archive-iframe') \
         .frame_locator('iframe') \
         .frame_locator('iframe') \
         .locator('h1').inner_text()
+    # Verify we are seing a WARC playback, not a WACZ playback
+    assert ".warc.gz?" in page.content()
+    assert ".wacz?" not in page.content()
+
 
 
 def test_link_required(logged_in_user) -> None:
 def test_link_required(page_with_logged_in_user) -> None:
+
+
+def test_link_required(page, user, log_in_user) -> None:
     """A friendly message should be displayed if the field is omitted"""
-    page_with_logged_in_user.locator('#rawUrl')
-    page_with_logged_in_user.locator('#addlink').click()
-    assert "URL cannot be empty" in page_with_logged_in_user.locator("p.message-large").text_content()
+    log_in_user(page, user)
+
+    page.locator('#rawUrl')
+    page.locator('#addlink').click()
+    assert "URL cannot be empty" in page.locator("p.message-large").text_content()
 
 
-def test_upload_nonexistent(page_with_logged_in_user) -> None:
+def test_upload_nonexistent(page, user, log_in_user) -> None:
     """A modal should be displayed if the user input a domain we can't resolve"""
-    url_field = page_with_logged_in_user.locator('#rawUrl')
+    log_in_user(page, user)
+
+    url_field = page.locator('#rawUrl')
     url_field.focus()
     url_field.type("https://fakedomain.fakething/")
-    page_with_logged_in_user.locator('#addlink').click()
-    assert "Couldn't resolve domain." in page_with_logged_in_user.locator("p.message-large").text_content()
+    page.locator('#addlink').click()
+    assert "Couldn't resolve domain." in page.locator("p.message-large").text_content()
 

--- a/perma_web/functional_tests/test_links.py
+++ b/perma_web/functional_tests/test_links.py
@@ -2,11 +2,7 @@ import re
 
 two_minutes = 120 * 1000
 
-
-def test_create_link_warc_playback(page, user, log_in_user) -> None:
-    """It should be possible to successfully create a link from a URL"""
-    log_in_user(page, user)
-
+def create_link(page):
     url_field = page.locator('#rawUrl')
     url_field.focus()
     url_field.type("https://example.com/")
@@ -18,14 +14,26 @@ def test_create_link_warc_playback(page, user, log_in_user) -> None:
         .frame_locator('iframe') \
         .frame_locator('iframe') \
         .locator('h1').inner_text()
+
+
+def test_create_link_warc_playback(page, user, log_in_user) -> None:
+    """It should be possible to successfully create a link from a URL"""
+    log_in_user(page, user)
+    create_link(page)
+
     # Verify we are seing a WARC playback, not a WACZ playback
     assert ".warc.gz?" in page.content()
     assert ".wacz?" not in page.content()
 
 
+def test_create_link_wacz_playback(page, wacz_user, log_in_user) -> None:
+    """It should be possible to successfully create a link from a URL"""
+    log_in_user(page, wacz_user)
+    create_link(page)
 
-def test_link_required(logged_in_user) -> None:
-def test_link_required(page_with_logged_in_user) -> None:
+    # Verify we are seing a WACZ playback, not a WARC playback
+    assert ".warc.gz?" not in page.content()
+    assert ".wacz?" in page.content()
 
 
 def test_link_required(page, user, log_in_user) -> None:

--- a/perma_web/functional_tests/test_links.py
+++ b/perma_web/functional_tests/test_links.py
@@ -3,15 +3,15 @@ import re
 two_minutes = 120 * 1000
 
 
-def test_create_link(logged_in_user) -> None:
+def test_create_link_warc_playback(page_with_logged_in_user) -> None:
     """It should be possible to successfully create a link from a URL"""
-    url_field = logged_in_user.locator('#rawUrl')
+    url_field = page_with_logged_in_user.locator('#rawUrl')
     url_field.focus()
     url_field.type("https://example.com/")
-    logged_in_user.locator('#addlink').click()
-    logged_in_user.wait_for_url(re.compile('/[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$'), timeout=two_minutes)
-    assert logged_in_user.title() == 'Perma | Example Domain'
-    assert"Example Domain" in logged_in_user \
+    page_with_logged_in_user.locator('#addlink').click()
+    page_with_logged_in_user.wait_for_url(re.compile('/[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$'), timeout=two_minutes)
+    assert page_with_logged_in_user.title() == 'Perma | Example Domain'
+    assert"Example Domain" in page_with_logged_in_user \
         .frame_locator('.archive-iframe') \
         .frame_locator('iframe') \
         .frame_locator('iframe') \
@@ -19,17 +19,18 @@ def test_create_link(logged_in_user) -> None:
 
 
 def test_link_required(logged_in_user) -> None:
+def test_link_required(page_with_logged_in_user) -> None:
     """A friendly message should be displayed if the field is omitted"""
-    logged_in_user.locator('#rawUrl')
-    logged_in_user.locator('#addlink').click()
-    assert "URL cannot be empty" in logged_in_user.locator("p.message-large").text_content()
+    page_with_logged_in_user.locator('#rawUrl')
+    page_with_logged_in_user.locator('#addlink').click()
+    assert "URL cannot be empty" in page_with_logged_in_user.locator("p.message-large").text_content()
 
 
-def test_upload_nonexistent(logged_in_user) -> None:
+def test_upload_nonexistent(page_with_logged_in_user) -> None:
     """A modal should be displayed if the user input a domain we can't resolve"""
-    url_field = logged_in_user.locator('#rawUrl')
+    url_field = page_with_logged_in_user.locator('#rawUrl')
     url_field.focus()
     url_field.type("https://fakedomain.fakething/")
-    logged_in_user.locator('#addlink').click()
-    assert "Couldn't resolve domain." in logged_in_user.locator("p.message-large").text_content()
+    page_with_logged_in_user.locator('#addlink').click()
+    assert "Couldn't resolve domain." in page_with_logged_in_user.locator("p.message-large").text_content()
 

--- a/perma_web/functional_tests/test_links.py
+++ b/perma_web/functional_tests/test_links.py
@@ -17,7 +17,7 @@ def create_link(page):
     page.locator('#addlink').click()
     page.wait_for_url(re.compile('/[A-Za-z0-9]{4}-[A-Za-z0-9]{4}$'), timeout=two_minutes)
     assert page.title() == 'Perma | Example Domain'
-    assert"Example Domain" in page \
+    assert "Example Domain" in page \
         .frame_locator('.archive-iframe') \
         .frame_locator('iframe') \
         .frame_locator('iframe') \

--- a/perma_web/perma/settings/deployments/settings_testing.py
+++ b/perma_web/perma/settings/deployments/settings_testing.py
@@ -125,3 +125,5 @@ TIERS = {
         }
     ]
 }
+
+WACZ_SAVING_ENABLED = True

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -493,13 +493,13 @@ class UserManagementViewsTestCase(PermaTestCase):
     ### USER A/E/D VIEWS ###
 
     def test_user_list_filters(self):
-        # test assumptions: eight users
+        # test assumptions: nine users
         # - one aspiring court user, faculty user, journal user
         response = self.get('user_management_manage_user',
                              user=self.admin_user).content
         soup = BeautifulSoup(response, 'html.parser')
         count = soup.select('.sort-filter-count')[0].text
-        self.assertEqual("Found: 8 users", count)
+        self.assertEqual("Found: 9 users", count)
         self.assertEqual(response.count(b'Interested in a court account'), 1)
         self.assertEqual(response.count(b'Interested in a journal account'), 1)
         self.assertEqual(response.count(b'Interested in a faculty account'), 1)


### PR DESCRIPTION
See ENG-967.

This PR adds a few basic tests of Perma's new WACZ-related features:
- one test for each branch of the "should we launch a WARC or a WACZ playback" code
- one functional test that actually does a WACZ playback, and confirms that it works.

To make the functional test easier to write:
- I set `WACZ_SAVING_ENABLED = True` in testing (seems harmless, right?)
- I did some light refactoring of the functional test fixtures to convert the `logged_in_user` fixture out into a utility function, for clarity and increased flexibility
- I created a new user fixture for whom the Django waffle "wacz-playback" flag is set to True.