### PR TITLE
Include link's folder placement in link creation transaction.

### DIFF
--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -504,11 +504,11 @@ class AuthenticatedLinkListView(BaseView):
 
                 link = serializer.save(created_by=request.user, bonus_link=bonus_link)
 
-            # put link in folder and handle Org settings based on folder
-            if folder.organization and folder.organization.default_to_private:
-                link.is_private = True
-                link.save()
-            link.move_to_folder_for_user(folder, request.user)  # also sets link.organization
+                # put link in folder and handle Org settings based on folder
+                if folder.organization and folder.organization.default_to_private:
+                    link.is_private = True
+                    link.save()
+                link.move_to_folder_for_user(folder, request.user)  # also sets link.organization
 
             # handle uploaded file
             uploaded_file = request.data.get('file')


### PR DESCRIPTION
I think this makes sense, logically: putting a new Perma Link into a folder _should_ be included in the "keep these together" db moves that create a new link.

But the reason I'm making this PR is, we found that locally, if you spam the API and POST a lot of simultaneous requests to make new Perma Links, after https://github.com/harvard-lil/perma/pull/3563 was merged, the database can get tangled up on [this line](https://github.com/harvard-lil/perma/blob/003cf3114517fb6aa25b0443b60077473feb6611/perma_web/perma/models.py#L1809), updating the user's bonus link count, for reasons I don't fully understand.

Some kind of three-process contention happens:
```
DETAIL:  Process 64 waits for ShareLock on transaction 269937; blocked by process 68.
Process 68 waits for ShareLock on transaction 269938; blocked by process 65.
Process 65 waits for ExclusiveLock on tuple (3624,4) of relation 17066 of database 16384; blocked by process 64.
```

That last line is the `select for update` [here in the POST view](https://github.com/harvard-lil/perma/blob/003cf3114517fb6aa25b0443b60077473feb6611/perma_web/api/views.py#L492). I am not sure how to figure out what the ShareLocks are. But... the situation is definitely only triggered by trying to update `user.bonus_links` inside `move_to_folder_for_user`.

I believe this change takes care of it. 

If it does _not_, then I think we should refactor this code to only update a user's bonus link count field when 100% necessary... which is extremely rare.