### PR TITLE
Update batch capture functions, add composable to fetch batch history

### DIFF
--- a/perma_web/frontend/components/App.vue
+++ b/perma_web/frontend/components/App.vue
@@ -6,6 +6,7 @@ import { onBeforeMount, watchEffect } from 'vue'
 import { getLinksRemainingStatus, getUserTypes, getUserOrganizations, getSponsoredFolders } from '../lib/store'
 import { globalStore } from '../stores/globalStore';
 import { showDevPlayground } from '../lib/consts'
+import LinkBatchHistory from './LinkBatchHistory.vue';
 
 onBeforeMount(() => {
     globalStore.updateLinksRemaining(links_remaining)
@@ -29,4 +30,5 @@ watchEffect(() => {
     <Toast />
     <CreateLink />
     <PermaLinkDetails v-if="showDevPlayground" />
+    <LinkBatchHistory v-if="showDevPlayground" />
 </template>

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -150,7 +150,6 @@ const handleBatchDetailsFetch = async () => {
     const { allJobs, progressSummary } = await useBatchDetailsFetch(batchCaptureId.value.id);
 
     if (allJobs.value && progressSummary.value) {
-        console.log(allJobs.value)
         batchCaptureJobs.value = allJobs.value;
         batchCaptureSummary.value = progressSummary.value;
     }

--- a/perma_web/frontend/components/CreateLinkBatch.vue
+++ b/perma_web/frontend/components/CreateLinkBatch.vue
@@ -147,21 +147,22 @@ const handleBatchError = ({ error, errorType }) => {
 }
 
 const handleBatchDetailsFetch = async () => {
-    const batchDetails = await useBatchDetailsFetch(batchCaptureId.value.id)
+    const { allJobs, progressSummary } = await useBatchDetailsFetch(batchCaptureId.value.id);
 
-    if (batchDetails?.allJobs && batchDetails?.progressSummary) {
-        batchCaptureJobs.value = batchDetails.allJobs
-        batchCaptureSummary.value = batchDetails.progressSummary
+    if (allJobs.value && progressSummary.value) {
+        console.log(allJobs.value)
+        batchCaptureJobs.value = allJobs.value;
+        batchCaptureSummary.value = progressSummary.value;
     }
 
-    if (batchDetails?.allJobs?.completed) {
-        clearInterval(progressInterval)
-        globalStore.updateBatchCapture('isCompleted')
+    if (allJobs.value?.completed) {
+        clearInterval(progressInterval);
+        globalStore.updateBatchCapture('isCompleted');
 
         const batchCompleted = new CustomEvent("BatchLinkModule.batchCompleted");
         window.dispatchEvent(batchCompleted);
     }
-}
+};
 
 const { addToast } = useToast();
 

--- a/perma_web/frontend/components/LinkBatchHistory.vue
+++ b/perma_web/frontend/components/LinkBatchHistory.vue
@@ -1,0 +1,22 @@
+<script setup>
+import { ref } from 'vue'
+import { useLinkBatchList } from '../lib/data'
+
+const linkRecords = ref([]) 
+const handleLinkBatchHistoryFetch = async () => {
+    const { linkBatches } = await useLinkBatchList();
+    linkRecords.value = linkBatches.value
+};
+</script>
+
+<template>
+    <!-- For Testing Only -->
+    <button :onClick="handleLinkBatchHistoryFetch">
+        Fetch Batch History
+    </button>
+    <ul v-if="linkRecords.length" v-for="link in linkRecords">
+        <li>
+            {{ link.started_on }}
+        </li>
+    </ul>
+</template>

--- a/perma_web/frontend/components/LinkBatchHistory.vue
+++ b/perma_web/frontend/components/LinkBatchHistory.vue
@@ -1,10 +1,10 @@
 <script setup>
 import { ref } from 'vue'
-import { useLinkBatchList } from '../lib/data'
+import { useBatchHistoryFetch } from '../lib/data'
 
 const linkRecords = ref([]) 
 const handleLinkBatchHistoryFetch = async () => {
-    const { linkBatches } = await useLinkBatchList();
+    const { linkBatches } = await useBatchHistoryFetch();
     linkRecords.value = linkBatches.value
 };
 </script>

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -36,6 +36,41 @@ export const useFetch = async (baseUrl, options) => {
   }
 }
 
+export const useLinkBatchList = async (limit = 7) => {
+  const state = reactive({
+    linkBatches: [],
+    isLoading: false,
+    hasError: false,
+    errorMessage: ''
+  });
+
+  const fetchLinkBatches = async () => {
+    state.isLoading = true;
+
+    try {
+      const { data, hasError, errorMessage } = await useFetch('/archives/batches/', { limit });
+
+      if (hasError.value || !data.value.objects.length) {
+        throw new Error(errorMessage.value || 'Failed to fetch link batches');
+      }
+
+      state.linkBatches = data.value.objects;
+    } catch (err) {
+      state.hasError = true;
+      state.errorMessage = err.message || 'An error occurred while fetching link batches';
+    }
+
+    state.isLoading = false;
+  };
+
+  await fetchLinkBatches();
+
+  return {
+    ...toRefs(state),
+    fetchLinkBatches
+  };
+}
+
 export const useBatchDetailsFetch = async (batchCaptureId) => {
   const state = reactive({
     isLoading: false,

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -1,5 +1,7 @@
 import { reactive, toRefs } from "vue";
 import { defaultError } from './errors'
+import { validStates, transitionalStates } from '../lib/consts.js'
+import { getErrorFromNestedObject } from '../lib/errors';
 
 export const useFetch = async (baseUrl, options) => {
   const state = reactive({
@@ -33,3 +35,58 @@ export const useFetch = async (baseUrl, options) => {
     ...toRefs(state)
   }
 }
+
+export const useBatchDetailsFetch = async (batchCaptureId) => {
+  const { data, hasError, errorMessage } = await useFetch(`/api/v1/archives/batches/${batchCaptureId}`)
+
+  if (hasError.value || !data.value.capture_jobs) {
+      console.log(errorMessage.value)
+      return
+  }
+
+  const { allJobs, progressSummary } = useFormatBatchDetails(data.value.capture_jobs)
+
+  return {
+    allJobs, progressSummary
+  }
+}
+
+export const useFormatBatchDetails = ((captureJobs) => {
+  const steps = 6
+  const allJobs = captureJobs.reduce((accumulatedJobs, currentJob) => {
+      const includesError = !validStates.includes(currentJob.status)
+      const isCapturing = transitionalStates.includes(currentJob.status)
+
+      let jobDetail = {
+          ...currentJob,
+          message: includesError ? getErrorFromNestedObject(JSON.parse(currentJob.message)) : '',
+          progress: (currentJob.step_count / steps) * 100,
+          url: `${window.location.hostname}/${currentJob.guid}`
+      };
+
+      if (isCapturing) {
+          accumulatedJobs.completed = false;
+      }
+
+      if (includesError) {
+          accumulatedJobs.errors += 1;
+      }
+
+      return {
+          ...accumulatedJobs,
+          details: [...accumulatedJobs.details, jobDetail]
+      };
+  }, {
+      details: [],
+      completed: true,
+      errors: 0
+  });
+
+  const totalProgress = allJobs.details.reduce((total, job) => total + job.progress, 0);
+  const maxProgress = allJobs.details.length * 100;
+  const percentComplete = Math.round((totalProgress / maxProgress) * 100);
+
+  const progressSummary = allJobs.completed ? "Batch complete." : `Batch ${percentComplete}% complete.`;
+
+  return { allJobs, progressSummary }
+})

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -2,6 +2,7 @@ import { reactive, toRefs } from "vue";
 import { defaultError } from './errors'
 import { validStates, transitionalStates } from '../lib/consts.js'
 import { getErrorFromNestedObject } from '../lib/errors';
+import { rootUrl } from '../lib/consts'
 
 export const useFetch = async (baseUrl, options) => {
   const state = reactive({
@@ -48,7 +49,7 @@ export const useLinkBatchList = async (limit = 7) => {
     state.isLoading = true;
 
     try {
-      const { data, hasError, errorMessage } = await useFetch('/archives/batches/', { limit });
+      const { data, hasError, errorMessage } = await useFetch(`${rootUrl}/archives/batches/`, { limit });
 
       if (hasError.value || !data.value.objects.length) {
         throw new Error(errorMessage.value || 'Failed to fetch link batches');
@@ -66,8 +67,7 @@ export const useLinkBatchList = async (limit = 7) => {
   await fetchLinkBatches();
 
   return {
-    ...toRefs(state),
-    fetchLinkBatches
+    ...toRefs(state)
   };
 }
 

--- a/perma_web/frontend/lib/data.js
+++ b/perma_web/frontend/lib/data.js
@@ -37,7 +37,7 @@ export const useFetch = async (baseUrl, options) => {
   }
 }
 
-export const useLinkBatchList = async (limit = 7) => {
+export const useBatchHistoryFetch = async (limit = 7) => {
   const state = reactive({
     linkBatches: [],
     isLoading: false,
@@ -45,7 +45,7 @@ export const useLinkBatchList = async (limit = 7) => {
     errorMessage: ''
   });
 
-  const fetchLinkBatches = async () => {
+  const fetchBatchHistory = async () => {
     state.isLoading = true;
 
     try {
@@ -64,7 +64,7 @@ export const useLinkBatchList = async (limit = 7) => {
     state.isLoading = false;
   };
 
-  await fetchLinkBatches();
+  await fetchBatchHistory();
 
   return {
     ...toRefs(state)


### PR DESCRIPTION
## Summary
This update refactors some previous component-scoped functions into composables (the Vue equivalent of React hooks) for reusability and adds a new composable for fetching a user's batch capture history. 

## Additional Notes
- Refactors `handleBatchDetailsFetch` and `handleBatchFormatting`. These have been renamed following the normal style for Vue composables, which are typically named `Use....`
- Adds `useBatchHistoryFetch` to fetch a user's batch history
- Adds `LinkBatchHistory` component with minimal developer-only UI for testing out fetch functionality 

Right now, this code merely displays the batch history when a user requests it by toggling a button. It does not automatically update the list of timestamps. In the future, this could become more reactive by moving the `batchCaptureId` out of  `CreateLinkBatch` and into the global store in `globalStore.js` — then writing a `watch` function to watch for changes to the batch capture id, and re-fetching an updated list of batch history info. 

For example, 

```
  watch(() => globalStore.batchCaptureId, () => {
        ....do a thing
  });

```

## Screenshots 
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/810402d0-1e5f-4765-81dc-3126533b407b">

## Linear issue
Satisfies Linear issue 2316

## How to test
- Make sure you've toggled the `vue-dashboard` and `developer-playground` Django flags
- Clicking "Fetch Batch History" should fetch and display the unformatted timestamps for the start time of the past 7 batch capture requests. 
- If you initiate another batch capture using the Perma UI, you should be able to click "Fetch Batch History" again and see a new timestamp show up at the top of the list.