### PR TITLE
Fix Folder.DoesNotExist error in local deployment

### DIFF
--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from datetime import timedelta
 from django.core.files.uploadedfile import SimpleUploadedFile
 from mock import patch
-from conftest import _fix_json_fixtures
 
 
 class LinkAuthorizationMixin():
@@ -22,7 +21,6 @@ class LinkAuthorizationMixin():
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        _fix_json_fixtures()
 
 
     def setUp(self):
@@ -308,7 +306,6 @@ class LinkAuthorizationTestCase(LinkAuthorizationMixin, ApiResourceTestCase):
 class LinkAuthorizationTransactionTestCase(LinkAuthorizationMixin, ApiResourceTransactionTestCase):
 
     def setUp(self):
-        _fix_json_fixtures()
         super(LinkAuthorizationTransactionTestCase, self).setUp()
         self.post_data = {'url': self.server_url + "/test.html",
                           'title': 'This is a test page'}

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -16,7 +16,6 @@ import pytest
 
 from .utils import ApiResourceTestCase, ApiResourceTransactionTestCase, TEST_ASSETS_DIR, index_warc_file, raise_on_call, raise_after_call, return_on_call, MockResponse
 from perma.models import Link, LinkUser, Folder
-from conftest import _fix_json_fixtures
 
 
 class LinkResourceTestMixin():
@@ -36,7 +35,6 @@ class LinkResourceTestMixin():
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        _fix_json_fixtures()
 
     def setUp(self):
         super(LinkResourceTestMixin, self).setUp()
@@ -357,7 +355,6 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
     ]
 
     def setUp(self):
-        _fix_json_fixtures()
         super(LinkResourceTransactionTestCase, self).setUp()
         self.post_data = {
             'url': self.server_url + "/test.html",

--- a/perma_web/fixtures/folders.json
+++ b/perma_web/fixtures/folders.json
@@ -11,7 +11,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "22"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "22",
+      "cached_has_children": false,
+      "tree_root": 22
     }
   },
   {
@@ -26,7 +30,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "23"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "23",
+      "cached_has_children": false,
+      "tree_root": 23
     }
   },
   {
@@ -41,7 +49,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "24"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "24",
+      "cached_has_children": false,
+      "tree_root": 24
     }
   },
   {
@@ -56,7 +68,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "25"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "25",
+      "cached_has_children": true,
+      "tree_root": 25
     }
   },
   {
@@ -71,7 +87,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "26"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "26",
+      "cached_has_children": false,
+      "tree_root": 26
     }
   },
   {
@@ -86,7 +106,11 @@
       "organization": 1,
       "is_shared_folder": true,
       "is_root_folder": false,
-      "cached_path": "27"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "27",
+      "cached_has_children": true,
+      "tree_root": 27
     }
   },
   {
@@ -101,7 +125,11 @@
       "organization": 2,
       "is_shared_folder": true,
       "is_root_folder": false,
-      "cached_path": "28"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "28",
+      "cached_has_children": true,
+      "tree_root": 28
     }
   },
   {
@@ -116,7 +144,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "25-30-29"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "25-29",
+      "cached_has_children": false,
+      "tree_root": 25
     }
   },
   {
@@ -131,7 +163,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "25-29-30"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "25-30",
+      "cached_has_children": false,
+      "tree_root": 25
     }
   },
   {
@@ -146,7 +182,11 @@
       "organization": 3,
       "is_shared_folder": true,
       "is_root_folder": false,
-      "cached_path": "31"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "31",
+      "cached_has_children": true,
+      "tree_root": 31
     }
   },
   {
@@ -161,7 +201,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "32"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "32",
+      "cached_has_children": false,
+      "tree_root": 32
     }
   },
   {
@@ -176,7 +220,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "33"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "33",
+      "cached_has_children": false,
+      "tree_root": 33
     }
   },
   {
@@ -191,7 +239,11 @@
       "organization": 1,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "27-34"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "27-34",
+      "cached_has_children": false,
+      "tree_root": 27
     }
   },
   {
@@ -206,7 +258,11 @@
       "organization": 1,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "27-35"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "27-35",
+      "cached_has_children": false,
+      "tree_root": 27
     }
   },
   {
@@ -221,7 +277,11 @@
       "organization": 2,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "28-36"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "28-36",
+      "cached_has_children": false,
+      "tree_root": 28
     }
   },
   {
@@ -236,7 +296,11 @@
       "organization": 2,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "28-37"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "28-37",
+      "cached_has_children": false,
+      "tree_root": 28
     }
   },
   {
@@ -251,7 +315,11 @@
       "organization": 3,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "31-38"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "31-38",
+      "cached_has_children": false,
+      "tree_root": 31
     }
   },
   {
@@ -266,7 +334,11 @@
       "organization": 3,
       "is_shared_folder": false,
       "is_root_folder": false,
-      "cached_path": "31-39"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "31-39",
+      "cached_has_children": false,
+      "tree_root": 31
     }
   },
   {
@@ -281,7 +353,11 @@
       "organization": 4,
       "is_shared_folder": true,
       "is_root_folder": false,
-      "cached_path": "40"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "40",
+      "cached_has_children": false,
+      "tree_root": 40
     }
   },
   {
@@ -296,7 +372,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "41"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "41",
+      "cached_has_children": false,
+      "tree_root": 41
     }
   },
   {
@@ -311,7 +391,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "42"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "42",
+      "cached_has_children": false,
+      "tree_root": 42
     }
   },
   {
@@ -326,7 +410,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "43"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "43",
+      "cached_has_children": false,
+      "tree_root": 43
     }
   },
   {
@@ -341,7 +429,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "44"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "44",
+      "cached_has_children": false,
+      "tree_root": 44
     }
   },
   {
@@ -356,7 +448,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "45"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "45",
+      "cached_has_children": false,
+      "tree_root": 45
     }
   },
   {
@@ -371,7 +467,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "46"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "46",
+      "cached_has_children": false,
+      "tree_root": 46
     }
   },
   {
@@ -386,7 +486,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "47"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "47",
+      "cached_has_children": false,
+      "tree_root": 47
     }
   },
   {
@@ -401,7 +505,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "48"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "48",
+      "cached_has_children": false,
+      "tree_root": 48
     }
   },
   {
@@ -416,7 +524,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "49"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "49",
+      "cached_has_children": false,
+      "tree_root": 49
     }
   },
   {
@@ -431,7 +543,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "50"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "50",
+      "cached_has_children": false,
+      "tree_root": 50
     }
   },
   {
@@ -446,7 +562,11 @@
       "organization": 5,
       "is_shared_folder": true,
       "is_root_folder": false,
-      "cached_path": "51"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "51",
+      "cached_has_children": false,
+      "tree_root": 51
     }
   },
   {
@@ -461,7 +581,11 @@
       "organization": 6,
       "is_shared_folder": true,
       "is_root_folder": false,
-      "cached_path": "52"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "52",
+      "cached_has_children": false,
+      "tree_root": 52
     }
   },
   {
@@ -476,7 +600,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "53"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "53",
+      "cached_has_children": false,
+      "tree_root": 53
     }
   },
   {
@@ -491,7 +619,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "54"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "54",
+      "cached_has_children": false,
+      "tree_root": 54
     }
   },
   {
@@ -506,7 +638,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "55"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "55",
+      "cached_has_children": false,
+      "tree_root": 55
     }
   },
   {
@@ -521,7 +657,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "56"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "56",
+      "cached_has_children": false,
+      "tree_root": 56
     }
   },
   {
@@ -536,7 +676,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "57"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "57",
+      "cached_has_children": false,
+      "tree_root": 57
     }
   },
   {
@@ -551,7 +695,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "58"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "58",
+      "cached_has_children": false,
+      "tree_root": 58
     }
   },
   {
@@ -567,7 +715,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": true,
-      "cached_path": "59"
+      "read_only": false,
+      "cached_path": "59",
+      "cached_has_children": true,
+      "tree_root": 59
     }
   },
   {
@@ -575,7 +726,7 @@
     "pk": 60,
     "fields": {
       "name": "Test Library",
-      "parent": null,
+      "parent": 59,
       "creation_timestamp": "2017-09-28T19:36:07Z",
       "created_by": 20,
       "owned_by": 20,
@@ -584,8 +735,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": false,
-      "parent": 59,
-      "cached_path": "59-60"
+      "read_only": false,
+      "cached_path": "59-60",
+      "cached_has_children": true,
+      "tree_root": 59
     }
   },
   {
@@ -593,6 +746,7 @@
     "pk": 61,
     "fields": {
       "name": "Sponsored Subfolder",
+      "parent": 60,
       "creation_timestamp": "2017-09-28T19:36:07Z",
       "created_by": 20,
       "owned_by": 20,
@@ -601,8 +755,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": false,
-      "parent": 60,
-      "cached_path": "59-60-61"
+      "read_only": false,
+      "cached_path": "59-60-61",
+      "cached_has_children": true,
+      "tree_root": 59
     }
   },
   {
@@ -618,7 +774,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": true,
-      "cached_path": "62"
+      "read_only": false,
+      "cached_path": "62",
+      "cached_has_children": true,
+      "tree_root": 62
     }
   },
   {
@@ -626,6 +785,7 @@
     "pk": 63,
     "fields": {
       "name": "Test Library",
+      "parent": 62,
       "creation_timestamp": "2017-09-28T19:36:07Z",
       "created_by": 22,
       "owned_by": 22,
@@ -634,9 +794,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": false,
-      "parent": 62,
       "read_only": true,
-      "cached_path": "62-63"
+      "cached_path": "62-63",
+      "cached_has_children": true,
+      "tree_root": 62
     }
   },
   {
@@ -644,6 +805,7 @@
     "pk": 64,
     "fields": {
       "name": "Sponsored Subsubfolder",
+      "parent": 61,
       "creation_timestamp": "2017-09-28T19:36:07Z",
       "created_by": 20,
       "owned_by": 20,
@@ -652,8 +814,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": false,
-      "parent": 61,
-      "cached_path": "59-60-61-64"
+      "read_only": false,
+      "cached_path": "59-60-61-64",
+      "cached_has_children": false,
+      "tree_root": 59
     }
   },
   {
@@ -661,6 +825,7 @@
     "pk": 65,
     "fields": {
       "name": "Inactive Sponsored Subfolder",
+      "parent": 63,
       "creation_timestamp": "2017-09-28T19:36:07Z",
       "created_by": 22,
       "owned_by": 22,
@@ -669,9 +834,10 @@
       "is_shared_folder": false,
       "is_root_folder": false,
       "is_sponsored_root_folder": false,
-      "parent": 63,
       "read_only": true,
-      "cached_path": "62-63-65"
+      "cached_path": "62-63-65",
+      "cached_has_children": false,
+      "tree_root": 62
     }
   },
   {
@@ -686,7 +852,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "66"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "66",
+      "cached_has_children": false,
+      "tree_root": 66
     }
   },
   {
@@ -701,7 +871,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "67"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "67",
+      "cached_has_children": false,
+      "tree_root": 67
     }
   },
   {
@@ -716,7 +890,11 @@
       "organization": null,
       "is_shared_folder": false,
       "is_root_folder": true,
-      "cached_path": "67"
+      "is_sponsored_root_folder": false,
+      "read_only": false,
+      "cached_path": "68",
+      "cached_has_children": false,
+      "tree_root": 68
     }
   }
 ]

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1791,7 +1791,7 @@ class Link(DeletableModel):
             # safely inside its destination folder, lest denormalized
             # ownership-related fields get out of sync
             for folder in itertools.chain(self.folders.all(), [folder]):
-                Folder.objects.select_for_update().get(pk=folder.tree_root_id)
+                Folder.objects.select_for_update().filter(id=folder.tree_root_id).first()
 
             # remove this link from any folders it's in for this user
             self.folders.remove(*self.folders.accessible_to(user))

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1791,7 +1791,7 @@ class Link(DeletableModel):
             # safely inside its destination folder, lest denormalized
             # ownership-related fields get out of sync
             for folder in itertools.chain(self.folders.all(), [folder]):
-                Folder.objects.select_for_update().filter(id=folder.tree_root_id).first()
+                Folder.objects.select_for_update().get(pk=folder.tree_root_id)
 
             # remove this link from any folders it's in for this user
             self.folders.remove(*self.folders.accessible_to(user))


### PR DESCRIPTION
https://github.com/harvard-lil/perma/pull/3563 may have introduced a regression affecting a locally deployed vanilla Perma setup (as far as I can tell, this does not affect prod). After re-deploying Perma from scratch with all Docker images, volumes, and caches cleared, the following error occurs when you submit any URL for capture:

```
  File "/perma/perma_web/api/views.py", line 512, in post
    link.move_to_folder_for_user(folder, request.user)  # also sets link.organization
  File "/perma/perma_web/perma/models.py", line 1794, in move_to_folder_for_user
    Folder.objects.select_for_update().get(pk=folder.tree_root_id)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 637, in get
    raise self.model.DoesNotExist(
perma.models.Folder.DoesNotExist: Folder matching query does not exist.
```

If we change the `get(pk=folder.tree_root_id)` to a `filter(id=folder.tree_root_id).first()`, the query just retrieves 0 rows and then moves on without throwing an exception.

Any concerns with this solution? Or does this suggest a deeper issue?