### PR TITLE
Add upload error handling

### DIFF
--- a/perma_web/frontend/components/CaptureError.vue
+++ b/perma_web/frontend/components/CaptureError.vue
@@ -49,6 +49,7 @@ defineExpose({
 </script>
 
 <template>
+
     <div class="container cont-fixed">
         <UpdateGUID v-if="showDevPlayground" />
         <div v-if="globalStore.captureErrorMessage" id="error-container">
@@ -61,7 +62,6 @@ defineExpose({
                     <p>You can <button @click.prevent="handleOpen">upload your own
                             archive</button> or <a href="{{contact_url}}">contact
                             us about this error.</a></p>
-                    <UploadForm ref="uploadDialogRef" />
                 </template>
                 <p v-else>You can <button id="upload-form-button">upload your own archive</button> or <a
                         href="/contact">contact us
@@ -69,4 +69,8 @@ defineExpose({
             </template>
         </div>
     </div>
+
+    <template v-if="showDevPlayground && globalStore.captureErrorMessage">
+        <UploadForm ref="uploadDialogRef" />
+    </template>
 </template>

--- a/perma_web/frontend/components/CreateLink.vue
+++ b/perma_web/frontend/components/CreateLink.vue
@@ -9,7 +9,7 @@ import LinkCount from './LinkCount.vue';
 import FolderSelect from './FolderSelect.vue';
 import { useStorage } from '@vueuse/core'
 import CreateLinkBatch from './CreateLinkBatch.vue';
-import { getErrorFromNestedObject, getErrorFromResponseStatus, getErrorResponse, folderError, defaultError } from "../lib/errors"
+import { getErrorFromNestedObject, getErrorFromResponseOrStatus, getErrorResponse, folderError, defaultError } from "../lib/errors"
 
 const batchDialogRef = ref('')
 const batchDialogOpen = () => {
@@ -95,7 +95,7 @@ const handleCaptureError = ({ error, errorType }) => {
 
     // Handle API-generated error messages
     if (error?.response) {
-        errorMessage = getErrorFromResponseStatus(error.status, error.response)
+        errorMessage = getErrorFromResponseOrStatus(error.status, error.response)
     }
 
     else if (error?.status) {

--- a/perma_web/frontend/components/FileInput.vue
+++ b/perma_web/frontend/components/FileInput.vue
@@ -1,7 +1,7 @@
 <script setup>
 const model = defineModel()
 const props = defineProps({
-    error: String,
+    error: Array,
     id: String
 })
 
@@ -23,6 +23,8 @@ const handleFileChange = (event) => {
         model.description }}</span></label>
         <input v-on:change="handleFileChange" :id="props.id" class="file" :name="props.id" type="file"
             accept=".png,.jpg,.jpeg,.gif,.pdf">
-        <span v-if="props.error" class="help-block js-warning">{{ props.error }}</span>
+        <template v-for="error in props.error">
+            <span class="help-block js-warning">{{ error }}</span>
+        </template>
     </div>
 </template>

--- a/perma_web/frontend/components/TextInput.vue
+++ b/perma_web/frontend/components/TextInput.vue
@@ -1,7 +1,7 @@
 <script setup>
 const model = defineModel()
 const props = defineProps({
-    error: String,
+    error: Array,
     id: String
 })
 
@@ -15,6 +15,8 @@ const props = defineProps({
                 class="label-instruction">{{
         model.description }}</span></label>
         <input v-model="model.value" :id="props.id" :name="props.id" type="text" :placeholder="model.placeholder" />
-        <span v-if="props.error" class="help-block js-warning">{{ props.error }}</span>
+        <template v-for="error in props.error">
+            <span class="help-block js-warning">{{ error }}</span>
+        </template>
     </div>
 </template>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -6,6 +6,7 @@ import Dialog from './Dialog.vue';
 import { getCookie } from '../../static/js/helpers/general.helpers';
 import { rootUrl } from '../lib/consts'
 import { globalStore } from '../stores/globalStore';
+import { getErrorResponse } from '../lib/errors'
 
 const defaultFields = {
     title: { name: "New Perma Link title", type: "text", description: "The page title associated", placeholder: "Example Page Title", value: '' },
@@ -92,7 +93,7 @@ const handleUploadRequest = async () => {
             })
 
         if (!response?.ok) {
-            const errorResponse = await response.json()
+            const errorResponse = await getErrorResponse(response)
             throw errorResponse
         }
 
@@ -103,7 +104,8 @@ const handleUploadRequest = async () => {
 
         window.location.href = `${window.location.origin}/${guid}`
     } catch (error) {
-        console.log(error) // TODO: Add actual error handling
+        console.log(error)
+        errors.value = error.response
     }
 };
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -6,7 +6,7 @@ import Dialog from './Dialog.vue';
 import { getCookie } from '../../static/js/helpers/general.helpers';
 import { rootUrl } from '../lib/consts'
 import { globalStore } from '../stores/globalStore';
-import { getErrorResponse, getGlobalErrorValues, getErrorFromStatus } from '../lib/errors'
+import { getErrorResponse, getGlobalErrorValues, getErrorFromStatus, defaultError } from '../lib/errors'
 
 
 const defaultFields = {

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import TextInput from './TextInput.vue';
 import FileInput from './FileInput.vue';
 import Dialog from './Dialog.vue';

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -6,7 +6,7 @@ import Dialog from './Dialog.vue';
 import { getCookie } from '../../static/js/helpers/general.helpers';
 import { rootUrl } from '../lib/consts'
 import { globalStore } from '../stores/globalStore';
-import { getErrorResponse } from '../lib/errors'
+import { getErrorResponse, getUniqueErrorValues } from '../lib/errors'
 
 const defaultFields = {
     title: { name: "New Perma Link title", type: "text", description: "The page title associated", placeholder: "Example Page Title", value: '' },
@@ -31,17 +31,10 @@ watch(
 );
 
 const errors = ref({})
-const uniqueErrors = computed(() => { return getUniqueErrorValues(formData, errors) })
-
-
-const getUniqueErrorValues = (formData, errors) => {
-    return Object.keys(errors).reduce((acc, key) => {
-        if (!(key in formData)) {
-            acc.push(errors[key])
-        }
-        return acc;
-    }, []);
-}
+const hasErrors = computed(() => {
+    return Object.keys(errors.value).length > 0;
+});
+const uniqueErrors = computed(() => { return getUniqueErrorValues(formData.value, errors.value) })
 
 const handleErrorReset = () => {
     errors.value = {}
@@ -147,11 +140,15 @@ defineExpose({
                         <button type="submit" @click.prevent="handleUploadRequest" class="btn btn-primary btn-large">{{
         !!globalStore.captureGUID ?
             "Upload" :
-                            "Create a Perma Link" }}</button>
+            "Create a Perma Link" }}</button>
                         <button type="button" @click.prevent="handleClose" class="btn cancel">Cancel</button>
                     </div>
-                    <div id="upload-error">
-                        <p class="field-error">Upload failed. </p>
+
+                    <div v-if="hasErrors" class="field-error">
+                        Upload failed.
+                        <span v-for="error in uniqueErrors">
+                            {{ error }}
+                        </span>
                     </div>
                 </form>
             </div>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -30,16 +30,17 @@ watch(
     }
 );
 
-// Match backend format for errors, for example {file:"message",url:"message"},
 const errors = ref({})
+const uniqueErrors = computed(() => { return getUniqueErrorValues(formData, errors) })
 
-// Debug only
-const handleErrorToggle = () => {
-    const mockedErrors = {
-        url: "URL cannot be empty.",
-        file: "File is too large."
-    }
-    errors.value = mockedErrors
+
+const getUniqueErrorValues = (formData, errors) => {
+    return Object.keys(errors).reduce((acc, key) => {
+        if (!(key in formData)) {
+            acc.push(errors[key])
+        }
+        return acc;
+    }, []);
 }
 
 const handleErrorReset = () => {
@@ -146,12 +147,12 @@ defineExpose({
                         <button type="submit" @click.prevent="handleUploadRequest" class="btn btn-primary btn-large">{{
         !!globalStore.captureGUID ?
             "Upload" :
-            "Create a Perma Link" }}</button>
+                            "Create a Perma Link" }}</button>
                         <button type="button" @click.prevent="handleClose" class="btn cancel">Cancel</button>
                     </div>
-
-                    <button @click.prevent="handleErrorToggle">Toggle Error</button>
-                    <button @click.prevent="handleErrorReset">Reset Errors</button>
+                    <div id="upload-error">
+                        <p class="field-error">Upload failed. </p>
+                    </div>
                 </form>
             </div>
         </div>

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -129,8 +129,6 @@ defineExpose({
                 <h3 id="batch-modal-title" class="modal-title">
                     Upload a file to Perma.cc
                 </h3>
-                errors: {{ errors }}
-                global errors: {{ globalErrors }}
             </div>
             <p class="modal-description">
                 {{

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -146,8 +146,8 @@ defineExpose({
 
                     <p v-if="hasErrors" class="field-error">
                         Upload failed.
-                        <span v-for="error in uniqueErrors">
-                            {{ error }}
+                        <span v-if="uniqueErrors">
+                            {{ uniqueErrors }}
                         </span>
                     </p>
 

--- a/perma_web/frontend/components/UploadForm.vue
+++ b/perma_web/frontend/components/UploadForm.vue
@@ -144,12 +144,13 @@ defineExpose({
                         <button type="button" @click.prevent="handleClose" class="btn cancel">Cancel</button>
                     </div>
 
-                    <div v-if="hasErrors" class="field-error">
+                    <p v-if="hasErrors" class="field-error">
                         Upload failed.
                         <span v-for="error in uniqueErrors">
                             {{ error }}
                         </span>
-                    </div>
+                    </p>
+
                 </form>
             </div>
         </div>

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -1,11 +1,18 @@
-export const getUniqueErrorValues = (formData, errors) => {
+export const getGlobalErrorValues = (formData, errors) => {
+  console.log(errors)
+  console.log(typeof errors)
+  if (typeof errors === 'string') {
+    return errors;
+  }
+
   const errorValues = Object.keys(errors).reduce((acc, key) => {
     if (!(key in formData)) {
-      return [...acc, ...errors[key]];
+      const errorValue = errors[key];
+      return Array.isArray(errorValue) ? [...acc, ...errorValue] : [...acc, errorValue];
     }
     return acc;
   }, []);
-  
+
   return errorValues.join(' ');
 }
 // Returns the first error string nested within an API error response object
@@ -28,7 +35,15 @@ export const getErrorFromNestedObject = (object) => {
     return getString(object) || null;
   }
 
- export const getErrorFromResponseStatus = (status, response) => {
+  export const getErrorFromStatus = (status) => {
+    if (status === 401) {
+      return loggedOutError
+    }
+
+    return `Error: ${status}`
+  }
+
+ export const getErrorFromResponseOrStatus = (status, response) => {
     let errorMessage
 
     switch (status) {
@@ -36,7 +51,7 @@ export const getErrorFromNestedObject = (object) => {
             errorMessage = getErrorFromNestedObject(response)
             break;
         case 401:
-            errorMessage = "You appear to be logged out."
+            errorMessage = loggedOutError
             break;
         default:
             errorMessage = `Error: ${status}`
@@ -60,5 +75,6 @@ export const getErrorResponse = async (response) => {
 };
 
 export const defaultError = "We're sorry, we've encountered an error processing your request."
+export const loggedOutError = "You appear to be logged out."
 export const folderError = "Missing folder selection. Please select a folder."
 export const missingUrlError = "Missing urls. Please submit valid urls."

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -1,12 +1,13 @@
 export const getUniqueErrorValues = (formData, errors) => {
-  return Object.keys(errors).reduce((acc, key) => {
-      if (!(key in formData)) {
-          return [...acc, ...errors[key]];
-      }
-      return acc;
+  const errorValues = Object.keys(errors).reduce((acc, key) => {
+    if (!(key in formData)) {
+      return [...acc, ...errors[key]];
+    }
+    return acc;
   }, []);
+  
+  return errorValues.join(' ');
 }
-
 // Returns the first error string nested within an API error response object
 // For example, passing {"url":["URL cannot be empty."]} would return "URL cannot be empty."
 export const getErrorFromNestedObject = (object) => {

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -6,7 +6,7 @@ export const getGlobalErrorValues = (formData, errors) => {
   const errorValues = Object.keys(errors).reduce((acc, key) => {
     if (!(key in formData)) {
       const errorValue = errors[key];
-      return Array.isArray(errorValue) ? [...acc, ...errorValue] : [...acc, errorValue];
+      return acc.concat(errorValue);
     }
     return acc;
   }, []);

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -1,3 +1,12 @@
+export const getUniqueErrorValues = (formData, errors) => {
+  return Object.keys(errors).reduce((acc, key) => {
+      if (!(key in formData)) {
+          return [...acc, ...errors[key]];
+      }
+      return acc;
+  }, []);
+}
+
 // Returns the first error string nested within an API error response object
 // For example, passing {"url":["URL cannot be empty."]} would return "URL cannot be empty."
 export const getErrorFromNestedObject = (object) => {

--- a/perma_web/frontend/lib/errors.js
+++ b/perma_web/frontend/lib/errors.js
@@ -1,6 +1,4 @@
 export const getGlobalErrorValues = (formData, errors) => {
-  console.log(errors)
-  console.log(typeof errors)
   if (typeof errors === 'string') {
     return errors;
   }

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3044,7 +3044,7 @@ textarea {
 }
 
 .field-error,
-.errorlist {
+.errorlist, {
   color: $color-error;
   font-family: $font-hed-alt;
   font-weight: 700;
@@ -5897,7 +5897,6 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
   width: 100%;
   padding: 0;
   border: none;
-  text-align: left;
 
   @include respond-tablet {
     margin-block-start: 3.75rem;

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -5897,6 +5897,7 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
   width: 100%;
   padding: 0;
   border: none;
+  text-align: left;
 
   @include respond-tablet {
     margin-block-start: 3.75rem;

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -3044,7 +3044,7 @@ textarea {
 }
 
 .field-error,
-.errorlist, {
+.errorlist {
   color: $color-error;
   font-family: $font-hed-alt;
   font-weight: 700;


### PR DESCRIPTION
## What this does 
This update primarily  passes errors from Perma's backend related to archive uploading to the new `UploadForm` component. 

It also: 

- Moves where the `UploadForm` component is being rendered. Previously, it was being rendered as a child of a div with the id `error-container`. There was some CSS that applied styling at a very high specificity, using the `error-container` id, that applied a handful of undesired styles to the dialog and its children. Moving the component should fix this without requiring CSS to be written at an even higher specificity. 
- Adds a function `getGlobalErrorValues` for splitting out errors — not tied to the key for any particular form field — from the rest of the error group.
- Adds a function `getErrorFromStatus` for generating errors for failed uploads that do not return a proper response body. 
- Renames a previous function to `getErrorFromResponseOrStatus` to better differentiate that it will return an error pulled from a response body or a response status. 

## Screenshots

If a user doesn't enter a url or upload a file:
<img width="647" alt="image" src="https://github.com/user-attachments/assets/0adf00d1-f69c-4c5b-b942-a70df1777512">

If the file size of an archive is larger than 100 MB: 
<img width="619" alt="image" src="https://github.com/user-attachments/assets/24d5dc0b-21d3-4c47-a16f-91f9ebeafc8d">

If the format of a url is invalid: 
<img width="619" alt="image" src="https://github.com/user-attachments/assets/0102dc81-1a76-4c06-b399-05854f0f86ca">

_Note: Perma's backend doesn't check if a url correctly resolves — only if the format of the url itself is valid_

If there is no API response body (or it can't be properly parsed), only a status:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/c998d317-751a-4c57-985a-6e52c254f825">

If there is no status nor valid response body: 
<img width="649" alt="image" src="https://github.com/user-attachments/assets/24b54fc3-67fb-4790-8ab4-eb6eda056049">  

## How to test 
- Make sure you've toggled both the `vue-dashboard` and `developer-playground` django waffle flags, either in the django dashboard or using a url query parameter. 
- You can either click "Trigger error" from the developer playground-provided UI, attempt to request a capture without providing a url, or manually make all captures fail. 
  - To make all captures fail, add this error to approximately line 344 of `celery_tasks.py`: `poll_data['status'] = 'failure'`, just after: 
  ```
        # Poll until done
        poll_network_errors = 0
        while True:
  ```
- Click the "Upload your own archive" button
- Try to submit the form without providing any information
- Try to submit the form with a file that is too large — over 100MB. There are some on the [Wikimedia page that lists media categorized as "large images"](https://commons.wikimedia.org/wiki/Category:Large_images)
- Try to submit the form with a file and an invalid format url, for example "shfhffhsagsgf" 
- Try to submit the form while manually throwing an error in `handleUploadRequest`: 
   - You can do this you comment out everything inside the `try` block and include this instead: 
   - ```        
       const error = {
            status: 500
        }
        const errorResponse = await getErrorResponse(error)

        throw errorResponse
        ```
- Try to correct your mistakes and resubmit the form. After the archive uploads, you should be redirected to the new perma capture. 