### PR TITLE
Add ability to export organization user list as CSV

### DIFF
--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -183,7 +183,7 @@
                 <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> in admin console</a>
               {% endif %}
               {% if request.user.is_staff or request.user.is_registrar_user or request.user.is_organization_user %}
-                <a class="action" href="{% url 'user_management_manage_single_organization_list_users_csv' org.id %}">download <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> CSV</a>
+                <a class="action" href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv">download <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> CSV</a>
               {% endif %}
             </div>
           </div>

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -156,6 +156,7 @@
               <div class="item-count-group">
                 <strong class="list-count-number">{{ org.organization_users|default_if_none:"0" }}</strong>
                 <span class="item-count-label">users <a href="{% url 'user_management_manage_organization_user' %}?org={{org.id}}">View <div class="sr-wrapper"><span class="sr-only">users</span></div> </a></span>
+                <a href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv" id="export-org-{{ org.id }}-csv" class="pull-right icon-download-alt" title="Export CSV"></a>
               </div>
             </div>
           </div>
@@ -183,7 +184,7 @@
                 <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> in admin console</a>
               {% endif %}
               {% if request.user.is_staff or request.user.is_registrar_user or request.user.is_organization_user %}
-                <a class="action" href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv">download <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> CSV</a>
+                <a class="action" href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv">download <div class="sr-wrapper"><span class="sr-only">{{ org.name }} </span></div>organization info</a>
               {% endif %}
             </div>
           </div>

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -182,6 +182,9 @@
               {% if request.user.is_staff %}
                 <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> in admin console</a>
               {% endif %}
+              {% if request.user.is_staff or request.user.is_registrar_user or request.user.is_organization_user %}
+                <a class="action" href="{% url 'user_management_manage_single_organization_list_users_csv' org.id %}">download <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> CSV</a>
+              {% endif %}
             </div>
           </div>
 

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -183,9 +183,6 @@
               {% if request.user.is_staff %}
                 <a class="action" href="{% url 'admin:perma_organization_change' org.id %}">edit <div class="sr-wrapper"><span class="sr-only">{{ org.name }}</span></div> in admin console</a>
               {% endif %}
-              {% if request.user.is_staff or request.user.is_registrar_user or request.user.is_organization_user %}
-                <a class="action" href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv">download <div class="sr-wrapper"><span class="sr-only">{{ org.name }} </span></div>organization info</a>
-              {% endif %}
             </div>
           </div>
 

--- a/perma_web/perma/templates/user_management/manage_orgs.html
+++ b/perma_web/perma/templates/user_management/manage_orgs.html
@@ -156,7 +156,7 @@
               <div class="item-count-group">
                 <strong class="list-count-number">{{ org.organization_users|default_if_none:"0" }}</strong>
                 <span class="item-count-label">users <a href="{% url 'user_management_manage_organization_user' %}?org={{org.id}}">View <div class="sr-wrapper"><span class="sr-only">users</span></div> </a></span>
-                <a href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv" id="export-org-{{ org.id }}-csv" class="pull-right icon-download-alt" title="Export CSV"></a>
+                <span class="item-export-download-label pull-right"><a href="{% url 'user_management_manage_single_organization_export_user_list' org.id %}?format=csv" id="export-org-{{ org.id }}-csv" class="icon-download-alt" title="Export CSV"></a></span>
               </div>
             </div>
           </div>

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -62,6 +62,7 @@ class PermissionsTestCase(PermaTestCase):
                     ['user_management_manage_organization_user'],
                     ['user_management_manage_organization'],
                     ['user_management_manage_single_organization', {'kwargs':{'org_id':1}}],
+                    ['user_management_manage_single_organization_export_user_list', {'kwargs': {'org_id': 1}}],
                     ['user_management_manage_single_organization_delete', {'kwargs':{'org_id':1}}],
                     ['user_management_organization_user_add_user'],
                     ['user_management_manage_single_organization_user_remove', {'kwargs':{'user_id': 3},

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -3,12 +3,13 @@
 import csv
 from datetime import datetime, timezone as tz
 from io import StringIO
+import json
 from mock import patch, sentinel
 from random import random
 import re
 
 from bs4 import BeautifulSoup
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.core import mail
 from django.conf import settings
@@ -348,7 +349,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # status filter tested in test_registrar_user_list_filters
 
-    def test_org_export_user_list_csv(self):
+    def test_org_export_user_list(self):
         expected_results = {
             # Org ID: (record count, org name)
             1: (3, 'Test Journal'),
@@ -359,16 +360,35 @@ class UserManagementViewsTestCase(PermaTestCase):
             6: (0, 'Some Other Case'),
         }
         for org_id, (record_count, org_name) in expected_results.items():
-            response: HttpResponse = self.get(
+            # Get CSV export output
+            csv_response: HttpResponse = self.get(
                 'user_management_manage_single_organization_export_user_list',
+                request_kwargs={'data': {'format': 'csv'}},
                 reverse_kwargs={'args': [org_id]},
                 user=self.admin_user,
             )
-            self.assertEqual(response.headers['Content-Type'], 'text/csv')
+            self.assertEqual(csv_response.headers['Content-Type'], 'text/csv')
 
             # Validate CSV output against expected results
-            csv_file = StringIO(response.content.decode('utf8'))
+            csv_file = StringIO(csv_response.content.decode('utf8'))
             reader = csv.DictReader(csv_file)
+            reader_record_count = 0
+            for record in reader:
+                self.assertEqual(record['organization_name'], org_name)
+                reader_record_count += 1
+            self.assertEqual(reader_record_count, record_count)
+
+            # Get JSON export output
+            json_response: JsonResponse = self.get(
+                'user_management_manage_single_organization_export_user_list',
+                request_kwargs={'data': {'format': 'json'}},
+                reverse_kwargs={'args': [org_id]},
+                user=self.admin_user,
+            )
+            self.assertEqual(json_response.headers['Content-Type'], 'application/json')
+
+            # Validate JSON output against expected results
+            reader = json.loads(json_response.content)
             reader_record_count = 0
             for record in reader:
                 self.assertEqual(record['organization_name'], org_name)

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -108,7 +108,7 @@ urlpatterns = [
 
     re_path(r'^manage/organizations/?$', user_management.manage_organization, name='user_management_manage_organization'),
     re_path(r'^manage/organizations/(?P<org_id>\d+)/?$', user_management.manage_single_organization, name='user_management_manage_single_organization'),
-    re_path(r'^manage/organization-users/(?P<org_id>\d+)/csv/?$', user_management.manage_single_organization_list_users_csv, name='user_management_manage_single_organization_list_users_csv'),
+    re_path(r'^manage/organization-users/(?P<org_id>\d+)/export/?$', user_management.manage_single_organization_export_user_list, name='user_management_manage_single_organization_export_user_list'),
     re_path(r'^manage/organization/(?P<org_id>\d+)/delete/?$', user_management.manage_single_organization_delete, name='user_management_manage_single_organization_delete'),
 
     re_path(r'^manage/admin-users/?$', user_management.manage_admin_user, name='user_management_manage_admin_user'),

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -108,6 +108,7 @@ urlpatterns = [
 
     re_path(r'^manage/organizations/?$', user_management.manage_organization, name='user_management_manage_organization'),
     re_path(r'^manage/organizations/(?P<org_id>\d+)/?$', user_management.manage_single_organization, name='user_management_manage_single_organization'),
+    re_path(r'^manage/organization-users/(?P<org_id>\d+)/csv/?$', user_management.manage_single_organization_list_users_csv, name='user_management_manage_single_organization_list_users_csv'),
     re_path(r'^manage/organization/(?P<org_id>\d+)/delete/?$', user_management.manage_single_organization_delete, name='user_management_manage_single_organization_delete'),
 
     re_path(r'^manage/admin-users/?$', user_management.manage_admin_user, name='user_management_manage_admin_user'),

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -29,7 +29,6 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-from django.utils.text import slugify
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -708,8 +707,7 @@ def manage_single_organization_export_user_list(
         .annotate(organization_name=F('organizations__name'))
         .values('email', 'first_name', 'last_name', 'organization_name')
     )
-    org_slug = slugify(org_users.first()['organization_name']) if org_users else str(org_id)
-    filename_stem = f'perma_{org_slug[:24]}_{timezone.now():%Y%m%d%HT%H%M%S}'
+    filename_stem = f'perma-organization-{org_id}-users'
 
     # Generate output records from query results and add organization name
     field_names = ['email', 'first_name', 'last_name', 'organization_name']

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -712,7 +712,7 @@ def manage_single_organization_export_user_list(
     field_names = ['email', 'first_name', 'last_name']
     make_record = functools.partial(model_to_dict, fields=field_names)
     records = map(make_record, org_users)
-    records = map(lambda rec: {**rec, 'organization': organization.name}, records)
+    records = map(lambda rec: {**rec, 'organization_name': organization.name}, records)
 
     # Export records as appropriate based on `format` URL parameter
     match request.GET.get('format', 'csv').casefold():
@@ -721,7 +721,7 @@ def manage_single_organization_export_user_list(
                 content_type='text/csv',
                 headers={'Content-Disposition': f'attachment; filename="{filename_stem}.csv"'},
             )
-            writer = csv.DictWriter(response, fieldnames=field_names + ['organization'])
+            writer = csv.DictWriter(response, fieldnames=field_names + ['organization_name'])
             writer.writeheader()
             for record in records:
                 writer.writerow(record)

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -706,7 +706,7 @@ def manage_single_organization_export_user_list(
     """Return a file listing all users belonging to an organization."""
     organization = Organization.objects.get(pk=org_id)
     org_users = LinkUser.objects.filter(organizations__id=org_id).order_by('email').all().iterator()
-    filename_stem = f'perma_{slugify(organization.name)}_{timezone.now():%Y%m%d%HT%H%M%S}'
+    filename_stem = f'perma_{slugify(organization.name)[:24]}_{timezone.now():%Y%m%d%HT%H%M%S}'
 
     # Generate output records from query results and add organization name
     field_names = ['email', 'first_name', 'last_name']

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1,8 +1,8 @@
 import csv
 from datetime import timedelta
-import functools
 import itertools
 import logging
+from typing import Literal
 
 import celery
 import redis
@@ -22,10 +22,9 @@ from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm, Pas
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
-from django.db.models import Count, Max, Sum
+from django.db.models import Count, F, Max, Sum
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce, Greatest
-from django.forms.models import model_to_dict
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_bytes
@@ -704,29 +703,31 @@ def manage_single_organization_export_user_list(
     request: HttpRequest, org_id: int
 ) -> HttpResponse | JsonResponse:
     """Return a file listing all users belonging to an organization."""
-    organization = Organization.objects.get(pk=org_id)
-    org_users = LinkUser.objects.filter(organizations__id=org_id).order_by('email').all().iterator()
-    filename_stem = f'perma_{slugify(organization.name)[:24]}_{timezone.now():%Y%m%d%HT%H%M%S}'
+    org_users = (
+        LinkUser.objects.filter(organizations__id=org_id)
+        .annotate(organization_name=F('organizations__name'))
+        .values('email', 'first_name', 'last_name', 'organization_name')
+    )
+    org_slug = slugify(org_users.first()['organization_name']) if org_users else str(org_id)
+    filename_stem = f'perma_{org_slug[:24]}_{timezone.now():%Y%m%d%HT%H%M%S}'
 
     # Generate output records from query results and add organization name
-    field_names = ['email', 'first_name', 'last_name']
-    make_record = functools.partial(model_to_dict, fields=field_names)
-    records = map(make_record, org_users)
-    records = map(lambda rec: {**rec, 'organization_name': organization.name}, records)
+    field_names = ['email', 'first_name', 'last_name', 'organization_name']
 
-    # Export records as appropriate based on `format` URL parameter
-    match request.GET.get('format', 'csv').casefold():
-        case 'csv':
+    # Export records in appropriate format based on `format` URL parameter
+    export_format: Literal['csv', 'json'] = request.GET.get('format', 'csv').casefold()
+    match export_format:
+        case 'json':
+            response = JsonResponse(list(org_users), safe=False)
+        case 'csv' | _:
             response = HttpResponse(
                 content_type='text/csv',
                 headers={'Content-Disposition': f'attachment; filename="{filename_stem}.csv"'},
             )
-            writer = csv.DictWriter(response, fieldnames=field_names + ['organization_name'])
+            writer = csv.DictWriter(response, fieldnames=field_names)
             writer.writeheader()
-            for record in records:
-                writer.writerow(record)
-        case 'json':
-            response = JsonResponse(list(records), safe=False)
+            for org_user in org_users:
+                writer.writerow(org_user)
     return response
 
 


### PR DESCRIPTION
This adds a new view, `manage_single_organization_export_user_list`, which allows authorized users (admins, registrar users, organization users) to export an organization's user list as a CSV. File and column naming conventions are patterned after Perma's existing "export links to CSV" feature wherever possible. (This view also includes undocumented support for JSON output, which can be helpful for validating/troubleshooting in the browser.)

Try out the new behavior as follows:

1. Run Perma locally from this branch
2. Log in as an admin, registrar user, or organization user
3. Navigate to `/manage/organizations` and click either of the new download buttons pointing to the export endpoint (`/manage/organization-users/2/export?format=csv`):
   ![image](https://github.com/harvard-lil/perma/assets/37311998/cee95d04-7db4-4ab9-8360-bb613cb7eb7d)
4. Open the downloaded CSV to view the list of organization users:
   ![image](https://github.com/harvard-lil/perma/assets/37311998/0dbb7d0f-4f4e-489c-8303-483464dcf872)

A test is also included; run it like so:
```sh
d pytest -k "test_org_export_user_list"
```

To discuss with Perma team: Which of the buttons should we keep, and what additional styling is needed?