### PR TITLE
Add explicit labels to buttons

### DIFF
--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -129,9 +129,9 @@
       <div class="panel-heading">
         Folders
         <span class="buttons">
-          <a href="#" class="pull-right delete-folder icon-trash" title="Delete Selected Folder"></a>
-          <a href="#" class="pull-right edit-folder icon-edit" title="Rename Selected Folder"></a>
-          <a href="#" class="pull-right new-folder icon-plus" title="New Folder"></a>
+          <a href="#" class="pull-right delete-folder icon-trash" aria-label="Delete Selected Folder" title="Delete Selected Folder"></a>
+          <a href="#" class="pull-right edit-folder icon-edit" aria-label="Rename Selected Folder" title="Rename Selected Folder"></a>
+          <a href="#" class="pull-right new-folder icon-plus" aria-label="New Folder" title="New Folder"></a>
         </span>
       </div>
       <div id="folder-tree"></div>

--- a/perma_web/static/js/hbs/link-list-header.handlebars
+++ b/perma_web/static/js/hbs/link-list-header.handlebars
@@ -3,4 +3,4 @@
 {{else}}
 Your Perma Links
 {{/if}}
-<a href="/api/v1/folders/{{ folder }}/archives/export" id="export-links-csv" class="pull-right icon-download-alt" title="Export Links"></a>
+<a href="/api/v1/folders/{{ folder }}/archives/export" id="export-links-csv" class="pull-right icon-download-alt" aria-label="Export Links" title="Export Links"></a>


### PR DESCRIPTION
See LIL-688.

During my accessibility audit of the Perma dashboard, my screenreader announced the "title" attribute as a label for these buttons. The recent third-party usability testing uncovered that they were missing explicit labels 🎉 . Huzzah.

This PR repeats the current title text as an aria-label. Yes, that risks some users hearing the text twice, but... still better than some users hearing nothing... and better than omitting the attempted tooltip-via-title of the current design, for users with mice.