### PR TITLE
Replace isDisabled prop with media feature query

### DIFF
--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -1,25 +1,28 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import * as Spinner from 'spin.js'
+import { usePreferredReducedMotion } from '@vueuse/core'
 
 const props = defineProps({
     top: String,
     length: String,
     color: String,
-    isDisabled: Boolean,
     classList: String,
 })
 
 let spinnerRef = ref(null)
 let spinner = new Spinner({ lines: 15, length: props.length ? parseInt(props.length) : 2, width: 2, radius: 9, corners: 0, color: props.color ? props.color : '#2D76EE', trail: 50, top: props.top ? props.top : '-20px' })
 
+const motionPreferences = usePreferredReducedMotion()
+const showLoader = motionPreferences === 'no-preference'
+
 onMounted(() => {
-    if (!props.isDisabled) {
+    if (showLoader) {
         spinner.spin(spinnerRef.value)
     }
 })
 </script>
 <template>
-    <div v-if="!isDisabled" ref="spinnerRef" :class="!!props.classList && props.classList"></div>
-    <div v-if="isDisabled">Loading</div>
+    <div v-if="showLoader" ref="spinnerRef" :class="!!props.classList && props.classList"></div>
+    <div v-else>Loading</div>
 </template>

--- a/perma_web/frontend/components/Spinner.vue
+++ b/perma_web/frontend/components/Spinner.vue
@@ -14,7 +14,7 @@ let spinnerRef = ref(null)
 let spinner = new Spinner({ lines: 15, length: props.length ? parseInt(props.length) : 2, width: 2, radius: 9, corners: 0, color: props.color ? props.color : '#2D76EE', trail: 50, top: props.top ? props.top : '-20px' })
 
 const motionPreferences = usePreferredReducedMotion()
-const showLoader = motionPreferences === 'no-preference'
+const showLoader = motionPreferences.value === 'no-preference'
 
 onMounted(() => {
     if (showLoader) {


### PR DESCRIPTION
## What this does 
This is a small quality-of-life improvement for the way the `Spinner` component currently functions. I previously added an `isDisabled` prop to the `Spinner` component so that the loading animation it typically displays can be disabled on a case-by-case basis. 

This update takes advantage of the `usePreferredReducedMotion` composable from the vue-use library to disable the `Spinner` based on if a user has toggled an OS-level setting to reduce or disable motion. For me personally, that means I can do work related to user uploads and captures without having to repeatedly manually disable the component. 

## Definition of done 
- The spinner should display "Loading" based on the value of the `prefers-reduced-motion` query. 
- This is not intended to meet the success criteria of [WCAG SC 2.2.2: Pause, Stop, Hide](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html), which could be addressed with a future redesign. 

## Screenshot 
Instead of a loading animation, the component will simply display the word "loading". 
<img width="1728" alt="Screenshot 2024-07-25 at 9 45 31 AM" src="https://github.com/user-attachments/assets/fa9dd73e-ae59-4e3d-8240-090464ab0bb0">

## Linear issue 
Satisfies Linear issue ENG-1001.  

## How to test 
- Before testing locally, you'll need to make sure the `vue-dashboard` flag is toggled to see the Vue island in the Perma dashboard. 
- You will also need to update your motion preferences. In Mac OS, a user can indicate a preference for reduced motion in System Settings, by navigating to System Settings > Accessibility > Display > Reduce motion. Toggle this flag and try to create a single capture — you should see the text "Loading".
  - Note: The labelling of this is specific to Mac OS. On Android, for example, the option is labeled "Remove animations." The [MDN web docs entry on prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences) provides a much more complete, cross-platform list of how to toggle the flag. 
- If you don't see the "Loading" text — and a capture simply immediately succeeds — this is almost certainly due to your local Docker config. I can double-check what you'd need to toggle to see loading states. 