### PR TITLE
Unset replaced WACZ when users upload their own.

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -622,6 +622,7 @@ class AuthenticatedLinkDetailView(BaseView):
                 # delete related captures, delete warc (rename), mark capture job as superseded
                 link.delete_related_captures()
                 link.safe_delete_warc()
+                link.safe_delete_wacz()
                 link.mark_capturejob_superseded()
 
                 # write new warc and capture

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1939,6 +1939,17 @@ class Link(DeletableModel):
                 storage.store_file(old_file, new_name)
             storage.delete(old_name)
 
+    def safe_delete_wacz(self):
+        old_name = self.wacz_storage_file()
+        storage = storages[settings.WACZ_STORAGE]
+        if storage.exists(old_name):
+            new_name = old_name.replace('.wacz', f'_replaced_{timezone.now().timestamp()}.wacz')
+            with storage.open(old_name) as old_file:
+                storage.store_file(old_file, new_name)
+            storage.delete(old_name)
+        self.wacz_size = 0
+        self.save(update_fields=['wacz_size'])
+
     def accessible_to(self, user):
         return user.can_edit(self)
 


### PR DESCRIPTION
See ENG-1003

If a Perma user is dissatisfied with the results of a high-fidelity web capture, they are allowed to upload an image file or PDF to play back instead. They have 24 hrs to do so. If they do, we delete the existing Capture objects associated with that Perma Link, rename the original warc so that AAAA-AAAA.warc.gz becomes AAAA-AAAA_replaced_{timezone.now().timestamp()}.warc.gz, and take the uploaded file and bundle it into a WARC, and save that as AAAA-AAAA.warc.gz.

We do not yet have the ability to produce a WACZ from these user uploaded files at the same time; that work is in progress.

This PR takes care of the first part of the process: renaming the original wacz so that AAAA-AAAA.wacz becomes AAAA-AAAA_replaced_{timezone.now().timestamp()}.wacz, just like the warc does, and zeroes out the Link's `wacz_size` field so that playback is directed to the new warc.

With this in place, we will be able to start saving WARCs and WACZs side-by-side, without breaking the upload-your-own feature.