### PR TITLE
Let admins request WARC playback.

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -215,6 +215,7 @@
       <div class="tray-actions col-xs-12">
         {% if request.user.is_staff %}
           <a href="?embed=False" class="btn btn-ui-small btn-dashboard">Show playback controls</a>
+          <a href="?embed=False&playback=warc" class="btn btn-ui-small btn-dashboard">Force WARC playback</a>
         {% endif %}
         {% if link.can_play_back %}
           <a href="{% url 'single_permalink' guid=link.guid %}?type=warc_download" role="button" class="btn btn-ui-small btn-dashboard" title="download">Download Archive</a>

--- a/perma_web/perma/views/common.py
+++ b/perma_web/perma/views/common.py
@@ -161,7 +161,8 @@ def single_permalink(request, guid):
         'protocol': protocol(),
     }
 
-    if flag_is_active(request, 'wacz-playback') and link.has_wacz_version():
+    playback_type = request.GET.get('playback')
+    if flag_is_active(request, 'wacz-playback') and link.has_wacz_version() and not playback_type == 'warc':
         context["playback_url"] = link.wacz_presigned_url_relative()
     else:
         context["playback_url"] = link.warc_presigned_url_relative()


### PR DESCRIPTION
See ENG-1006.

We plan to start storing WARCs and WACZs side-by-side, and to start opting in to WACZ playback when one is available.

This PR adds a button to the tray, only visible to admins, that lets you opt in to a WARC playback even when a WACZ is present. Our hope is that, one day, this will be a feature of the playback software, but in the meantime, this gives developers a quick way to look for differences in the two playbacks, helping us debug potential (CD)indexing issues.

![image](https://github.com/user-attachments/assets/792de970-284e-4485-a58c-86adae6fd78f)
