### PR TITLE
Fix broken links in Perma docs

### DIFF
--- a/perma_web/perma/templates/docs/index.html
+++ b/perma_web/perma/templates/docs/index.html
@@ -108,7 +108,7 @@ Welcome to the Perma.cc user guide. The best place to learn about how Perma.cc w
       <p class="body-text">How you use a Perma Link in a citation is up to you. One common method, encouraged by <a href="https://www.legalbluebook.com/">The Bluebook</a>, is to include both the Perma Link and the original URL in the citation, like this:</p>
 
       <figure>
-        <figcaption>An example from the <a href="http://cdn.harvardlawreview.org/wp-content/uploads/2014/06/vol127_west.pdf">Harvard Law Review</a></figcaption>
+        <figcaption>An example from the <a href="https://harvardlawreview.org/wp-content/uploads/2014/06/vol127_west.pdf">Harvard Law Review</a></figcaption>
         <img src="{{ STATIC_URL }}img/docs/citation_example.png" class="img-responsive screen-shot" alt="Footnote 4. See, e.g., Charles P. Pierce, This Cannot Be the Way Occupy Ends, ESQUIRE: POL. BLOG (Nov 17, 2011) http://www.esquire.com/blogs/politics/occupy-wall-street-violence-6575448, archived at https://perma.cc/48VC-ZS62 (bemoaning protestors' 'reciprocal violence' and arguing that the protest 'can't end in images of bleeding cops and tossed barricades'" />
       </figure>
 

--- a/perma_web/perma/templates/docs/perma-link-creation.html
+++ b/perma_web/perma/templates/docs/perma-link-creation.html
@@ -93,7 +93,7 @@ This section of the user guide covers how to create new archives and organize yo
       <p class="body-text">Give your readers access to the Perma Records you create by adding the relevant Perma Link to your citation.</p>
 
       <figure>
-        <figcaption>An example from the <a href="http://cdn.harvardlawreview.org/wp-content/uploads/2014/06/vol127_west.pdf">Harvard Law Review</a></figcaption>
+        <figcaption>An example from the <a href="https://harvardlawreview.org/wp-content/uploads/2014/06/vol127_west.pdf">Harvard Law Review</a></figcaption>
         <img src="{{ STATIC_URL }}img/docs/citation_example.png" class="img-responsive screen-shot" alt="Footnote 4. See, e.g., Charles P. Pierce, This Cannot Be the Way Occupy Ends, ESQUIRE: POL. BLOG (Nov 17, 2011) http://www.esquire.com/blogs/politics/occupy-wall-street-violence-6575448, archived at https://perma.cc/48VC-ZS62 (bemoaning protestors' 'reciprocal violence' and arguing that the protest 'can't end in images of bleeding cops and tossed barricades'" />
       </figure>
 

--- a/perma_web/perma/templates/registration/sign-up-faculty.html
+++ b/perma_web/perma/templates/registration/sign-up-faculty.html
@@ -39,7 +39,7 @@
       <p class="body-text">The Bluebook now encourages archiving online sources when a reliable service such as Perma.cc is available.<p class="body-text">
 
       <h3 class="body-bh">Contact your library for a journal account</h3>
-      <p class="body-text">If your library is already registered with us (see the full list <a href="{% url 'about' %}#partners">here</a>), contact them for setup. If not, invite your library to visit our <a href="{% url 'libraries' %}">library resource page</a> to request membership, and we’ll help them get started.<p class="body-text">
+      <p class="body-text">If your library is already registered with us, contact them for setup. If not, invite your library to visit our <a href="{% url 'libraries' %}">library resource page</a> to request membership, and we’ll help them get started.<p class="body-text">
 
       <h3 class="body-bh">Try it now</h3>
       <p class="body-text">Users not associated with a registrar library must <a href="{% url 'sign_up' %}">sign up for a paid subscription.</a> New users can create 10 Perma Links for free to try out the service. Create an account now to start your free trial. Your library will be able to upgrade your individual account at a later date.<p class="body-text">

--- a/perma_web/perma/templates/registration/sign-up-journals.html
+++ b/perma_web/perma/templates/registration/sign-up-journals.html
@@ -39,7 +39,7 @@
       <p class="body-text">The Bluebook now encourages archiving online sources when a reliable service such as Perma.cc is available.<p class="body-text">
 
       <h3 class="body-bh">Contact your library for a journal account</h3>
-      <p class="body-text">If your library is already registered with us (see the full list <a href="{% url 'about' %}#partners">here</a>), contact them for setup. If not, invite your library to visit our <a href="{% url 'libraries' %}">library resource page</a> to request membership, and we’ll help them get started.<p class="body-text">
+      <p class="body-text">If your library is already registered with us, contact them for setup. If not, invite your library to visit our <a href="{% url 'libraries' %}">library resource page</a> to request membership, and we’ll help them get started.<p class="body-text">
 
       <h3 class="body-bh">Try it now</h3>
       <p class="body-text">Users not associated with a registrar library must <a href="{% url 'sign_up' %}">sign up for a paid subscription.</a> New users can create 10 Perma Links for free to try out the service. Create an account now to start your free trial. Your library will be able to connect this account to your journal’s account at a later date.<p class="body-text">

--- a/perma_web/perma/templates/registration/sign-up-libraries.html
+++ b/perma_web/perma/templates/registration/sign-up-libraries.html
@@ -39,7 +39,7 @@
       <h2 class="body-ah">Libraries power Perma.cc</h2>
       <p class="body-text">For centuries, libraries have worked together to preserve print sources and to make those sources accessible to the public. Today they do the same for online sources through Perma.cc’s active network of library partners.</p>
       <h3 class="body-bh">Network of registrars</h3>
-      <p class="body-text">We call our library partners “registrars,” and our <a href="{% url 'about' %}#partners">network of registrars</a> is now <strong>{{registrar_count}}</strong> institutions strong. Each registrar sponsors and administers Perma for its local community of scholars and journals.</p>
+      <p class="body-text">We call our library partners “registrars,” and our network of registrars is now many institutions strong. Each registrar sponsors and administers Perma for its local community of scholars and journals.</p>
 
       <h3 class="body-bh">Free for academics</h3>
       <p class="body-text">Perma.cc is free for academic libraries and the journals and faculty they support, and it's easy to use and administer. Please review our <a href="{% url 'docs' %}#libraries-and-registrars">user guide</a> to learn more about how libraries use Perma.cc. We now can offer registrar status to non-academic libraries via a paid subscription.</p>


### PR DESCRIPTION
This fixes a few broken links and references in the Perma documentation, namely:

* Several signup pages link to the anchor `/about#partners`, which no longer exists
* The libraries signup page also refers to the var `registrar_count`, which was [removed](https://github.com/harvard-lil/perma/commit/14e24078920fef3f104de1d3a30ff409e931d6ca) back in 2016!
* [Harvard Law Review article](http://cdn.harvardlawreview.org/wp-content/uploads/2014/06/vol127_west.pdf) linked in a few examples points to an out-of-date subdomain