### PR TITLE
Fix custom select keyboard navigation issue

### DIFF
--- a/perma_web/frontend/components/FolderCustomSelect.vue
+++ b/perma_web/frontend/components/FolderCustomSelect.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, nextTick } from 'vue'
 import { globalStore } from '../stores/globalStore'
 import { onClickOutside } from '@vueuse/core'
 
@@ -48,6 +48,21 @@ onClickOutside(selectContainerRef, () => {
 
 const handleSelectToggle = () => {
     isSelectExpanded.value = !isSelectExpanded.value
+}
+
+const handleKeyboardSelectToggle = async (e) => {
+    const isButton = e.target.matches('button')
+
+    if (!isButton) {
+        return
+    }
+
+    if (isSelectExpanded.value) {
+        return handleArrowDown(e)
+    }
+
+    handleSelectToggle()
+    await nextTick()
 }
 
 const handleFocus = (index) => {
@@ -106,7 +121,9 @@ const handleSelection = (e) => {
         <div ref="selectContainerRef" @keydown.home.prevent="handleFocus(0)"
             @keydown.end.prevent="handleFocus(props.folders.length)" @keydown.esc="handleClose"
             @keydown.tab="handleClose" class="dropdown dropdown-affil" :class="{ 'open': isSelectExpanded }">
-            <button ref="selectButtonRef" @keydown.down.prevent="handleFocus(0)" @click="handleSelectToggle"
+            <button ref="selectButtonRef" @keydown.down.prevent.self="handleKeyboardSelectToggle"
+                @keydown.enter.prevent.self="handleKeyboardSelectToggle"
+                @keydown.space.prevent="handleKeyboardSelectToggle" @click="handleSelectToggle"
                 class="dropdown-toggle selector selector-affil needsclick" type="button" aria-haspopup="listbox"
                 :aria-expanded="isSelectExpanded" aria-owns="folder-select-list">
                 {{ selectedOption }}


### PR DESCRIPTION
## What this does 
If a user navigates to the custom select and hits the down arrow, a console error is thrown because a DOM node cannot be found and focused. 

This behavior should be fixed, and match the previous behavior of the legacy custom dropdown:

- If a user hits spacebar, clicks, or presses the down arrow key on the menu trigger button, the select options menu should become visible. 
- A user should be able to hit the down arrow to navigate to the first item in the options menu.

## Sentry error 
Addresses PERMA-38P

## Linear issue
Further detailed in LIL-2251

## Screenshot 
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/9ada48f6-1b35-460a-825b-64c2f13cc532">

## How to test
- Make sure you've toggled the feature flag for the vue dashboard: 
```https://perma.test:8000/manage/create?dwft_vue-dashboard=1```
- Use the tab key to navigate to the custom select trigger button.
- Hit spacebar while the custom select is focused: this should trigger the options menu
- Hit the down arrow: this should navigate to the first option in the menu

Optionally:

- You can test if hitting the `end` button and the `home` button navigate to the last and first options in the menu, respectively. (They should focus an option, but not select it)
- Hitting escape should close the options menu and focus the select trigger button again. 
- You can also retest this process using the return key, rather than the spacebar, to trigger the options menu. 