### PR TITLE
Prevent race conditions, when moving links.

### DIFF
--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from datetime import timedelta
 from django.core.files.uploadedfile import SimpleUploadedFile
 from mock import patch
+from conftest import _fix_json_fixtures
 
 
 class LinkAuthorizationMixin():
@@ -17,6 +18,12 @@ class LinkAuthorizationMixin():
                 'fixtures/folders.json',
                 'fixtures/api_keys.json',
                 'fixtures/archive.json']
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _fix_json_fixtures()
+
 
     def setUp(self):
         super(LinkAuthorizationMixin, self).setUp()
@@ -281,6 +288,7 @@ class LinkAuthorizationTestCase(LinkAuthorizationMixin, ApiResourceTestCase):
 class LinkAuthorizationTransactionTestCase(LinkAuthorizationMixin, ApiResourceTransactionTestCase):
 
     def setUp(self):
+        _fix_json_fixtures()
         super(LinkAuthorizationTransactionTestCase, self).setUp()
         self.post_data = {'url': self.server_url + "/test.html",
                           'title': 'This is a test page'}

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -16,6 +16,7 @@ import pytest
 
 from .utils import ApiResourceTestCase, ApiResourceTransactionTestCase, TEST_ASSETS_DIR, index_warc_file, raise_on_call, raise_after_call, return_on_call, MockResponse
 from perma.models import Link, LinkUser, Folder
+from conftest import _fix_json_fixtures
 
 
 class LinkResourceTestMixin():
@@ -31,6 +32,11 @@ class LinkResourceTestMixin():
     @pytest.fixture(autouse=True)
     def _pass_fixtures(self, capsys):
         self.capsys = capsys
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _fix_json_fixtures()
 
     def setUp(self):
         super(LinkResourceTestMixin, self).setUp()
@@ -351,6 +357,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
     ]
 
     def setUp(self):
+        _fix_json_fixtures()
         super(LinkResourceTransactionTestCase, self).setUp()
         self.post_data = {
             'url': self.server_url + "/test.html",

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -76,14 +76,7 @@ def live_server_ssl_cert(set_up_certs):
     }
 
 
-def _load_json_fixtures():
-    call_command('loaddata', *[
-        'fixtures/users.json',
-        'fixtures/api_keys.json',
-        'fixtures/folders.json',
-        'fixtures/archive.json'
-    ])
-
+def _fix_json_fixtures():
     # make sure cached_path is accurate, for Folders made from old fixtures
     Folder.objects.update(
         cached_path=Folder.objects.with_tree_fields().filter(
@@ -110,6 +103,16 @@ def _load_json_fixtures():
             )
         )
     )
+
+def _load_json_fixtures():
+    call_command('loaddata', *[
+        'fixtures/users.json',
+        'fixtures/api_keys.json',
+        'fixtures/folders.json',
+        'fixtures/archive.json'
+    ])
+    _fix_json_fixtures()
+
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
See ENG-901.

Currently, a person can move a link from one folder to another... while the source or destination folder is itself being moved.

That has, over the lifetime of the Perma app, resulted in about 12K Perma Links with some incorrect denormalized metadata: while a link's ownership is properly determined by the ownership of its folder, for convenience, we cache that information on the link itself, in the `organization` field.

This PR locks the source and destination folder trees before moving a link, to prevent that from happening going forward. (We'll clean up the 12K messed up links separately.)

It looks weird because, although according to our business logic, and as displayed in the UI, a Perma Link can only be in one folder at a time... at the database level, it is actually set up as a many-to-many relationship: according to the code, links can be in many folders. So, that's why we iterate over `self.folders.all()` and the destination folder, instead of more obviously just the source and the destination folders.

Adding this code uncovered a complexity of our test suite. The `test_link_authorization` and `test_link_resource` modules configure test fixtures right there, in the class... and as a result, they do not get the "fixit" code for JSON fixtures I added to `conftest.py`. So, I abstracted it out to a helper function, and arranged for it to be run every time these fixtures are loaded in these modules: once at the beginning of the class setup for the "regular" `TestCase` class (since with `TestCase`, fixtures are loaded once, and each test runs in a transaction, and the transaction is reverted after the test), and before every test for the `TransactionTestCase` tests (since there, the tables are truncated between every test and the fixtures re-loaded).

What a mess 🙄 🤣.

I look forward to making a case that we fit in a refactoring of the link->folder relationship to one-to-many, and fit in continued modernization of our test suite, soon. 