### PR TITLE
Notify new user if their email domain matches existing Perma partner(s)

### DIFF
--- a/perma_web/perma/templates/email/includes/activation.txt
+++ b/perma_web/perma/templates/email/includes/activation.txt
@@ -1,6 +1,10 @@
 In order to complete your account activation, please confirm your email address and set a password. It’s as simple as clicking the link below. The link will be valid for the next {% widthratio activation_expires 3600 1 %} hours.
 
-{{ activation_route }}
+    {{ activation_route }}
+
+{% if suggested_registrars %}Note: We’ve also found {% if suggested_registrars|length == 1 %}a Perma.cc partner institution{% else %}some Perma.cc partner institutions{% endif %} with whom you might be affiliated. You may be able to request a sponsored account by contacting them:
+{% for suggested_registrar in suggested_registrars %}
+  - {{ suggested_registrar.name }}: {{ suggested_registrar.email }}{% endfor %}{% endif %}
 
 Thanks,
 The Perma.cc Team

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -2656,15 +2656,9 @@ class UserManagementViewsTestCase(PermaTestCase):
         message = mail.outbox[0]
         lines = message.body.splitlines()
         captures = []
-        capture_line = False
         for line in lines:
-            if capture_line is True:
-                captures.append(line.lstrip('- '))
-                continue
-            if line.startswith('Note: We’ve also found'):
-                capture_line = True
-            elif line == '':
-                capture_line = False
+            if line.lstrip().startswith('- '):
+                captures.append(line.strip('- '))
 
         # Validate suggested registrar(s)
         self.assertEqual(len(captures), 1)

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -2,6 +2,7 @@ import csv
 from datetime import timedelta
 import itertools
 import logging
+import re
 from typing import Literal
 
 import celery
@@ -1988,17 +1989,27 @@ def firm_request_response(request):
     return render(request, 'registration/firm_request.html')
 
 
-def match_user_email_to_existing_registrar(user: LinkUser) -> Registrar | None:
-    """If a user's email matches an existing registrar, return it."""
-    _, user_domain = user.email.split('@')
-    pattern = r'https?://(www\.)?' + user_domain + r'/?'
-    try:
-        return Registrar.objects.get(website__iregex=pattern)
-    except (Registrar.DoesNotExist, Registrar.MultipleObjectsReturned):
-        return None
+def suggest_registrars(user: LinkUser, limit: int = 5) -> BaseManager[Registrar]:
+    """Suggest potential registrars for a user based on email domain.
+
+    This queries the database for registrars whose website URL matches
+    the base domain from the user's email address. For example, if the
+    user's email is `username@law.harvard.edu`, this will suggest
+    registrars whose URLs end with `harvard.edu`.
+    """
+    _, email_domain = user.email.split('@')
+    base_domain = '.'.join(email_domain.rsplit('.', 2)[-2:])
+    pattern = f'{re.escape(base_domain)}/?$'
+    registrars = (
+        Registrar.objects.exclude(status='pending')
+        .filter(website__iregex=pattern)
+        .order_by('-link_count')
+        .all()[:limit]
+    )
+    return registrars
 
 
-def email_new_user(request, user, template="email/new_user.txt", context={}):
+def email_new_user(request, user, template='email/new_user.txt', context=None):
     """
     Send email to newly created accounts
     """
@@ -2007,17 +2018,19 @@ def email_new_user(request, user, template="email/new_user.txt", context={}):
         urlsafe_base64_encode(force_bytes(user.pk)),
         default_token_generator.make_token(user),
     ]))
-    context.update({
-        'activation_route': activation_route,
-        'activation_expires': settings.PASSWORD_RESET_TIMEOUT,
-        'request': request
-    })
 
-    # If using default template, check whether user's email matches an existing registrar
-    if template == 'email/new_user.txt':
-        context['registrar_match'] = match_user_email_to_existing_registrar(user)
-    else:
-        context['registrar_match'] = None
+    # Include context variables
+    template_is_default = template == 'email/new_user.txt'
+    context = context if context is not None else {}
+    context.update(
+        {
+            'activation_expires': settings.PASSWORD_RESET_TIMEOUT,
+            'activation_route': activation_route,
+            'request': request,
+            # Only query DB if we're using the default template; otherwise there's no need
+            'suggested_registrars': suggest_registrars(user) if template_is_default else [],
+        }
+    )
 
     send_user_email(
         user.raw_email,

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1992,19 +1992,18 @@ def firm_request_response(request):
 def suggest_registrars(user: LinkUser, limit: int = 5) -> BaseManager[Registrar]:
     """Suggest potential registrars for a user based on email domain.
 
-    This queries the database for registrars whose website URL matches
-    the base domain from the user's email address. For example, if the
+    This queries the database for registrars whose website matches the
+    base domain from the user's email address. For example, if the
     user's email is `username@law.harvard.edu`, this will suggest
-    registrars whose URLs end with `harvard.edu`.
+    registrars whose domains end with `harvard.edu`.
     """
     _, email_domain = user.email.split('@')
     base_domain = '.'.join(email_domain.rsplit('.', 2)[-2:])
-    pattern = f'{re.escape(base_domain)}/?$'
+    pattern = f'^https?://([a-zA-Z0-9\\-\\.]+\\.)?{re.escape(base_domain)}(/.*)?$'
     registrars = (
         Registrar.objects.exclude(status='pending')
         .filter(website__iregex=pattern)
-        .order_by('-link_count')
-        .all()[:limit]
+        .order_by('-link_count', 'name')[:limit]
     )
     return registrars
 

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import itertools
 import logging
 from typing import Literal
+from urllib.parse import urlsplit
 
 import celery
 import redis
@@ -1986,6 +1987,18 @@ def firm_request_response(request):
     After the user has requested info about a firm account
     """
     return render(request, 'registration/firm_request.html')
+
+
+def match_user_email_to_existing_registrar(user: LinkUser) -> Registrar | None:
+    """Determine whether a user's domain matches an existing registrar."""
+    _, user_domain = user.email.split('@')
+    registrars = Registrar.objects.filter(website__icontains=user_domain)
+    for registrar in registrars:
+        registrar_domain = urlsplit(registrar.website).hostname
+        if (registrar_domain is not None) and (registrar_domain == user_domain):
+            return registrar
+    else:
+        return None
 
 
 def email_new_user(request, user, template="email/new_user.txt", context={}):


### PR DESCRIPTION
This branch adds some logic to notify new users if we think they might belong to one or more existing Perma registrars.

How this works: upon new user registration, `suggest_registrars` queries the DB for `Registrar.website` values whose base domain matches the base domain from the new user's email address. If there are matches, they are included in the confirmation email:

```txt
Note: We’ve also found some Perma.cc partner institutions with whom you might be
affiliated. You may be able to request a sponsored account by contacting them:
  - Registrar1: registrar1_contact@example.com
  - Registrar2: registrar2_contact@other.example.com
```

## Validation

1. Run your local Perma instance from this branch.
2. As an admin user, create one or more new registrars, making sure to use a common base domain for their `website` values. For example, `https://lil.law.harvard.edu` and `https://library.harvard.edu`.
3. Log out, then go to `/sign-up` and create a new user account using an email address with the base domain from step 2. For example, `new_user@law.harvard.edu`.
4. Note the inclusion of the suggested registrar(s) in the registration confirmation email as logged to your terminal output.