### PR TITLE
Fix missing step_count property

### DIFF
--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -127,7 +127,7 @@ const handleCaptureStatus = async (guid) => {
         const job = await response.json()
 
         return {
-            step_count: job.step_count ?? 0,
+            step_count: job.step_count ?? 1,
             status: job.status,
             error: job.status === 'failed' ? job.message : ''
         }
@@ -137,7 +137,7 @@ const handleCaptureStatus = async (guid) => {
         console.log(error)
         return {
             step_count: 0,
-            status: 'failed',
+            status: 'indeterminate',
             error
         }
     }

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -127,7 +127,7 @@ const handleCaptureStatus = async (guid) => {
         const job = await response.json()
 
         return {
-            step_count: job.step_count ?? 1,
+            step_count: job.step_count,
             status: job.status,
             error: job.status === 'failed' ? job.message : ''
         }

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -127,7 +127,7 @@ const handleCaptureStatus = async (guid) => {
         const job = await response.json()
 
         return {
-            step_count: job.step_count,
+            step_count: job.step_count ?? 0,
             status: job.status,
             error: job.status === 'failed' ? job.message : ''
         }
@@ -135,7 +135,11 @@ const handleCaptureStatus = async (guid) => {
     } catch (error) {
         // TODO: Implement maxFailedAttempts logic here
         console.log(error)
-        return
+        return {
+            step_count: 0,
+            status: 'failed',
+            error
+        }
     }
 }
 

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -136,7 +136,6 @@ const handleCaptureStatus = async (guid) => {
         // TODO: Implement maxFailedAttempts logic here
         console.log(error)
         return {
-            step_count: 0,
             status: 'indeterminate',
             error
         }
@@ -144,11 +143,12 @@ const handleCaptureStatus = async (guid) => {
 }
 
 const handleProgressUpdate = async () => {
-    const { step_count, status, error } = await handleCaptureStatus(globalStore.captureGUID);
+    const response = await handleCaptureStatus(globalStore.captureGUID);
+    const { status } = response
 
     if (status === 'in_progress') {
         globalStore.updateCapture('isCapturing')
-        userLinkProgressBar.value = `${step_count / 5 * 100}%`
+        userLinkProgressBar.value = `${response.step_count / 5 * 100}%`
     }
 
     if (status === 'completed') {
@@ -158,7 +158,7 @@ const handleProgressUpdate = async () => {
     }
 
     if (status === 'failed') {
-        const errorMessage = error.length ? getErrorFromNestedObject(JSON.parse(error)) : defaultError
+        const errorMessage = response.error.length ? getErrorFromNestedObject(JSON.parse(response.error)) : defaultError
 
         clearInterval(progressInterval)
 


### PR DESCRIPTION
## What this fixes
After a user requests a new capture, there's periodic polling that happens to update the Perma UI with the status of the in-progress capture. This process can fail — for example, due to a 503 bad gateway error. 

We do not currently have error-handling in place for this situation because if one status update request fails due to an issue like connectivity reasons, the web application should currently just wait another interval to attempt another status request. 

However, a small bug that needs to be fixed is that while error handling doesn't need to happen for an error like a 503, we currently do always need to return a `step_count`, even if it's unused — because of the way props are destructured. 

For consistency, this adds fallback values to a successful and failed status request so that there should never be an undefined `step_count`. 

## Sentry reporting
Addresses PERMA-38M

## Linear issue
Satisfies LIL-2250

## How to test 
To test this, I edited `handleCaptureStatus` to intentionally throw an error on every request, and verify that if this function throws any error (no matter how generic) it shouldn't cause an issue for a user.

```
const handleCaptureStatus = async (guid) => {
    try {
        const response = await fetch(`/api/v1/user/capture_jobs/${guid}`)

        if (!response?.ok) {
            throw new Error(response.status)
        }

        // const job = await response.json()

        // return {
        //     step_count: job.step_count ?? 1,
        //     status: job.status,
        //     error: job.status === 'failed' ? job.message : ''
        // }

        throw new Error(response.status)

    } catch (error) {
        console.log(error)
        return {
            step_count: 0,
            status: 'indeterminate',
            error
        }
    }
}
```