### PR TITLE
Add upload form

### DIFF
--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -1,10 +1,17 @@
 <script setup>
 import { ref, watch } from 'vue'
 import { globalStore } from '../stores/globalStore';
+import UploadForm from './UploadForm.vue';
+import { showDevPlayground } from '../lib/consts'
 
 const showUploadLink = ref()
 const showGeneric = ref()
 const showLoginLink = ref()
+
+const uploadDialogRef = ref('')
+const handleOpen = () => {
+    uploadDialogRef.value.handleOpen()
+}
 
 watch(
     () => globalStore.captureErrorMessage,
@@ -33,6 +40,11 @@ watch(
         }
     }
 );
+
+defineExpose({
+    handleOpen
+});
+
 </script>
 
 <template>
@@ -42,9 +54,21 @@ watch(
                     Please <a href='/login'>log in</a> to continue.
                 </span></p>
             <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
-            <p v-if="showUploadLink">You can <button id="upload-form-button">upload your own archive</button> or <a
-                    href="/contact">contact us
-                    about this error.</a></p>
+            <template v-if="showUploadLink">
+                <template v-if="showDevPlayground">
+                    <p>You can <button @click.prevent="uploadDialogOpen">upload your own
+                            archive</button> or <a href="{{contact_url}}">contact
+                            us about this error.</a></p>
+                    <!-- TODO: Connect upload form to capture processes -->
+                    <!-- <UploadForm ref="uploadDialogRef" /> -->
+                </template>
+                <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
+                        href="/contact">contact us
+                        about this error.</a></p>
+            </template>
+
         </div>
     </div>
+    <!-- Testing only -->
+    <UploadForm v-if="showDevPlayground" ref="uploadDialogRef" />
 </template>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -10,18 +10,17 @@ import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
 import CreateLinkBatch from './CreateLinkBatch.vue';
 import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse, folderError, defaultError } from "../lib/errors"
-import UploadForm from './UploadForm.vue';
-
 import { showDevPlayground } from '../lib/consts'
-
-const uploadDialogRef = ref('')
-const uploadDialogOpen = () => {
-    uploadDialogRef.value.handleOpen()
-}
 
 const batchDialogRef = ref('')
 const batchDialogOpen = () => {
     batchDialogRef.value.handleOpen();
+}
+
+/* Temporary for testing */
+const uploadDialogRef = ref('')
+const uploadDialogOpen = () => {
+    uploadDialogRef.value.handleOpen()
 }
 
 const userLink = ref('')
@@ -230,15 +229,10 @@ onBeforeUnmount(() => {
         </div><!-- cont-full-bleed cont-sm-fixed -->
     </div><!-- container cont-full-bleed -->
 
-    <CaptureError />
+    <CaptureError ref="uploadDialogRef" />
 
     <template v-if="showDevPlayground">
-        <p class="message">We’re unable to create your Perma Link.</p>
-        <p>You can <button @click.prevent="uploadDialogOpen">upload your own
-                archive</button> or <a href="{{contact_url}}">contact
-                us about this error.</a></p>
-
-        <UploadForm ref="uploadDialogRef" />
+        <button @click.prevent="uploadDialogOpen">Toggle Upload Dialog</button>
     </template>
 
     <CreateLinkBatch ref="batchDialogRef" />

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -11,10 +11,15 @@ import { useStorage } from '@vueuse/core'
 import CreateLinkBatch from './CreateLinkBatch.vue';
 import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse, folderError, defaultError } from "../lib/errors"
 import UploadForm from './UploadForm.vue';
+
 import { showDevPlayground } from '../lib/consts'
 
-const batchDialogRef = ref('')
+const uploadDialogRef = ref('')
+const uploadDialogOpen = () => {
+    uploadDialogRef.value.handleOpen()
+}
 
+const batchDialogRef = ref('')
 const batchDialogOpen = () => {
     batchDialogRef.value.handleOpen();
 }
@@ -227,7 +232,14 @@ onBeforeUnmount(() => {
 
     <CaptureError />
 
-    <UploadForm v-if="showDevPlayground" />
+    <template v-if="showDevPlayground">
+        <p class="message">We’re unable to create your Perma Link.</p>
+        <p>You can <button @click.prevent="uploadDialogOpen">upload your own
+                archive</button> or <a href="{{contact_url}}">contact
+                us about this error.</a></p>
+
+        <UploadForm ref="uploadDialogRef" />
+    </template>
 
     <CreateLinkBatch ref="batchDialogRef" />
 </template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import TextInput from './TextInput.vue';
 import FileInput from './FileInput.vue';
 import Dialog from './Dialog.vue';
@@ -19,7 +19,7 @@ const fieldsWithGUID = {
     file: defaultFields.file
 }
 
-const initialData = props.guid ? fieldsWithGUID : defaultFields
+const initialData = computed(() => props.guid ? fieldsWithGUID : defaultFields)
 
 const formData = ref(initialData)
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -8,14 +8,20 @@ const props = defineProps({
     guid: String,
 })
 
-const defaultFormData = {
+const defaultFields = {
     title: { name: "New Perma Link title", type: "text", description: "The page title associated", placeholder: "Example Page Title", value: '' },
     description: { name: "New Perma Link description", type: "text", description: "The page description associated with this upload", placeholder: "Example description", value: '' },
     url: { name: 'New Perma Link URL', type: "text", description: "The URL associated with this upload", placeholder: "www.example.com", value: '' },
     file: { name: "Choose a file", type: "file", description: ".gif, .jpg, .pdf, and .png allowed, up to 100 MB", value: '' },
 }
 
-const formData = ref(defaultFormData)
+const fieldsWithGUID = {
+    file: defaultFields.file
+}
+
+const initialData = props.guid ? fieldsWithGUID : defaultFields
+
+const formData = ref(initialData)
 
 // Match backend format for errors, for example {file:"message",url:"message"},
 const errors = ref({})
@@ -43,9 +49,8 @@ const handleClose = () => {
     formDialogRef.value.handleDialogClose();
 }
 
-
 const handleReset = () => {
-    formData.value = defaultFormData;
+    formData.value = initialData;
 }
 
 const handleClick = (e) => {
@@ -68,11 +73,12 @@ defineExpose({
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only" id="loading">Close</span>
                 </button>
-                <h3 id="batch-modal-title" class="modal-title">Upload a file to Perma.cc</h3>
+                <h3 id="batch-modal-title" class="modal-title">
+                    Upload a file to Perma.cc
+                </h3>
             </div>
             <p class="modal-description">
-                <!-- This will update the Perma Link you have created. -->
-                This will create a new Perma Link.
+                {{ props.guid ? "This will update the Perma Link you have created." : "Upload a file to Perma.cc" }}
             </p>
             <div class="modal-body">
                 <form id="archive_upload_form" @submit.prevent>
@@ -84,8 +90,8 @@ defineExpose({
                             :id="key" />
                     </template>
                     <div class="form-buttons">
-                        <button type="submit" class="btn btn-primary btn-large">Create a Perma
-                            Link</button>
+                        <button type="submit" class="btn btn-primary btn-large">{{ props.guid ? "Upload" :
+        "Create a Perma Link" }}</button>
                         <button type="button" @click.prevent="handleClose" class="btn cancel">Cancel</button>
                     </div>
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -19,7 +19,7 @@ const fieldsWithGUID = {
     file: defaultFields.file
 }
 
-const initialData = computed(() => props.guid ? fieldsWithGUID : defaultFields)
+const initialData = props.guid ? fieldsWithGUID : defaultFields
 
 const formData = ref(initialData)
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -2,12 +2,20 @@
 import { ref } from 'vue'
 import TextInput from './TextInput.vue';
 import FileInput from './FileInput.vue';
+import Dialog from './Dialog.vue';
 
-const formData = ref({
-    // Data is for debugging only right now
-    url: { name: 'New Perma Link URL', type: "text", description: "The URL associated with this upload", placeholder: "Page URL", value: '' },
-    file: { name: "Choose a file", type: "file", description: ".gif, .jpg, .pdf, and .png allowed, up to 100 MB", value: '' },
+const props = defineProps({
+    guid: String,
 })
+
+const defaultFormData = {
+    title: { name: "New Perma Link title", type: "text", description: "The page title associated", placeholder: "Example Page Title", value: '' },
+    description: { name: "New Perma Link description", type: "text", description: "The page description associated with this upload", placeholder: "Example description", value: '' },
+    url: { name: 'New Perma Link URL', type: "text", description: "The URL associated with this upload", placeholder: "www.example.com", value: '' },
+    file: { name: "Choose a file", type: "file", description: ".gif, .jpg, .pdf, and .png allowed, up to 100 MB", value: '' },
+}
+
+const formData = ref(defaultFormData)
 
 // Match backend format for errors, for example {file:"message",url:"message"},
 const errors = ref({})
@@ -25,23 +33,66 @@ const handleErrorReset = () => {
     errors.value = {}
 }
 
+const formDialogRef = ref('')
+const handleOpen = () => {
+    formDialogRef.value.handleDialogOpen();
+}
+
+const handleClose = () => {
+    handleReset()
+    formDialogRef.value.handleDialogClose();
+}
+
+
+const handleReset = () => {
+    formData.value = defaultFormData;
+}
+
+const handleClick = (e) => {
+    if (e.target.classList.contains('c-dialog')) {
+        handleClose();
+    }
+}
+
+defineExpose({
+    handleOpen
+});
+
 </script>
 
-
 <template>
-    <div class="modal-content">
-        <div class="modal-body">
-            <form id="archive_upload_form" @submit.prevent>
-                <template v-for="(_, key) in formData" :key="key">
-                    {{ formData[key].value }} <!-- Testing only -->
-                    <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]"
-                        :id="key" />
-                    <FileInput v-if="formData[key].type === 'file'" v-model="formData[key]" :error="errors[key]"
-                        :id="key" />
-                </template>
-                <button @click.prevent="handleErrorToggle">Toggle Error</button>
-                <button @click.prevent="handleErrorReset">Reset Errors</button>
-            </form>
+    <Dialog :handleClick="handleClick" :handleClose="handleClose" ref="formDialogRef">
+        <div class="modal-dialog modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" @click.prevent="handleClose">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only" id="loading">Close</span>
+                </button>
+                <h3 id="batch-modal-title" class="modal-title">Upload a file to Perma.cc</h3>
+            </div>
+            <p class="modal-description">
+                <!-- This will update the Perma Link you have created. -->
+                This will create a new Perma Link.
+            </p>
+            <div class="modal-body">
+                <form id="archive_upload_form" @submit.prevent>
+                    <template v-for="(_, key) in formData" :key="key">
+                        {{ formData[key].value }} <!-- Testing only -->
+                        <TextInput v-if="formData[key].type === 'text'" v-model="formData[key]" :error="errors[key]"
+                            :id="key" />
+                        <FileInput v-if="formData[key].type === 'file'" v-model="formData[key]" :error="errors[key]"
+                            :id="key" />
+                    </template>
+                    <div class="form-buttons">
+                        <button type="submit" class="btn btn-primary btn-large">Create a Perma
+                            Link</button>
+                        <button type="button" @click.prevent="handleClose" class="btn cancel">Cancel</button>
+                    </div>
+
+                    <button @click.prevent="handleErrorToggle">Toggle Error</button>
+                    <button @click.prevent="handleErrorReset">Reset Errors</button>
+                </form>
+            </div>
         </div>
-    </div>
+    </Dialog>
 </template>


### PR DESCRIPTION
## What this does 
Adds a upload form component to allow users to upload their own static archive if a capture process fails. 

## Requirements 
- Render an upload form within a dialog using the existing Dialog wrapper component, as much of the existing HTML as possible, and while refactoring the existing legacy JavaScript.
- The dialog should be triggered with a button: 
![image](https://github.com/harvard-lil/perma/assets/4039311/c69a8af5-87b5-482b-8f28-4bc10caa46f2)
- The length of the form — how many inputs it includes — should conditionally depend on if there is a guid from the most recent, failed capture.
  - If a guid does not exist, display the full form:
![image](https://github.com/harvard-lil/perma/assets/4039311/b56e2b6e-f059-4b58-9754-a9ea9c022b59)
  - If a guid does exist, only show  the following form elements: 
<img width="657" alt="image" src="https://github.com/harvard-lil/perma/assets/4039311/4a198ea8-de08-48d2-99ad-d42cba033fb8">

- A user should be able to fill out the form and click "Upload", but nothing needs to happen after they click the button
  - Form submission handling itself and error handling with be taken care of in separate PRs
 
## How to test
- You need to toggle the "vue-dashboard" django waffle feature flag to view any of the updated Vue UI. 
- To test out this feature, and see some developer-only UI for testing, you will also need to toggle the `developer-playground` feature flag. 
- Both flags can be toggled from the django admin dashboard or by visiting urls following the pattern `https://perma.test:8000/manage/create?dwft_FLAG-NAME=1`

<img width="837" alt="image" src="https://github.com/harvard-lil/perma/assets/4039311/898cddd8-0269-434d-993a-2b103149fd1c">

- Once you've toggled both flags, you should be able to interact with a "Toggle Upload Dialog" button on the page. 
- Clicking the button should surface the upload form, which includes additional testing-only buttons to test out triggering and clearing errors for a couple of the inputs. 
- Hitting escape, hitting return on the either the "x" close or cancel buttons, or clicking outside the dialog element should all close the dialog. 
- To toggle the form state that shows when there is a previous, valid guid associated with a capture for now, you'll need to manually pass a guid to the `UploadForm` component, for example: 
```
 <UploadForm guid="4" v-if="showDevPlayground" ref="uploadDialogRef" />
```

## Additional Notes 
- The dialog containing the upload form should match the styling and functionality of the current batch upload form. 
- No changes in this PR should affect how Perma works in the staging or prod environments, unless someone manually toggles on the dev-playground flag
- As mentioned above, the form is not intended to be fully functional just yet. Once all UI is merged, it should be easier to review form submission handling and error verification. 