### PR TITLE
Address Dialog warning

### DIFF
--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -226,7 +226,7 @@ onBeforeUnmount(() => {
 });
 
 defineExpose({
-    handleOpen
+    handleOpen, handleClose
 });
 
 </script>
@@ -261,9 +261,9 @@ defineExpose({
                     </div>
                 </div>
 
-                <LinkBatchDetails v-if="showBatchDetails" :handleClose :batchCaptureJobs :batchCaptureSummary
-                    :showBatchCSVUrl="globalStore.batchCaptureStatus === 'isCompleted'" :batchCSVUrl
-                    :targetFolder="globalStore.selectedFolder.path.join(' > ')" />
+                <LinkBatchDetails v-if="showBatchDetails" :handleClose="handleClose" :batchCaptureJobs
+                    :batchCaptureSummary :showBatchCSVUrl="globalStore.batchCaptureStatus === 'isCompleted'"
+                    :batchCSVUrl :targetFolder="globalStore.selectedFolder.path.join(' > ')" />
             </div>
         </div>
     </Dialog>

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -226,7 +226,7 @@ onBeforeUnmount(() => {
 });
 
 defineExpose({
-    handleOpen, handleClose
+    handleOpen
 });
 
 </script>
@@ -261,9 +261,9 @@ defineExpose({
                     </div>
                 </div>
 
-                <LinkBatchDetails v-if="showBatchDetails" :handleClose="handleClose" :batchCaptureJobs
-                    :batchCaptureSummary :showBatchCSVUrl="globalStore.batchCaptureStatus === 'isCompleted'"
-                    :batchCSVUrl :targetFolder="globalStore.selectedFolder.path.join(' > ')" />
+                <LinkBatchDetails v-if="showBatchDetails" :handleClose :batchCaptureJobs :batchCaptureSummary
+                    :showBatchCSVUrl="globalStore.batchCaptureStatus === 'isCompleted'" :batchCSVUrl
+                    :targetFolder="globalStore.selectedFolder.path.join(' > ')" />
             </div>
         </div>
     </Dialog>

--- a/perma_web/frontend/components/Dialog.vue
+++ b/perma_web/frontend/components/Dialog.vue
@@ -25,8 +25,7 @@ defineExpose({
 </script>
 
 <template>
-    <dialog class="c-dialog" ref="dialogRef" @click="props.handleClick" @keydown.esc="props.handleClose"
-        id="batch-modal">
+    <dialog class="c-dialog" ref="dialogRef" @click="props.handleClick" @keydown.esc="props.handleClose">
         <slot></slot>
     </dialog>
 </template>

--- a/perma_web/frontend/components/LinkBatchDetails.vue
+++ b/perma_web/frontend/components/LinkBatchDetails.vue
@@ -15,11 +15,10 @@ const props = defineProps({
 
 <template>
   <div id="batch-details-wrapper">
-    <button @click.prevent="handleTestButton">Another Test Button</button>
     <p id="batch-progress-report">
       {{ props.batchCaptureSummary }}
       <span v-if="!!props.batchCaptureJobs.errors">{{ props.batchCaptureJobs.errors }} {{
-      props.batchCaptureJobs.errors > 1 ? 'errors' : 'error' }}</span>
+        props.batchCaptureJobs.errors > 1 ? 'errors' : 'error' }}</span>
     </p>
     <div id="batch-details" aria-describedby="batch-progress-report">
       <div class="form-group">

--- a/perma_web/frontend/components/LinkBatchDetails.vue
+++ b/perma_web/frontend/components/LinkBatchDetails.vue
@@ -15,10 +15,11 @@ const props = defineProps({
 
 <template>
   <div id="batch-details-wrapper">
+    <button @click.prevent="handleTestButton">Another Test Button</button>
     <p id="batch-progress-report">
       {{ props.batchCaptureSummary }}
       <span v-if="!!props.batchCaptureJobs.errors">{{ props.batchCaptureJobs.errors }} {{
-        props.batchCaptureJobs.errors > 1 ? 'errors' : 'error' }}</span>
+      props.batchCaptureJobs.errors > 1 ? 'errors' : 'error' }}</span>
     </p>
     <div id="batch-details" aria-describedby="batch-progress-report">
       <div class="form-group">
@@ -53,7 +54,7 @@ const props = defineProps({
       </div>
     </div>
     <div class="form-buttons">
-      <button class="btn cancel" @click.prevent="handleClose">Exit</button>
+      <button class="btn cancel" @click.prevent="props.handleClose">Exit</button>
       <a v-if="props.showBatchCSVUrl" :href="props.batchCSVUrl" class="btn">Export list as
         CSV</a>
     </div>


### PR DESCRIPTION
## What this does 
This makes a couple of small changes to the `Dialog` component. 

- The most relevant change is fixing the name of the function called by the `LinkBatchDetails` component. This is detailed more in-depth below.

- This PR also removes an unnecessary id. In the legacy Perma application, an event listener is used to toggle the appearance of the previous modal using the id. This isn't, and shouldn't, be at all necessary to add to our native dialog element. 

## Relevant Sentry Error
An unhandled error was logged by Sentry, where a user clicked a button in the batch dialog and it threw the following console error: 

```
dialogRef.value.close is not a function. (In 'dialogRef.value.close()', 'dialogRef.value.close' is undefined)
```

## Debugging 
To start debugging this, I updated the `handleDialogClose` function within the `Dialog` component to log the value of `dialogRef.value.close`:

```
const handleDialogClose = () => {
    console.log(dialogRef.value.close)
    dialogRef.value.close()
}
```

I expected to see `ƒ close() { [native code] }` logged whenever the dialog closes, because `close` is a built-in, native function provided by all `dialog` elements. When activating any of the many ways to close a dialog, I was able to successfully log this. So this didn't appear to be the issue.

One obvious issue I think involves the `LinkBatchDetails` component. There is an "Exit" button in `LinkBatchDetails` that was attempting to call `handleClose` instead of `props.handleClose`. `handleClose` itself is an undefined method, which likely triggered the sentry warning.

I was able to verify that `handleClose` was undefined if I console logged its value, but the slightly confusing thing is 
that I still couldn't duplicate that console error locally by clicking that button: without properly defining `props.handleClose` as the function that a close button should call, the correct event still executed, and I didn't see the console error. 

But there is an explanation for this.

If a particular function does not exist in the scope of a child component, Vue's event handling can search and execute the function if it exists in the scope of the parent component. However, because the function still isn't defined locally within the correct component scope, Vue can warn about the method being undefined — even if the event itself is still successfully executed.  

## Screenshots

Clicking "create multiple links" should render a dialog element. 
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/212a6032-fd10-454f-98c8-25914dd83fe6">

After submitting a form to create one or more captures, the dialog should show an "Exit" button at the bottom of the dialog.
<img width="648" alt="image" src="https://github.com/user-attachments/assets/04fa7693-cb8b-49f8-9209-11f7309ee02b">

## How to test 
There are several ways to close the native dialog element used to allow users to create batch captures: 

- Hitting escape while the dialog is open
- Clicking or hitting return on the "Cancel" button, which displays before a batch capture process has started
- Clicking or hitting return on the "Exit" button, which displays after a batch capture process has ended
- Clicking or hitting return on the "x" button in the righthand corner of the batch dialog

The console error Sentry logged was caused specifically when a user clicked a close button at the bottom of the dialog that is rendered for batch captures, after a capture was successfully requested.

