### PR TITLE
Add refreshLinkList dispatch

### DIFF
--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -196,6 +196,9 @@ const handleBatchFormatting = ((captureJobs) => {
     if (allJobs.completed) {
         clearInterval(progressInterval)
         globalStore.updateBatchCapture('isCompleted')
+
+        const batchCompleted = new CustomEvent("BatchLinkModule.batchCompleted");
+        window.dispatchEvent(batchCompleted);
     }
 
     const totalProgress = allJobs.details.reduce((total, job) => total + job.progress, 0);

--- a/perma_web/static/js/link-batch.module.js
+++ b/perma_web/static/js/link-batch.module.js
@@ -26,6 +26,10 @@ window.addEventListener('BatchLinkModule.batchCreated', function (event) {
     Helpers.triggerOnWindow("BatchLinkModule.batchCreated");
 });
 
+window.addEventListener('BatchLinkModule.batchCompleted', function (event) {
+    $(window).trigger("BatchLinkModule.refreshLinkList");
+});
+
 function render_batch(links_in_batch, folder_path) {
     const steps = 6;
 


### PR DESCRIPTION
## What this fixes
This fixes a small bug within the Perma dashboard. If a user created a batch of multiple captures at once, the captures would be successfully created but the legacy Perma dashboard would not immediately update to display the details of the new links.

This is fixed by creating a dispatch to the legacy application once the batch capture process is confirmed to be complete.

## Linear details 
This fixes Linear issue #ENG-1022.

## How to test 
- Make sure you've toggled the new Vue island within the Perma dashboard. An easy way to identify if you've toggled it is if the submit button for creating a new, single Perma capture is not disabled. If the submit button is disabled, you are looking at the legacy link capture UI, not the updated Vue island. 
  - If you haven't toggled it, the flag can be either toggled with a link: `https://perma.test:8000/manage/create?dwft_vue-dashboard=1` or by changing your user django flags within the django admin. 
- Make a link batch and wait for it to complete. 
- After closing the link batch creation dialog, you should see the main link list region update with the details of your new link(s):
<img width="893" alt="image" src="https://github.com/user-attachments/assets/fe1121d0-0185-40a2-bf9f-a62689d9bf53">
