### PR TITLE
Updated upload form handling

### DIFF
--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -4,6 +4,7 @@ import { globalStore } from '../stores/globalStore';
 import UploadForm from './UploadForm.vue';
 import { showDevPlayground } from '../lib/consts'
 
+
 const showUploadLink = ref()
 const showGeneric = ref()
 const showLoginLink = ref()
@@ -49,26 +50,27 @@ defineExpose({
 
 <template>
     <div class="container cont-fixed">
-        <div v-if="globalStore.captureErrorMessage" id="error-container">
+        <!-- <div v-if="globalStore.captureErrorMessage" id="error-container"> -->
+        <div id="error-container">
             <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
                     Please <a href='/login'>log in</a> to continue.
                 </span></p>
-            <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
-            <template v-if="showUploadLink">
-                <template v-if="showDevPlayground">
-                    <p>You can <button @click.prevent="uploadDialogOpen">upload your own
-                            archive</button> or <a href="{{contact_url}}">contact
-                            us about this error.</a></p>
-                    <!-- TODO: Connect upload form to capture processes -->
-                    <!-- <UploadForm ref="uploadDialogRef" /> -->
-                </template>
-                <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
-                        href="/contact">contact us
-                        about this error.</a></p>
+            <!-- <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p> -->
+            <p class="message">We’re unable to create your Perma Link.</p>
+            <!-- <template> -->
+            <template v-if="showDevPlayground">
+                <p>You can <button @click.prevent="handleOpen">upload your own
+                        archive</button> or <a href="{{contact_url}}">contact
+                        us about this error.</a></p>
+                <UploadForm ref="uploadDialogRef" />
             </template>
+            <!-- <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
+                        href="/contact">contact us
+                        about this error.</a></p> -->
+            <!-- </template> -->
 
         </div>
     </div>
-    <!-- Testing only -->
-    <UploadForm v-if="showDevPlayground" ref="uploadDialogRef" />
+
+    <!-- <UploadForm ref="uploadDialogRef" /> -->
 </template>

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import { globalStore } from '../stores/globalStore';
 import UploadForm from './UploadForm.vue';
 import { showDevPlayground } from '../lib/consts'
-import UpdateGUD from './UpdateGUID.vue'
+import UpdateGUID from './UpdateGUID.vue'
 
 const showUploadLink = ref()
 const showGeneric = ref()

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -56,15 +56,17 @@ defineExpose({
                     Please <a href='/login'>log in</a> to continue.
                 </span></p>
             <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
-            <template v-if="showDevPlayground">
-                <p>You can <button @click.prevent="handleOpen">upload your own
-                        archive</button> or <a href="{{contact_url}}">contact
-                        us about this error.</a></p>
-                <UploadForm ref="uploadDialogRef" />
+            <template v-if="showUploadLink">
+                <template v-if="showDevPlayground">
+                    <p>You can <button @click.prevent="handleOpen">upload your own
+                            archive</button> or <a href="{{contact_url}}">contact
+                            us about this error.</a></p>
+                    <UploadForm ref="uploadDialogRef" />
+                </template>
+                <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
+                        href="/contact">contact us
+                        about this error.</a></p>
             </template>
-            <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
-                    href="/contact">contact us
-                    about this error.</a></p>
         </div>
     </div>
 </template>

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -50,7 +50,7 @@ defineExpose({
 
 <template>
     <div class="container cont-fixed">
-        <UpdateGUD v-if="showDevPlayground" />
+        <UpdateGUID v-if="showDevPlayground" />
         <div v-if="globalStore.captureErrorMessage" id="error-container">
             <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
                     Please <a href='/login'>log in</a> to continue.

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -52,21 +52,19 @@ defineExpose({
     <div class="container cont-fixed">
         <UpdateGUD v-if="showDevPlayground" />
         <div v-if="globalStore.captureErrorMessage" id="error-container">
-            <div id="error-container">
-                <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
-                        Please <a href='/login'>log in</a> to continue.
-                    </span></p>
-                <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
-                <template v-if="showDevPlayground">
-                    <p>You can <button @click.prevent="handleOpen">upload your own
-                            archive</button> or <a href="{{contact_url}}">contact
-                            us about this error.</a></p>
-                    <UploadForm ref="uploadDialogRef" />
-                </template>
-                <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
-                        href="/contact">contact us
-                        about this error.</a></p>
-            </div>
+            <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
+                    Please <a href='/login'>log in</a> to continue.
+                </span></p>
+            <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
+            <template v-if="showDevPlayground">
+                <p>You can <button @click.prevent="handleOpen">upload your own
+                        archive</button> or <a href="{{contact_url}}">contact
+                        us about this error.</a></p>
+                <UploadForm ref="uploadDialogRef" />
+            </template>
+            <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
+                    href="/contact">contact us
+                    about this error.</a></p>
         </div>
     </div>
 </template>

--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import { globalStore } from '../stores/globalStore';
 import UploadForm from './UploadForm.vue';
 import { showDevPlayground } from '../lib/consts'
-
+import UpdateGUD from './UpdateGUID.vue'
 
 const showUploadLink = ref()
 const showGeneric = ref()
@@ -50,27 +50,23 @@ defineExpose({
 
 <template>
     <div class="container cont-fixed">
-        <!-- <div v-if="globalStore.captureErrorMessage" id="error-container"> -->
-        <div id="error-container">
-            <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
-                    Please <a href='/login'>log in</a> to continue.
-                </span></p>
-            <!-- <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p> -->
-            <p class="message">We’re unable to create your Perma Link.</p>
-            <!-- <template> -->
-            <template v-if="showDevPlayground">
-                <p>You can <button @click.prevent="handleOpen">upload your own
-                        archive</button> or <a href="{{contact_url}}">contact
-                        us about this error.</a></p>
-                <UploadForm ref="uploadDialogRef" />
-            </template>
-            <!-- <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
+        <UpdateGUD v-if="showDevPlayground" />
+        <div v-if="globalStore.captureErrorMessage" id="error-container">
+            <div id="error-container">
+                <p class="message-large">{{ globalStore.captureErrorMessage }} <span v-if="showLoginLink">
+                        Please <a href='/login'>log in</a> to continue.
+                    </span></p>
+                <p v-if="showGeneric" class="message">We’re unable to create your Perma Link.</p>
+                <template v-if="showDevPlayground">
+                    <p>You can <button @click.prevent="handleOpen">upload your own
+                            archive</button> or <a href="{{contact_url}}">contact
+                            us about this error.</a></p>
+                    <UploadForm ref="uploadDialogRef" />
+                </template>
+                <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
                         href="/contact">contact us
-                        about this error.</a></p> -->
-            <!-- </template> -->
-
+                        about this error.</a></p>
+            </div>
         </div>
     </div>
-
-    <!-- <UploadForm ref="uploadDialogRef" /> -->
 </template>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -164,8 +164,7 @@ const handleProgressUpdate = async () => {
 }
 
 watch(() => globalStore.captureGUID, () => {
-    /* Testing only */
-    if (globalStore.captureStatus === 'captureError') {
+    if (globalStore.captureErrorMessage === 'testing') {
         return
     }
 

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -150,6 +150,7 @@ const handleProgressUpdate = async () => {
     if (status === 'completed') {
         clearInterval(progressInterval)
         globalStore.updateCapture('success')
+        window.location.href = `${window.location.origin}/${globalStore.captureGUID}`
     }
 
     if (status === 'failed') {
@@ -170,10 +171,6 @@ watch(() => globalStore.captureGUID, () => {
 
     handleProgressUpdate()
     progressInterval = setInterval(handleProgressUpdate, 2000);
-})
-
-watch(() => globalStore.captureStatus === 'success', () => {
-    window.location.href = `${window.location.origin}/${globalStore.captureGUID}`
 })
 
 onBeforeUnmount(() => {

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -185,7 +185,6 @@ onBeforeUnmount(() => {
         <div class="container cont-fixed">
             <h1 class="create-title">Create a new <span class="nobreak">Perma Link</span></h1>
             <p class="create-lede">Enter any URL to preserve it forever.</p>
-            <p>{{ globalStore.captureGUID }}</p>
         </div>
         <div class="container cont-full-bleed cont-sm-fixed">
             <form class="form-priority" :class="{ '_isPrivate': globalStore.selectedFolder.isPrivate }" id="linker">

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -140,7 +140,6 @@ const handleCaptureStatus = async (guid) => {
 }
 
 const handleProgressUpdate = async () => {
-    console.log('handling new update')
     const { step_count, status, error } = await handleCaptureStatus(globalStore.captureGUID);
 
     if (status === 'in_progress') {
@@ -164,7 +163,11 @@ const handleProgressUpdate = async () => {
 }
 
 watch(() => globalStore.captureGUID, () => {
-    console.log('handling update')
+    /* Testing only */
+    if (globalStore.captureStatus === 'captureError') {
+        return
+    }
+
     handleProgressUpdate()
     progressInterval = setInterval(handleProgressUpdate, 2000);
 })

--- a/perma_web/frontend/components/UpdateGUID.vue
+++ b/perma_web/frontend/components/UpdateGUID.vue
@@ -5,16 +5,18 @@ import { globalStore } from '../stores/globalStore'
 const testGUID = ref('');
 
 const updateGUID = () => {
+    triggerError()
     globalStore.updateCaptureGUID(testGUID.value)
 };
 
 const clearGUID = () => {
     globalStore.updateCaptureGUID('');
+    testGUID.value = ''
 };
 
 const triggerError = () => {
     globalStore.updateCapture('captureError')
-    globalStore.updateCaptureErrorMessage("Generic capture error")
+    globalStore.updateCaptureErrorMessage("Dev testing")
 };
 </script>
 

--- a/perma_web/frontend/components/UpdateGUID.vue
+++ b/perma_web/frontend/components/UpdateGUID.vue
@@ -16,7 +16,7 @@ const clearGUID = () => {
 
 const triggerError = () => {
     globalStore.updateCapture('captureError')
-    globalStore.updateCaptureErrorMessage("Dev testing")
+    globalStore.updateCaptureErrorMessage('testing')
 };
 </script>
 

--- a/perma_web/frontend/components/UpdateGUID.vue
+++ b/perma_web/frontend/components/UpdateGUID.vue
@@ -1,0 +1,31 @@
+<script setup>
+import { ref } from 'vue';
+import { globalStore } from '../stores/globalStore'
+
+const testGUID = ref('');
+
+const updateGUID = () => {
+    globalStore.updateCaptureGUID(testGUID.value)
+};
+
+const clearGUID = () => {
+    globalStore.updateCaptureGUID('');
+};
+
+const triggerError = () => {
+    globalStore.updateCapture('captureError')
+    globalStore.updateCaptureErrorMessage("Generic capture error")
+};
+</script>
+
+<template>
+    <div>
+        <p>Current GUID in store: {{ globalStore.captureGUID ? globalStore.captureGUID : "None" }}</p>
+
+        <label for="guid-input">GUID</label>
+        <input id="guid-input" v-model="testGUID" />
+        <button @click="updateGUID">Update GUID</button>
+        <button @click="clearGUID">Clear GUID</button>
+        <button @click="triggerError">Trigger Error</button>
+    </div>
+</template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -76,10 +76,9 @@ const handleUploadRequest = async () => {
     const formDataObj = new FormData();
     formDataObj.append('folder', globalStore.selectedFolder.folderId);
 
-    Object.keys(formData.value).forEach(key => {
-        const { value } = formData.value[key];
+    for (const [key, { value }] of Object.entries(formData.value)) {
         formDataObj.append(key, value);
-    });
+    }
 
     try {
         const response = await fetch(requestUrl,

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -73,14 +73,6 @@ const handleUploadRequest = async () => {
     const archiveBaseUrl = `${rootUrl}/archives/`
     const requestUrl = globalStore.captureGUID ? `${archiveBaseUrl}${globalStore.captureGUID}/` : archiveBaseUrl
 
-    const formValues = Object.keys(formData.value).reduce((acc, current) => {
-        const { value } = formData.value[current]
-        acc[current] = value
-        return acc;
-    }, {
-        folder: globalStore.selectedFolder.folderId,
-    })
-
     const formDataObj = new FormData();
     formDataObj.append('folder', globalStore.selectedFolder.folderId);
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, } from 'vue'
+import { ref, watch } from 'vue'
 import TextInput from './TextInput.vue';
 import FileInput from './FileInput.vue';
 import Dialog from './Dialog.vue';
@@ -21,6 +21,13 @@ const fieldsWithGUID = {
 const initialData = !!globalStore.captureGUID ? fieldsWithGUID : defaultFields
 
 const formData = ref(initialData)
+
+watch(
+    () => globalStore.captureGUID,
+    (newGUID) => {
+        formData.value = newGUID ? fieldsWithGUID : defaultFields;
+    }
+);
 
 // Match backend format for errors, for example {file:"message",url:"message"},
 const errors = ref({})

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -97,11 +97,12 @@ const handleUploadRequest = async () => {
         }
 
         const successResponse = await response.json()
-        console.log(successResponse)
-
-        handleReset()
+        const { guid } = successResponse /* Needed if a guid did not previously exist */
         globalStore.updateCapture('success')
 
+        handleReset()
+
+        window.location.href = `${window.location.origin}/${guid}`
     } catch (error) {
         console.log(error) // TODO: Add actual error handling
     }

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -96,8 +96,7 @@ const handleUploadRequest = async () => {
             throw errorResponse
         }
 
-        const successResponse = await response.json()
-        const { guid } = successResponse /* Needed if a guid did not previously exist */
+        const { guid } = await response.json()
         globalStore.updateCapture('success')
 
         handleReset()

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -96,8 +96,8 @@ const handleUploadRequest = async () => {
             throw errorResponse
         }
 
-        const successReponse = await response.json()
-        console.log(successReponse)
+        const successResponse = await response.json()
+        console.log(successResponse)
 
         handleReset()
         globalStore.updateCapture('success')

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -116,54 +116,6 @@ defineExpose({
 
 </script>
 
-<!-- function successfulUpload (data) {
-    return
-    $uploadModal.modal('hide');
-    window.location.href = '/' + data.guid;
-  }
-  
-  function failedUpload (jqXHR) {
-    // Display an error message in our upload modal
-    // TODO: refactor this when addressing form validation accessibility
-  
-    uploadFormSpinner.stop();
-    $('.js-warning').remove();
-    $('.has-error').removeClass('has-error');
-  
-    // special handling if user becomes unexpectedly logged out
-    if(jqXHR.status == 401){
-      APIModule.showError(jqXHR);
-      return;
-    }
-  
-    let response;
-    let reasons = [];
-    try {
-      response = JSON.parse(jqXHR.responseText);
-    } catch (e) {
-      reasons = [jqXHR.responseText];
-    }
-    if (response) {
-      // If error message comes in as {file:"message",url:"message"},
-      // show appropriate error message next to each field.
-      for (let key in response) {
-        if (response.hasOwnProperty(key)) {
-          let input = $('#' + key);
-          if (input.length) {
-            input.after('<span class="help-block js-warning">' + response[key] + '</span>');
-            input.closest('div').addClass('has-error');
-          } else {
-            reasons.push(response[key]);
-          }
-        }
-      }
-    }
-    $uploadValidationError.html('<p class="field-error">Upload failed. ' + reasons.join(". ") + '</p>');
-    DOMHelpers.toggleBtnDisable('#uploadPermalink', false);
-    DOMHelpers.toggleBtnDisable('.cancel', false);
-  }
-   -->
-
 <template>
     <Dialog :handleClick="handleClick" :handleClose="handleClose" ref="formDialogRef">
         <div class="modal-dialog modal-content">

--- a/perma_web/frontend/lib/consts.js
+++ b/perma_web/frontend/lib/consts.js
@@ -1,3 +1,4 @@
 export const validStates = ["pending", "in_progress", "completed"]
 export const transitionalStates = ['pending', 'in_progress']
 export const showDevPlayground = waffle.FLAGS["developer-playground"]
+export const rootUrl = "/api/v1"

--- a/perma_web/frontend/stores/globalStore.js
+++ b/perma_web/frontend/stores/globalStore.js
@@ -6,6 +6,11 @@ export const globalStore = reactive({
     this.captureStatus = state
   },
 
+  captureGUID: '', 
+  updateCaptureGUID(value) {
+    this.captureGUID = value
+  },
+
   captureErrorMessage: '',
   updateCaptureErrorMessage(message) {
     this.captureErrorMessage = message
@@ -68,5 +73,5 @@ export const globalStore = reactive({
   additionalSubfolder: false,
   updateAdditionalSubfolder(value) {
     this.additionalSubfolder = value
-  }
+  },
 })


### PR DESCRIPTION
## What this does 
Adds form handling to the `UploadForm` component, so that users can either update an existing failed capture with their own static image as an archive of a page, or create a new record entirely (if no GUID ever existed) with an image. 

Satisfies Linear issue ENG-1000.

## Additional notes
- Moves user GUIDs to the global store so that it can more easily be shared within components
- Adds a `watch` function to `UploadForm` so that if a GUID changes the form will update to the appropriate full or abbreviated form fields
- Adds a testing component, `UpdateGUID` so that you can easily test out the upload functionality without a failed previous capture. 
 
## Requirements / Definition of "Done"
Using the provided developer-only testing UI, a reviewer should be able to:
- Create a new perma record that contains the user-provided image
- Update an existing perma record with an image
- The page should redirect to the new or updated Perma record when the upload process is successfully completed

Error handling and loading states will be added in future PRs. For now, testing only needs to happen for use cases where a user fills out all required fields and doesn't upload an image that is too large (over 100mb).

## Screenshots 
GUID testing tools
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/e4a57b5c-ed8a-4250-9096-00cb371f2482">

Developer testing-specific error, which surfaces a button for triggering the upload form
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/8036f771-f029-4e8c-8ce0-8d06c3b43d28">

If no GUID is present in the global store, a user should be shown the full upload form 
<img width="674" alt="image" src="https://github.com/user-attachments/assets/8882bd90-bc5a-4937-9085-c06e755ccc4e">

If a GUID is present, a user should only be shown an abbreviated form
<img width="669" alt="image" src="https://github.com/user-attachments/assets/73d8e273-6fb2-494e-bcfb-c23e6cb72ebb">

Typing in a GUID for a previous capture and hitting the "Update GUID" button should update the store, and allow the abbreviated form to be triggered
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/4b5354c8-7d25-45d2-ba64-d9e464f7e308">

## How to test
- To test this PR, you'll need to locally toggle both the `vue-dashboard` and `developer-playground` waffle flags. 
  - If they haven't been already toggled, you can toggle them in the django admin or by visiting urls with the following format: `https://perma.test:8000/manage/create?dwft_FLAGNAME=1` 
- Click the "trigger error" button to surface the upload button, and trigger the upload dialog
- Try creating a brand-new perma record by filling out the required fields in the upload dialog. The page should redirect once the POST request is complete
- Try updating an existing perma record. You should be able to do this by copying the GUID from an existing perma record in the Perma link list region into the test GUID input. For example, if a perma url is `perma.test:8000/K9C8-DFGW` the guid is K9C8-DFGW