### PR TITLE
fix org user expiry bug

### DIFF
--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -32,7 +32,7 @@
         {% for aff in affiliations %}
           <div class="settings-block">
             <p>{{ aff.organization.name }}</p>
-            <button name="org" value="{{ aff.id }}" class="btn btn-default btn-xs leave-org-btn" data-toggle="tooltip">Remove</button>
+            <button name="affiliation" value="{{ aff.id }}" class="btn btn-default btn-xs leave-org-btn" data-toggle="tooltip">Remove</button>
             {% if aff.expires_at %}
               <br><p>Expiration date: {{ aff.expires_at }}</p>
             {% endif %}

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -17,7 +17,7 @@ from django.db import IntegrityError
 from django.test import override_settings
 
 from perma.exceptions import PermaPaymentsCommunicationException
-from perma.models import LinkUser, Organization, Registrar, Sponsorship
+from perma.models import LinkUser, Organization, Registrar, Sponsorship, UserOrganizationAffiliation
 from perma.tests.utils import PermaTestCase
 
 # Fixtures
@@ -86,6 +86,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         cls.unrelated_registrar = Registrar.objects.get(pk=2)
         cls.unrelated_registrar_user = cls.unrelated_registrar.users.first()
         cls.organization = Organization.objects.get(pk=1)
+        cls.user_organization_affiliation = UserOrganizationAffiliation.objects.get(pk=1)
         cls.organization_user = cls.organization.users.first()
         cls.another_organization = Organization.objects.get(pk=2)
         cls.unrelated_organization = cls.unrelated_registrar.organizations.first()
@@ -870,10 +871,10 @@ class UserManagementViewsTestCase(PermaTestCase):
     def test_can_remove_user_from_organization(self):
         self.log_in_user(self.registrar_user)
         self.submit_form('user_management_manage_single_organization_user_remove',
-                         data={'org': self.organization.pk},
+                         data={'affiliation': self.user_organization_affiliation.pk},
                          reverse_kwargs={'args': [self.organization_user.pk]},
                          success_url=reverse('user_management_manage_organization_user'))
-        self.assertFalse(self.organization_user.organizations.filter(pk=self.organization.pk).exists())
+        self.assertFalse(self.organization_user.organizations.filter(pk=self.user_organization_affiliation.pk).exists())
 
     def test_registrar_cannot_remove_unrelated_user_from_organization(self):
         self.log_in_user(self.registrar_user)
@@ -892,10 +893,10 @@ class UserManagementViewsTestCase(PermaTestCase):
     def test_can_remove_self_from_organization(self):
         self.log_in_user(self.organization_user)
         self.submit_form('user_management_manage_single_organization_user_remove',
-                         data={'org': self.organization.pk},
+                         data={'affiliation': self.user_organization_affiliation.pk},
                          reverse_kwargs={'args': [self.organization_user.pk]},
                          success_url=reverse('create_link'))
-        self.assertFalse(self.organization_user.organizations.filter(pk=self.organization.pk).exists())
+        self.assertFalse(self.organization_user.organizations.filter(pk=self.user_organization_affiliation.pk).exists())
 
     ### ADDING NEW USERS TO REGISTRARS AS SPONSORED USERS ###
 

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -976,8 +976,7 @@ def manage_single_organization_user_remove(request, user_id):
 
     if request.method == 'POST':
         affiliation = get_object_or_404(UserOrganizationAffiliation, id=request.POST.get('affiliation'))
-        org = get_object_or_404(Organization, id=affiliation.organization_id)
-        if not request.user.can_edit_organization(org):
+        if not request.user.can_edit_organization(affiliation.organization):
             return HttpResponseForbidden()
 
         affiliation.delete()

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -975,12 +975,12 @@ def manage_single_organization_user_remove(request, user_id):
         return HttpResponseForbidden()
 
     if request.method == 'POST':
-        affiliation = UserOrganizationAffiliation.objects.filter(id=request.POST.get('org')).values('organization_id').first()
-        org = get_object_or_404(Organization, id=affiliation['organization_id'])
+        affiliation = get_object_or_404(UserOrganizationAffiliation, id=request.POST.get('affiliation'))
+        org = get_object_or_404(Organization, id=affiliation.organization_id)
         if not request.user.can_edit_organization(org):
             return HttpResponseForbidden()
 
-        UserOrganizationAffiliation.objects.filter(id=request.POST.get('org')).delete()
+        affiliation.delete()
 
         # special case -- user demoted themselves, can't see page anymore
         if request.user == target_user and not target_user.organizations.exists():

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -975,11 +975,12 @@ def manage_single_organization_user_remove(request, user_id):
         return HttpResponseForbidden()
 
     if request.method == 'POST':
-        org = get_object_or_404(Organization, id=request.POST.get('org'))
+        affiliation = UserOrganizationAffiliation.objects.filter(id=request.POST.get('org')).values('organization_id').first()
+        org = get_object_or_404(Organization, id=affiliation['organization_id'])
         if not request.user.can_edit_organization(org):
             return HttpResponseForbidden()
 
-        target_user.organizations.remove(org)
+        UserOrganizationAffiliation.objects.filter(id=request.POST.get('org')).delete()
 
         # special case -- user demoted themselves, can't see page anymore
         if request.user == target_user and not target_user.organizations.exists():


### PR DESCRIPTION
To reproduce, navigate to `/manage/organization-users/<user_id>`, click `remove`. The page errors with 404. 

<img width="892" alt="image" src="https://github.com/user-attachments/assets/4c28b48f-e6bf-4af3-880c-e620d42792a8">

The fix is to grab the affiliation id coming from the post request of the view and delete the affiliation. Previously the affiliation id was being used to query the organizations. I also renamed the `org` field in the template to represent the value it carries more accurately. 

