### PR TITLE
Update Docker Compose references to V2

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -350,7 +350,7 @@ __NB__: If you make changes to static files, like css, while running with DEBUG=
 
 Aspects of Perma's paid subscription service are handled by the companion application, [Perma Payments](https://github.com/harvard-lil/perma-payments).
 
-By default, Perma's `docker-compose` file will spin up a local Perma Payments for you to experiment with. For more fruitful experimentation, configure this Perma Payments to interact with Cybersource's test tier, by running Payments with a custom settings.py that contains our credentials. See `docker-compose.yml` and `/services/docker/perma-payments/settings.py.example` for more information. CyberSource will not be able to communicate its responses back to your local instance, of course, but you can simulate active subscriptions using the Django admin.
+By default, Perma's `docker-compose.yml` file will spin up a local Perma Payments for you to experiment with. For more fruitful experimentation, configure this Perma Payments to interact with Cybersource's test tier, by running Payments with a custom settings.py that contains our credentials. See `docker-compose.yml` and `/services/docker/perma-payments/settings.py.example` for more information. CyberSource will not be able to communicate its responses back to your local instance, of course, but you can simulate active subscriptions using the Django admin.
 
 ### Test Perma Interaction with Perma Payments
 
@@ -381,7 +381,7 @@ It just means that Perma Payments is still running: the network is maintained un
 
 Perma's web archives are produced using [Scoop](https://github.com/harvard-lil/scoop): Perma capture requests call out to the [Scoop API](https://github.com/harvard-lil/perma-scoop-api/), which capture the requested website and return a WARC/WACZ to Perma.
 
-By default, Perma's `docker-compose` file will spin up a local Scoop API for you to experiment with.
+By default, Perma's `docker-compose.yml` file will spin up a local Scoop API for you to experiment with.
 
 ### Working with both repositories simultaneously
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -106,7 +106,7 @@ services:
     # copy ./services/docker/perma-payments/settings.py.example
     # to ./services/docker/perma-payments/settings.py,
     # alter config as desired, in the usual way, then comment in this volume
-    # and re-run docker-compose up
+    # and re-run docker compose up
     # volumes:
     #   - ./services/docker/perma-payments/settings.py:/app/web/config/settings/settings.py
     networks:

--- a/ingest.sh
+++ b/ingest.sh
@@ -43,6 +43,6 @@ if [[ $((OPTIND - $#)) -ne 1 ]]; then
 fi
 
 echo "Loading data from $FILE ..."
-docker cp "$FILE" "$(docker-compose ps -q db)":/tmp/data.dump
-docker-compose exec db pg_restore --username=perma --verbose --no-owner -h localhost -d perma /tmp/data.dump
-docker-compose exec db rm -f /tmp/data.dump
+docker cp "$FILE" "$(docker compose ps -q db)":/tmp/data.dump
+docker compose exec db pg_restore --username=perma --verbose --no-owner -h localhost -d perma /tmp/data.dump
+docker compose exec db rm -f /tmp/data.dump

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Perma database
-docker-compose exec web invoke dev.init-db
+docker compose exec web invoke dev.init-db
 
 # Perma SSL cert
 bash make_cert.sh


### PR DESCRIPTION
Per [Docker docs](https://docs.docker.com/compose/migrate/), `docker-compose` has been deprecated since July 2023 in favor of `docker compose`. This PR updates `docker-compose` references throughout the Perma codebase, most notably in the init shell script.