### PR TITLE
Add ability to export sponsored user list as CSV

### DIFF
--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -85,7 +85,9 @@
       <div id="results" class="sort-filter-count"><strong>Found:</strong> {{ users.paginator.count }} user{{ users.paginator.count|pluralize }}</div>
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>
+        {% if group_name == 'sponsored_user' %}
         <div class="dropdown"><button class="btn-transparent"><a href="{% url 'user_management_manage_sponsored_user_export_user_list' %}?{% current_query_string format='csv' %}" id="export-sponsored-user-csv" class="icon-download-alt" title="Export CSV"></a></button></div>
+        {% endif %}
         <div class="dropdown">
           <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Sort <span class="caret"></span></button>
           <ul class="dropdown-menu">

--- a/perma_web/perma/templates/user_management/manage_users.html
+++ b/perma_web/perma/templates/user_management/manage_users.html
@@ -85,6 +85,7 @@
       <div id="results" class="sort-filter-count"><strong>Found:</strong> {{ users.paginator.count }} user{{ users.paginator.count|pluralize }}</div>
       <div class="sort-filter-bar">
         <strong>Filter &amp; Sort:</strong>
+        <div class="dropdown"><button class="btn-transparent"><a href="{% url 'user_management_manage_sponsored_user_export_user_list' %}?{% current_query_string format='csv' %}" id="export-sponsored-user-csv" class="icon-download-alt" title="Export CSV"></a></button></div>
         <div class="dropdown">
           <button class="btn-transparent" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">Sort <span class="caret"></span></button>
           <ul class="dropdown-menu">

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -48,6 +48,7 @@ class PermissionsTestCase(PermaTestCase):
                     ['user_management_registrar_user_add_user'],
                     ['user_management_manage_single_registrar', {'kwargs':{'registrar_id': 1}}],
                     ['user_management_manage_sponsored_user'],
+                    ['user_management_manage_sponsored_user_export_user_list'],
                     ['user_management_sponsored_user_add_user'],
                     ['user_management_manage_single_sponsored_user', {'kwargs':{'user_id': 20}}],
                     ['user_management_manage_single_sponsored_user_remove', {'kwargs':{'user_id': 20, 'registrar_id': 1}}],

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -108,7 +108,7 @@ urlpatterns = [
 
     re_path(r'^manage/organizations/?$', user_management.manage_organization, name='user_management_manage_organization'),
     re_path(r'^manage/organizations/(?P<org_id>\d+)/?$', user_management.manage_single_organization, name='user_management_manage_single_organization'),
-    re_path(r'^manage/organization-users/(?P<org_id>\d+)/export/?$', user_management.manage_single_organization_export_user_list, name='user_management_manage_single_organization_export_user_list'),
+    re_path(r'^manage/organizations/(?P<org_id>\d+)/export/?$', user_management.manage_single_organization_export_user_list, name='user_management_manage_single_organization_export_user_list'),
     re_path(r'^manage/organization/(?P<org_id>\d+)/delete/?$', user_management.manage_single_organization_delete, name='user_management_manage_single_organization_delete'),
 
     re_path(r'^manage/admin-users/?$', user_management.manage_admin_user, name='user_management_manage_admin_user'),

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -138,6 +138,7 @@ urlpatterns = [
     re_path(r'^manage/organization-users/(?P<user_id>\d+)/remove/?$', user_management.manage_single_organization_user_remove, name='user_management_manage_single_organization_user_remove'),
 
     re_path(r'^manage/sponsored-users/?$', user_management.manage_sponsored_user, name='user_management_manage_sponsored_user'),
+    re_path(r'^manage/sponsored-users/export/?$', user_management.manage_sponsored_user_export_user_list, name='user_management_manage_sponsored_user_export_user_list'),
     re_path(r'^manage/sponsored-users/add-user/?$', AddSponsoredUserToRegistrar.as_view(), name='user_management_sponsored_user_add_user'),
     re_path(r'^manage/sponsored-users/(?P<user_id>\d+)/?$', user_management.manage_single_sponsored_user, name='user_management_manage_single_sponsored_user'),
     re_path(r'^manage/sponsored-users/(?P<user_id>\d+)/delete/?$', user_management.manage_single_sponsored_user_delete, name='user_management_manage_single_sponsored_user_delete'),

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -653,7 +653,7 @@ def manage_sponsored_user(request):
 
 
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
-def manage_sponsored_user_export_user_list(request: HttpRequest):
+def manage_sponsored_user_export_user_list(request: HttpRequest) -> HttpResponse | JsonResponse:
     # Get query results via list_sponsored_users
     field_names = [
         'email',


### PR DESCRIPTION
This adds the ability for Perma admins or registrar users to export a list of sponsored users as a CSV. It includes a new view, `manage_sponsored_user_export_user_list`, that behaves like the "export organization users" endpoint added in https://github.com/harvard-lil/perma/pull/3556.

## Changes made

* Added view function `manage_sponsored_user_export_user_list` for exporting sponsored users to CSV (or JSON)
* Modified the existing `list_sponsored_users` to accept an optional arg `export`; if true, this returns the ORM query results manager directly rather than rendering a view
* Added download button in `/manage/sponsored-users` template

Unrelatedly, I also fixed the URL for the "export org users" view from https://github.com/harvard-lil/perma/pull/3556 to make it consistent with others.

## How to validate

Try the new behavior as follows:

1. Run Perma locally from this branch.
2. Log in as an admin or registrar user.
3. Navigate to `/manage/sponsored-users` and click the download button at right:
   <img width="539" alt="image" src="https://github.com/user-attachments/assets/fc40330d-aeba-4f07-89ce-e39172689ccd">
   Note that any filter/sort options you've set in the UI will persist within the exported file.
4. Open the downloaded CSV to view the list of sponsored users.

## Testing

Run the included test like so:

```sh
d pytest -k "test_sponsored_user_export_user_list"
```