### PR TITLE
Refactor test_permissions.py

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -41,12 +41,6 @@ def _create_server(self, connections_override=None):
 HTTPSLiveServerThread._create_server = _create_server
 
 
-# shadow this fixture from  pytest_django_liveserver_ssl so that it doesn't request the admin client (which doesn't work with our fixture situation)
-@pytest.fixture()
-def live_server_ssl_clients_for_patch(client):
-    return [client]
-
-
 @pytest.fixture(scope="session")
 def set_up_certs():
     certs = [

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -519,6 +519,11 @@ def org_user(org_user_factory):
 
 
 @pytest.fixture
+def admin_user(link_user_factory):
+    return link_user_factory(is_staff=True)
+
+
+@pytest.fixture
 def perma_client():
     """
     A version of the Django test client that allows us to specify a user login for a particular request with an

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1072,7 +1072,12 @@ class LinkUser(CustomerModel, AbstractBaseUser, PermissionsMixin):
         return self.is_staff or self.registrar == registrar
 
     def can_edit_organization(self, organization):
-        return self.organizations.filter(pk=organization.pk).exists()
+        if self.is_staff:
+            return True
+        elif self.registrar:
+            return self.registrar == organization.registrar
+        else:
+            return self.organizations.filter(pk=organization.pk).exists()
 
 
     ### subscriptions ###

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -3,144 +3,157 @@ from django.test.utils import override_settings
 
 from perma.urls import urlpatterns
 
-from .utils import PermaTestCase
+from perma.models import LinkUser, Registrar
+
+import pytest
 
 
-class PermissionsTestCase(PermaTestCase):
 
-    @override_settings(SECURE_SSL_REDIRECT=False)
-    def test_permissions(self):
-        """Test who can log into restricted pages."""
-        all_users = {
-            'test_admin_user@example.com',
-            'test_registrar_user@example.com',
-            'test_org_user@example.com',
-            'test_user@example.com'
-        }
-        views = [
-            {
-                'urls': [
-                    ['user_management_stats'],
-                    ['user_management_manage_admin_user'],
-                    ['user_management_admin_user_add_user'],
-                    ['user_management_manage_single_admin_user_delete', {'kwargs':{'user_id': 1}}],
-                    ['user_management_manage_single_admin_user_remove', {'kwargs':{'user_id': 1}}],
-                    ['user_management_manage_registrar'],
-                    ['user_management_manage_single_registrar_user', {'kwargs':{'user_id': 2}}],
-                    ['user_management_manage_single_registrar_user_delete', {'kwargs':{'user_id': 2}}],
-                    ['user_management_manage_single_registrar_user_reactivate', {'kwargs':{'user_id': 2}}],
-                    ['user_management_approve_pending_registrar', {'kwargs':{'registrar_id': 2}}],
-                    ['user_management_manage_user'],
-                    ['user_management_user_add_user'],
-                    ['user_management_manage_single_user', {'kwargs':{'user_id': 4}}],
-                    ['user_management_manage_single_user_delete', {'kwargs':{'user_id': 4}}],
-                    ['user_management_manage_single_organization_user_delete', {'kwargs':{'user_id': 3}}],
-                    ['user_management_manage_single_organization_user_reactivate', {'kwargs':{'user_id': 3}}],
-                    ['user_management_manage_single_user_reactivate', {'kwargs':{'user_id': 4}}],
-                    ['user_management_manage_single_sponsored_user_delete', {'kwargs':{'user_id': 20}}],
-                    ['user_management_manage_single_sponsored_user_reactivate', {'kwargs':{'user_id': 20}}]
-                ],
-                'allowed': {'test_admin_user@example.com'},
-            },
-            {
-                'urls': [
-                    ['user_management_manage_registrar_user'],
-                    ['user_management_registrar_user_add_user'],
-                    ['user_management_manage_single_registrar', {'kwargs':{'registrar_id': 1}}],
-                    ['user_management_manage_sponsored_user'],
-                    ['user_management_manage_sponsored_user_export_user_list'],
-                    ['user_management_sponsored_user_add_user'],
-                    ['user_management_manage_single_sponsored_user', {'kwargs':{'user_id': 20}}],
-                    ['user_management_manage_single_sponsored_user_remove', {'kwargs':{'user_id': 20, 'registrar_id': 1}}],
-                    ['user_management_manage_single_sponsored_user_readd', {'kwargs':{'user_id': 20, 'registrar_id': 1}}],
-                    ['user_management_manage_single_sponsored_user_links', {'kwargs':{'user_id': 20, 'registrar_id': 1}}]
-                ],
-                'allowed': {'test_admin_user@example.com', 'test_registrar_user@example.com'},
-            },
-            {
-                'urls': [
-                    ['user_management_manage_single_organization_user', {'kwargs':{'user_id': 3}}],
-                    ['user_management_manage_organization_user'],
-                    ['user_management_manage_organization'],
-                    ['user_management_manage_single_organization', {'kwargs':{'org_id':1}}],
-                    ['user_management_manage_single_organization_export_user_list', {'kwargs': {'org_id': 1}}],
-                    ['user_management_manage_single_organization_delete', {'kwargs':{'org_id':1}}],
-                    ['user_management_organization_user_add_user'],
-                    ['user_management_manage_single_organization_user_remove', {'kwargs':{'user_id': 3},
-                     'success_status': 302}],
-                ],
-                'allowed': {'test_admin_user@example.com', 'test_registrar_user@example.com',
-                        'test_org_user@example.com'},
-            },
-            {
-                'urls': [
-                    ['user_management_manage_single_registrar_user_remove', {'kwargs':{'user_id': 2}}],
-                ],
-                'allowed': {'test_registrar_user@example.com'}
-            },
+@override_settings(SECURE_SSL_REDIRECT=False)
+@pytest.mark.django_db
+def test_permissions(client):
+    """Test who can log into restricted pages."""
+    admin_user = LinkUser.objects.get(id=1)
+    registrar_user = LinkUser.objects.get(id=2)
+    org_user = LinkUser.objects.get(id=3)
+    regular_user = LinkUser.objects.get(id=4)
+    sponsored_user = LinkUser.objects.get(id=20)
 
-            {
-                'urls': [
-                    ['user_management_organization_user_leave_organization', {'kwargs':{'org_id': 1}}],
-                ],
-                'allowed': {'test_org_user@example.com'}
-            },
+    pending_registrar = Registrar.objects.get(id=2)
+    registrar_user_registrar = registrar_user.registrar
+    sponsored_user_registrar = sponsored_user.sponsorships.first().registrar
 
-            {
-                'urls': [
-                    ['user_management_settings_profile'],
-                    ['user_management_settings_password'],
-                    ['user_management_settings_tools'],
-                    ['create_link'],
-                    ['user_delete_link', {'kwargs':{'guid':'1234-1234'},'success_status':404}],
-                ],
-                'allowed': {'test_user@example.com'},
-                'disallowed': set(),
-            },
-        ]
+    org_user_org = org_user.organizations.first()
 
-        views_tested = set()
-        for view in views:
-            for url in view['urls']:
-                view_name = url[0]
-                opts = url[1] if len(url)>1 else {}
-                views_tested.add(view_name)
-                url = reverse(view_name, kwargs=opts.get('kwargs', None))
-                success_status = opts.get('success_status', 200)
-                success_test = opts.get('success_test', None)
+    all_users = {
+        admin_user,
+        registrar_user,
+        org_user,
+        regular_user
+    }
+    views = [
+        {
+            'urls': [
+                ['user_management_stats'],
+                ['user_management_manage_admin_user'],
+                ['user_management_admin_user_add_user'],
+                ['user_management_manage_single_admin_user_delete', {'kwargs':{'user_id': admin_user.id}}],
+                ['user_management_manage_single_admin_user_remove', {'kwargs':{'user_id': admin_user.id}}],
+                ['user_management_manage_registrar'],
+                ['user_management_manage_single_registrar_user', {'kwargs':{'user_id': registrar_user.id}}],
+                ['user_management_manage_single_registrar_user_delete', {'kwargs':{'user_id': registrar_user.id}}],
+                ['user_management_manage_single_registrar_user_reactivate', {'kwargs':{'user_id': registrar_user.id}}],
+                ['user_management_approve_pending_registrar', {'kwargs':{'registrar_id': pending_registrar.id}}],
+                ['user_management_manage_user'],
+                ['user_management_user_add_user'],
+                ['user_management_manage_single_user', {'kwargs':{'user_id': regular_user.id}}],
+                ['user_management_manage_single_user_delete', {'kwargs':{'user_id': regular_user.id}}],
+                ['user_management_manage_single_organization_user_delete', {'kwargs':{'user_id': org_user.id}}],
+                ['user_management_manage_single_organization_user_reactivate', {'kwargs':{'user_id': org_user.id}}],
+                ['user_management_manage_single_user_reactivate', {'kwargs':{'user_id': regular_user.id}}],
+                ['user_management_manage_single_sponsored_user_delete', {'kwargs':{'user_id': sponsored_user.id}}],
+                ['user_management_manage_single_sponsored_user_reactivate', {'kwargs':{'user_id': sponsored_user.id}}]
+            ],
+            'allowed': {admin_user},
+        },
+        {
+            'urls': [
+                ['user_management_manage_registrar_user'],
+                ['user_management_registrar_user_add_user'],
+                ['user_management_manage_single_registrar', {'kwargs':{'registrar_id': registrar_user_registrar.id}}],
+                ['user_management_manage_sponsored_user'],
+                ['user_management_manage_sponsored_user_export_user_list'],
+                ['user_management_sponsored_user_add_user'],
+                ['user_management_manage_single_sponsored_user', {'kwargs':{'user_id': sponsored_user.id}}],
+                ['user_management_manage_single_sponsored_user_remove', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}],
+                ['user_management_manage_single_sponsored_user_readd', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}],
+                ['user_management_manage_single_sponsored_user_links', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}]
+            ],
+            'allowed': {admin_user, registrar_user},
+        },
+        {
+            'urls': [
+                ['user_management_manage_single_organization_user', {'kwargs':{'user_id': org_user.id}}],
+                ['user_management_manage_organization_user'],
+                ['user_management_manage_organization'],
+                ['user_management_manage_single_organization', {'kwargs':{'org_id': org_user_org.id}}],
+                ['user_management_manage_single_organization_export_user_list', {'kwargs': {'org_id': org_user_org.id}}],
+                ['user_management_manage_single_organization_delete', {'kwargs':{'org_id': org_user_org.id}}],
+                ['user_management_organization_user_add_user'],
+                ['user_management_manage_single_organization_user_remove', {'kwargs':{'user_id': org_user.id},
+                 'success_status': 302}],
+            ],
+            'allowed': {admin_user, registrar_user, org_user},
+        },
+        {
+            'urls': [
+                ['user_management_manage_single_registrar_user_remove', {'kwargs':{'user_id': registrar_user.id}}],
+            ],
+            'allowed': {registrar_user}
+        },
 
-                # try while logged out
-                self.client.logout()
-                resp = self.client.get(url)
-                self.assertRedirects(resp, f"{reverse('user_management_limited_login')}?next={url}")
+        {
+            'urls': [
+                ['user_management_organization_user_leave_organization', {'kwargs':{'org_id': org_user_org.id}}],
+            ],
+            'allowed': {org_user}
+        },
 
-                # try with valid users
-                for user in view['allowed']:
-                    self.log_in_user(user)
-                    resp = self.client.get(url, secure=True)
-                    if success_test:
-                        success_test(resp)
-                    else:
-                        self.assertEqual(resp.status_code, success_status,
-                                         "View %s returned status %s for user %s; expected %s." % (view_name, resp.status_code, user, success_status))
+        {
+            'urls': [
+                ['user_management_settings_profile'],
+                ['user_management_settings_password'],
+                ['user_management_settings_tools'],
+                ['create_link'],
+                ['user_delete_link', {'kwargs':{'guid':'1234-1234'},'success_status':404}],
+            ],
+            'allowed': {regular_user},
+            'disallowed': set(),
+        },
+    ]
 
-                # try with invalid users
-                for user in view.get('disallowed', all_users - view['allowed']):
-                    self.log_in_user(user)
-                    resp = self.client.get(url)
-                    self.assertEqual(resp.status_code, 403,
-                                         "View %s returned status %s for user %s; expected %s." % (view_name, resp.status_code, user, success_status))
-                    # self.assertRedirects(resp, settings.LOGIN_URL+"?next="+url, target_status_code=302,
-                    #                      msg_prefix="Error while confirming that %s can't view %s: " % (user, view_name))
+    views_tested = set()
+    for view in views:
+        for url in view['urls']:
+            view_name = url[0]
+            opts = url[1] if len(url)>1 else {}
+            views_tested.add(view_name)
+            url = reverse(view_name, kwargs=opts.get('kwargs', None))
+            success_status = opts.get('success_status', 200)
+            success_test = opts.get('success_test', None)
 
-        # make sure that all ^manage/ views were tested
-        for urlpattern in urlpatterns:
+            # try while logged out
+            client.logout()
+            resp = client.get(url)
 
-            # Things that are no longer needed and have become redirects or other special cases
-            excluded_names = ['create_link_with_org',
-                              'link_browser',
-                              'user_management_resend_activation']
+            assert resp.status_code == 302
+            assert resp['Location'] == f"{reverse('user_management_limited_login')}?next={url}"
 
-            if urlpattern.pattern._regex.startswith(r'^manage/') and urlpattern.pattern._regex != '^manage/?$' and urlpattern.name not in excluded_names:
-                self.assertTrue(urlpattern.name in views_tested,
-                                "Permissions not checked for view '%s' -- add to 'views' or 'any_user_allowed'." % urlpattern.name)
+            # try with valid users
+            for user in view['allowed']:
+                client.force_login(user)
+                resp = client.get(url, secure=True)
+                if success_test:
+                    success_test(resp)
+                else:
+                    assert resp.status_code == success_status, \
+                        "View %s returned status %s for user %s; expected %s." % (view_name, resp.status_code, user, success_status)
+
+            # try with invalid users
+            for user in view.get('disallowed', all_users - view['allowed']):
+                client.force_login(user)
+                resp = client.get(url)
+                assert resp.status_code == 403, \
+                    "View %s returned status %s for user %s; expected %s." % (view_name, resp.status_code, user, success_status)
+
+    # make sure that all ^manage/ views were tested
+    for urlpattern in urlpatterns:
+
+        # Things that are no longer needed and have become redirects or other special cases
+        excluded_names = ['create_link_with_org',
+                          'link_browser',
+                          'user_management_resend_activation']
+
+        if urlpattern.pattern._regex.startswith(r'^manage/') and urlpattern.pattern._regex != '^manage/?$' and urlpattern.name not in excluded_names:
+            assert urlpattern.name in views_tested, \
+                "Permissions not checked for view '%s' -- add to 'views' or 'any_user_allowed'." % urlpattern.name

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -227,7 +227,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.get('user_management_manage_single_registrar',
                  user=self.registrar_user,
                  reverse_kwargs={'args': [self.unrelated_registrar.pk]},
-                 require_status_code=404)
+                 require_status_code=403)
 
     def test_admin_can_approve_pending_registrar(self):
         self.submit_form('user_management_approve_pending_registrar',
@@ -538,13 +538,13 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.get('user_management_manage_single_organization',
                  user=self.registrar_user,
                  reverse_kwargs={'args': [self.unrelated_organization.pk]},
-                 require_status_code=404)
+                 require_status_code=403)
 
     def test_org_user_cannot_update_unrelated_organization(self):
         self.get('user_management_manage_single_organization',
                  user=self.organization_user,
                  reverse_kwargs={'args': [self.unrelated_organization.pk]},
-                 require_status_code=404)
+                 require_status_code=403)
 
     def _delete_organization(self, user, should_succeed=True):
         if should_succeed:
@@ -833,14 +833,14 @@ class UserManagementViewsTestCase(PermaTestCase):
         # User from another registrar's org fails
         self.get('user_management_manage_single_organization_user',
                   reverse_kwargs={'args': [self.another_unrelated_organization_user.pk]},
-                  require_status_code=404)
+                  require_status_code=403)
         # Repeat with the other registrar, to confirm we're
         # getting 404s because of permission reasons, not because the
         # test fixtures are broken.
         self.log_in_user(self.unrelated_registrar_user)
         self.get('user_management_manage_single_organization_user',
                   reverse_kwargs={'args': [self.organization_user.pk]},
-                  require_status_code=404)
+                  require_status_code=403)
         self.get('user_management_manage_single_organization_user',
                   reverse_kwargs={'args': [self.another_unrelated_organization_user.pk]})
 
@@ -855,15 +855,13 @@ class UserManagementViewsTestCase(PermaTestCase):
         # User from another org fails
         self.get('user_management_manage_single_organization_user',
                   reverse_kwargs={'args': [self.pk_from_email(org_two_users[0])]},
-                  require_status_code=404)
-        # Repeat in reverse, to confirm we're
-        # getting 404s because of permission reasons, not because the
-        # test fixtures are broken.
+                  require_status_code=403)
+
+        # Repeat with another org
         self.log_in_user(org_two_users[1])
         self.get('user_management_manage_single_organization_user',
                   reverse_kwargs={'args': [self.pk_from_email(org_one_users[1])]},
-                  require_status_code=404)
-        # User from another org fails
+                  require_status_code=403)
         self.get('user_management_manage_single_organization_user',
                   reverse_kwargs={'args': [self.pk_from_email(org_two_users[0])]})
 


### PR DESCRIPTION
I set out to convert `test_permissions.py` to pytest format, and to remove its dependency on our legacy JSON test fixtures, swapping in our pytest test fixtures instead.

I did that, but it got a little more complicated 😅.

This test module loads (nearly) every page in the app, as all our different kinds of users, and makes sure people have permission to see everything they should be able to see, and can't see anything else.

But, it turns out that the original code doesn't test every combination: it does _not_ test what happens if registrar users visit pages associated with other registrars. 

Switching to the pytest fixtures called that to attention: the original fixtures were carefully crafted so that the sponsorship and org being tested were associated with the same registrar, whereas the pytest fixtures don't do this by default. Instead of more carefully invoking the pytest fixtures to recreate that situation, I instead decided to, instead, include the missing combinations.

That revealed that we have been handling a lack of permission differently, on different pages here. While it's true that sometimes, if a user should not have access to a particular page, you might want to return 404 instead of 403 to prevent them from discovered something they shouldn't know... in this case, we were returning 403 when a user categorically couldn't see a page (for instance, if a regular user tried to visit a registrar-only page), but at the same time, we were _sometimes_ returning 404 when a user should visit _some_ pages of a particular kind, but not others (for instance, if a registrar user tried to view a page associated with a different registrar)... but not always.

This PR makes the behavior of all the pages consistent: 404 means something legitimately does not exist, 403 means you aren't allowed to see it. I did that because... that was the easiest way to get the tests passing lol!!! If we want something different or more nuanced, I propose we handle it in a separate PR.

