### PR TITLE
Separate sign-up views into their own module

### DIFF
--- a/perma_web/perma/templates/user_management/manage_registrars.html
+++ b/perma_web/perma/templates/user_management/manage_registrars.html
@@ -116,7 +116,7 @@
           <h4 class="item-title" id="registrar-{{ registrar.id }}" tabindex="-1">
             {{ registrar.name }}
             {% if registrar.status == "pending" %}
-              <a class="text-warning" href="{% url 'user_management_approve_pending_registrar' registrar.id %}"> needs approval</a>
+              <a class="text-warning" href="{% url 'user_sign_up_approve_pending_registrar' registrar.id %}"> needs approval</a>
             {% endif %}
           </h4>
           <div class="item-subtitle">{{ registrar.email }}</div>
@@ -158,7 +158,7 @@
           <div>
             <div class="itlem-status">
               {% if registrar.status != "approved" %}
-                <a class="action action-approve" href="{% url 'user_management_approve_pending_registrar' registrar.id %}">
+                <a class="action action-approve" href="{% url 'user_sign_up_approve_pending_registrar' registrar.id %}">
                   {% if registrar.status == "pending" %}
                     Review and approve <span class="sr-only">{{ registrar.name }}</span>
                   {% else %}

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -50,7 +50,7 @@ def test_permissions(client, admin_user, registrar_user, org_user, link_user_fac
                 ['user_management_manage_single_registrar_user', {'kwargs':{'user_id': registrar_user.id}}],
                 ['user_management_manage_single_registrar_user_delete', {'kwargs':{'user_id': registrar_user.id}}],
                 ['user_management_manage_single_registrar_user_reactivate', {'kwargs':{'user_id': registrar_user.id}}],
-                ['user_management_approve_pending_registrar', {'kwargs':{'registrar_id': pending_registrar.id}}],
+                ['user_sign_up_approve_pending_registrar', {'kwargs':{'registrar_id': pending_registrar.id}}],
                 ['user_management_manage_user'],
                 ['user_management_user_add_user'],
                 ['user_management_manage_single_user', {'kwargs':{'user_id': regular_user.id}}],

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -230,7 +230,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                  require_status_code=403)
 
     def test_admin_can_approve_pending_registrar(self):
-        self.submit_form('user_management_approve_pending_registrar',
+        self.submit_form('user_sign_up_approve_pending_registrar',
                          user=self.admin_user,
                          data={'status':'approved'},
                          reverse_kwargs={'args': [self.pending_registrar.pk]},
@@ -238,7 +238,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                                                                 status="approved").exists())
 
     def test_admin_can_deny_pending_registrar(self):
-        self.submit_form('user_management_approve_pending_registrar',
+        self.submit_form('user_sign_up_approve_pending_registrar',
                          user=self.admin_user,
                          data={'status': 'denied'},
                          reverse_kwargs={'args': [self.pending_registrar.pk]},
@@ -1912,7 +1912,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.assertIn(user['raw_email'], message.body)
 
         id = Registrar.objects.get(email=new_lib['email']).id
-        approve_url = "http://testserver{}".format(reverse('user_management_approve_pending_registrar', args=[id]))
+        approve_url = "http://testserver{}".format(reverse('user_sign_up_approve_pending_registrar', args=[id]))
         self.assertIn(approve_url, message.body)
         self.assertEqual(message.subject, "Perma.cc new library registrar account request")
         self.assertEqual(message.from_email, our_address)

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -9,7 +9,18 @@ from django.views.generic import RedirectView
 
 from perma.views.user_management import AddUserToOrganization, AddUserToRegistrar, AddSponsoredUserToRegistrar, AddUserToAdmin, AddRegularUser
 from .views.common import DirectTemplateView
-from .views import (admin_stats, common, contact, link_management, memento, playback, user_settings, service, user_management)
+from .views import (
+    admin_stats,
+    common,
+    contact,
+    link_management,
+    memento,
+    playback,
+    user_settings,
+    service,
+    user_management,
+    user_sign_up,
+)
 from .forms import SetPasswordForm
 
 # between 9/5/2013 and 11/13/2014,
@@ -53,15 +64,15 @@ urlpatterns = [
     # Users with old-style activation links should get redirected so they can generate a new one
     re_path(r'^register/password/(?P<token>.*)/?$', user_management.redirect_to_reset, name='redirect_to_reset'),
 
-    re_path(r'^sign-up/?$', user_management.sign_up, name='sign_up'),
-    re_path(r'^sign-up/courts/?$', user_management.sign_up_courts, name='sign_up_courts'),
-    re_path(r'^sign-up/firms/?$', user_management.sign_up_firm, name='sign_up_firm'),
-    re_path(r'^libraries/?$', user_management.libraries, name='libraries'),
+    re_path(r'^sign-up/?$', user_sign_up.sign_up, name='sign_up'),
+    re_path(r'^sign-up/courts/?$', user_sign_up.sign_up_courts, name='sign_up_courts'),
+    re_path(r'^sign-up/firms/?$', user_sign_up.sign_up_firm, name='sign_up_firm'),
+    re_path(r'^libraries/?$', user_sign_up.libraries, name='libraries'),
+    re_path(r'^register/email/?$', user_sign_up.register_email_instructions, name='register_email_instructions'),
+    re_path(r'^register/library/?$', user_sign_up.register_library_instructions, name='register_library_instructions'),
+    re_path(r'^register/court/?$', user_sign_up.court_request_response, name='court_request_response'),
+    re_path(r'^register/firm/?$', user_sign_up.firm_request_response, name='firm_request_response'),
 
-    re_path(r'^register/email/?$', user_management.register_email_instructions, name='register_email_instructions'),
-    re_path(r'^register/library/?$', user_management.register_library_instructions, name='register_library_instructions'),
-    re_path(r'^register/court/?$', user_management.court_request_response, name='court_request_response'),
-    re_path(r'^register/firm/?$', user_management.firm_request_response, name='firm_request_response'),
     re_path(r'^password/change/?$', auth_views.PasswordChangeView.as_view(template_name='registration/password_change_form.html'), name='password_change'),
     re_path(r'^password/change/done/?$', auth_views.PasswordChangeDoneView.as_view(template_name='registration/password_change_done.html'), name='password_change_done'),
     re_path(r'^password/reset/?$', user_management.reset_password, name='password_reset'),
@@ -102,7 +113,7 @@ urlpatterns = [
 
     re_path(r'^manage/registrars/?$', user_management.manage_registrar, name='user_management_manage_registrar'),
     re_path(r'^manage/registrars/(?P<registrar_id>\d+)/?$', user_management.manage_single_registrar, name='user_management_manage_single_registrar'),
-    re_path(r'^manage/registrars/approve/(?P<registrar_id>\d+)/?$', user_management.approve_pending_registrar, name='user_management_approve_pending_registrar'),
+    re_path(r'^manage/registrars/approve/(?P<registrar_id>\d+)/?$', user_sign_up.approve_pending_registrar, name='user_sign_up_approve_pending_registrar'),
 
     re_path(r'^manage/organizations/?$', user_management.manage_organization, name='user_management_manage_organization'),
     re_path(r'^manage/organizations/(?P<org_id>\d+)/?$', user_management.manage_single_organization, name='user_management_manage_single_organization'),

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1,68 +1,66 @@
 import csv
 import logging
-import re
 from typing import Literal
 
-from django.core.exceptions import PermissionDenied
-from django.views.decorators.cache import never_cache
-from django.views.decorators.debug import sensitive_post_parameters
-
-
-from ratelimit.decorators import ratelimit
-
-from django.views.generic import UpdateView
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.contrib.auth import views as auth_views
-from django.contrib.auth.tokens import default_token_generator
-from django.db import transaction
+from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
+from django.core.exceptions import PermissionDenied
 from django.db.models import Count, F, Max, Sum
 from django.db.models.functions import Coalesce, Greatest
 from django.db.models.manager import BaseManager
-from django.utils.decorators import method_decorator
-from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
 from django.http import (
+    Http404,
     HttpRequest,
     HttpResponse,
-    HttpResponseBadRequest,
-    HttpResponseRedirect,
-    Http404,
     HttpResponseForbidden,
+    HttpResponseRedirect,
     JsonResponse,
 )
-
 from django.shortcuts import get_object_or_404, render
-from django.urls import reverse, reverse_lazy
 from django.template.context_processors import csrf
-from django.contrib import messages
+from django.urls import reverse, reverse_lazy
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+from django.views.decorators.debug import sensitive_post_parameters
+from django.views.generic import UpdateView
+from ratelimit.decorators import ratelimit
 
+from perma.email import send_user_email
 from perma.forms import (
-    check_honeypot,
-    RegistrarForm,
-    LibraryRegistrarForm,
-    OrganizationWithRegistrarForm,
     OrganizationForm,
-    FirmOrganizationForm,
-    FirmUsageForm,
-    UserForm,
-    UserFormWithRegistrar,
-    UserFormWithSponsoringRegistrar,
-    UserFormWithOrganization,
-    CreateUserFormWithCourt,
-    CreateUserFormWithFirm,
+    OrganizationWithRegistrarForm,
+    RegistrarForm,
+    UserAddAdminForm,
+    UserAddOrganizationForm,
     UserAddRegistrarForm,
     UserAddSponsoringRegistrarForm,
-    UserAddOrganizationForm,
+    UserForm,
     UserFormWithAdmin,
-    UserAddAdminForm,
+    UserFormWithOrganization,
+    UserFormWithRegistrar,
+    UserFormWithSponsoringRegistrar,
 )
-from perma.models import Registrar, LinkUser, Organization, Link, Sponsorship, Folder, UserOrganizationAffiliation
-from perma.utils import (apply_search_query, apply_pagination, apply_sort_order, get_form_data,
-    ratelimit_ip_key, user_passes_test_or_403)
-from perma.email import send_admin_email, send_user_email
-
+from perma.models import (
+    Folder,
+    Link,
+    LinkUser,
+    Organization,
+    Registrar,
+    Sponsorship,
+    UserOrganizationAffiliation,
+)
+from perma.utils import (
+    apply_pagination,
+    apply_search_query,
+    apply_sort_order,
+    get_form_data,
+    ratelimit_ip_key,
+    user_passes_test_or_403,
+)
+from perma.views.user_sign_up import email_new_user
 
 logger = logging.getLogger(__name__)
 valid_member_sorts = ['last_name', '-last_name', 'date_joined', '-date_joined', 'last_login', '-last_login', 'link_count', '-link_count']
@@ -173,39 +171,6 @@ def manage_single_registrar(request, registrar_id):
         'this_page': 'users_registrars',
         'form': form
     })
-
-@user_passes_test_or_403(lambda user: user.is_staff)
-def approve_pending_registrar(request, registrar_id):
-    """ Perma admins can approve account requests from libraries """
-
-    target_registrar = get_object_or_404(Registrar, id=registrar_id)
-    target_registrar_user = target_registrar.pending_users.first()
-
-    if request.method == 'POST':
-
-        with transaction.atomic():
-
-            new_status = request.POST.get("status")
-            if new_status in ["approved", "denied"]:
-                target_registrar.status = new_status
-                target_registrar.save()
-
-                if new_status == "approved":
-                    target_registrar_user.registrar = target_registrar
-                    target_registrar_user.pending_registrar = None
-                    target_registrar_user.save()
-                    email_approved_registrar_user(request, target_registrar_user)
-
-                    messages.add_message(request, messages.SUCCESS, f'<h4>Registrar approved!</h4> <strong>{target_registrar_user.email}</strong> will receive a notification email with further instructions.', extra_tags='safe')
-                else:
-                    messages.add_message(request, messages.SUCCESS, f'Registrar request for <strong>{target_registrar}</strong> denied. Please inform {target_registrar_user.email} if appropriate.', extra_tags='safe')
-
-        return HttpResponseRedirect(reverse('user_management_manage_registrar'))
-
-    return render(request, 'user_management/approve_pending_registrar.html', {
-        'target_registrar': target_registrar,
-        'target_registrar_user': target_registrar_user,
-        'this_page': 'users_registrars'})
 
 
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user() or user.is_organization_user)
@@ -1245,392 +1210,3 @@ def redirect_to_reset(request, token):
         request a new-style activation link.
     """
     return HttpResponseRedirect(reverse('password_reset_confirm', args=['0', token]))
-
-
-@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
-def libraries(request):
-    """
-    Info for libraries, allow them to request accounts
-    """
-    if request.method == 'POST':
-
-        if something_took_the_bait := check_honeypot(request, 'register_library_instructions', 'a-telephone', check_js=True):
-            return something_took_the_bait
-
-        registrar_form = LibraryRegistrarForm(request.POST, request.FILES, prefix ="b")
-        if request.user.is_authenticated:
-            user_form = None
-        else:
-            user_form = UserForm(request.POST, prefix = "a")
-            user_form.fields['email'].label = "Your email"
-        user_email = request.POST.get('a-e-address', '').lower()
-        try:
-            target_user = LinkUser.objects.get(email=user_email)
-        except LinkUser.DoesNotExist:
-            target_user = None
-        if target_user:
-            messages.add_message(request, messages.INFO, "You already have a Perma account, please sign in to request an account for your library.")
-            request.session['request_data'] = registrar_form.data
-            return HttpResponseRedirect('/login?next=/libraries/')
-
-        # test if both form objects that comprise the signup form are valid
-        if user_form:
-            form_is_valid = user_form.is_valid() and registrar_form.is_valid()
-        else:
-            form_is_valid = registrar_form.is_valid()
-        if form_is_valid:
-            new_registrar = registrar_form.save()
-            email_registrar_request(request, new_registrar)
-            if user_form:
-                new_user = user_form.save(commit=False)
-                new_user.pending_registrar = new_registrar
-                new_user.save()
-                email_pending_registrar_user(request, new_user)
-                return HttpResponseRedirect(reverse('register_library_instructions'))
-            else:
-                request.user.pending_registrar = new_registrar
-                request.user.save()
-                return HttpResponseRedirect(reverse('settings_affiliations'))
-    else:
-        request_data = request.session.get('request_data','')
-        user_form = None
-        if not request.user.is_authenticated:
-            user_form = UserForm(prefix="a")
-            user_form.fields['email'].label = "Your email"
-        if request_data:
-            registrar_form = LibraryRegistrarForm(request_data, prefix="b")
-        else:
-            registrar_form = LibraryRegistrarForm(prefix="b")
-
-    return render(request, "registration/sign-up-libraries.html",
-        {'user_form':user_form, 'registrar_form':registrar_form})
-
-@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
-def sign_up(request):
-    """
-    Register a new user
-    """
-    if request.method == 'POST':
-
-        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
-            return something_took_the_bait
-
-        form = UserForm(request.POST)
-        if form.is_valid():
-            new_user = form.save()
-            email_new_user(request, new_user)
-            return HttpResponseRedirect(reverse('register_email_instructions'))
-    else:
-        form = UserForm()
-
-    return render(request, "registration/sign-up.html", {'form': form})
-
-
-@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
-def sign_up_courts(request):
-    """
-    Register a new court user
-    """
-    if request.method == 'POST':
-
-        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
-            return something_took_the_bait
-
-        form = CreateUserFormWithCourt(request.POST)
-        submitted_email = request.POST.get('e-address', '').lower()
-
-        try:
-            target_user = LinkUser.objects.get(email=submitted_email)
-        except LinkUser.DoesNotExist:
-            target_user = None
-
-        if target_user:
-            requested_account_note = request.POST.get('requested_account_note', None)
-            target_user.requested_account_type = 'court'
-            target_user.requested_account_note = requested_account_note
-            target_user.save()
-            email_court_request(request, target_user)
-            return HttpResponseRedirect(reverse('court_request_response'))
-
-        if form.is_valid():
-            new_user = form.save(commit=False)
-            new_user.requested_account_type = 'court'
-            create_account = request.POST.get('create_account', None)
-            if create_account:
-                new_user.save()
-                email_new_user(request, new_user)
-                email_court_request(request, new_user)
-                messages.add_message(request, messages.INFO, "We will shortly follow up with more information about how Perma.cc could work in your court.")
-                return HttpResponseRedirect(reverse('register_email_instructions'))
-            else:
-                email_court_request(request, new_user)
-                return HttpResponseRedirect(reverse('court_request_response'))
-
-    else:
-        form = CreateUserFormWithCourt()
-
-    return render(request, "registration/sign-up-courts.html", {'form': form})
-
-
-@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
-def sign_up_firm(request):
-    """
-    Register a new law firm user
-    """
-    if request.method == 'POST':
-
-        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
-            return something_took_the_bait
-
-        user_form = CreateUserFormWithFirm(request.POST)
-        user_email = request.POST.get('e-address', '').lower()
-
-        try:
-            existing_user = LinkUser.objects.get(email=user_email)
-        except LinkUser.DoesNotExist:
-            existing_user = None
-
-        # If user email in form matches an existing user in database, update user record to include
-        # organization name under `LinkUser.requested_account_note` field
-        if existing_user is not None:
-            organization_name = request.POST.get('name', None)
-            existing_user.requested_account_type = 'firm'
-            existing_user.requested_account_note = organization_name
-            existing_user.save()
-            email_firm_request(request, existing_user)
-            return HttpResponseRedirect(reverse('firm_request_response'))
-
-        # Otherwise, validate the user form, create a new user account (if requested), and email a
-        # firm request to Perma administrators
-        elif user_form.is_valid():
-            new_user = user_form.save(commit=False)
-            new_user.requested_account_type = 'firm'
-            create_account = request.POST.get('create_account', None)
-            if create_account:
-                new_user.save()
-                email_new_user(request, new_user)
-                email_firm_request(request, new_user)
-                messages.add_message(
-                    request,
-                    messages.INFO,
-                    'We will shortly follow up with more information about how Perma.cc could work in your organization.',
-                )
-                return HttpResponseRedirect(reverse('register_email_instructions'))
-            else:
-                email_firm_request(request, new_user)
-                return HttpResponseRedirect(reverse('firm_request_response'))
-
-        else:
-            organization_form = FirmOrganizationForm()
-            usage_form = FirmUsageForm()
-
-    else:
-        user_form = CreateUserFormWithFirm()
-        organization_form = FirmOrganizationForm()
-        usage_form = FirmUsageForm()
-
-    return render(
-        request,
-        'registration/sign-up-firms.html',
-        {
-            'user_form': user_form,
-            'organization_form': organization_form,
-            'usage_form': usage_form,
-        },
-    )
-
-
-def register_email_instructions(request):
-    """
-    After the user has registered, give the instructions for confirming
-    """
-    return render(request, 'registration/check_email.html')
-
-
-def register_library_instructions(request):
-    """
-    After the user requested a library account, give instructions
-    """
-    return render(request, 'registration/check_email_library.html')
-
-
-def court_request_response(request):
-    """
-    After the user has requested info about a court account
-    """
-    return render(request, 'registration/court_request.html')
-
-def firm_request_response(request):
-    """
-    After the user has requested info about a firm account
-    """
-    return render(request, 'registration/firm_request.html')
-
-
-def suggest_registrars(user: LinkUser, limit: int = 5) -> BaseManager[Registrar]:
-    """Suggest potential registrars for a user based on email domain.
-
-    This queries the database for registrars whose website matches the
-    base domain from the user's email address. For example, if the
-    user's email is `username@law.harvard.edu`, this will suggest
-    registrars whose domains end with `harvard.edu`.
-    """
-    _, email_domain = user.email.split('@')
-    base_domain = '.'.join(email_domain.rsplit('.', 2)[-2:])
-    pattern = f'^https?://([a-zA-Z0-9\\-\\.]+\\.)?{re.escape(base_domain)}(/.*)?$'
-    registrars = (
-        Registrar.objects.exclude(status='pending')
-        .filter(website__iregex=pattern)
-        .order_by('-link_count', 'name')[:limit]
-    )
-    return registrars
-
-
-def email_new_user(request, user, template='email/new_user.txt', context=None):
-    """
-    Send email to newly created accounts
-    """
-    # This uses the forgot-password flow; logic is borrowed from auth_forms.PasswordResetForm.save()
-    activation_route = request.build_absolute_uri(reverse('password_reset_confirm', args=[
-        urlsafe_base64_encode(force_bytes(user.pk)),
-        default_token_generator.make_token(user),
-    ]))
-
-    # Include context variables
-    template_is_default = template == 'email/new_user.txt'
-    context = context if context is not None else {}
-    context.update(
-        {
-            'activation_expires': settings.PASSWORD_RESET_TIMEOUT,
-            'activation_route': activation_route,
-            'request': request,
-            # Only query DB if we're using the default template; otherwise there's no need
-            'suggested_registrars': suggest_registrars(user) if template_is_default else [],
-        }
-    )
-
-    send_user_email(
-        user.raw_email,
-        template,
-        context
-    )
-
-
-def email_pending_registrar_user(request, user):
-    """
-    Send email to newly created accounts for folks requesting library accounts
-    """
-    email_new_user(request, user, template='email/pending_registrar.txt')
-
-
-def email_registrar_request(request, pending_registrar):
-    """
-    Send email to Perma.cc admins when a library requests an account
-    """
-    host = request.get_host()
-    try:
-        email = request.user.raw_email
-    except AttributeError:
-        # User did not have an account
-        email = request.POST.get('a-e-address')
-
-    send_admin_email(
-        "Perma.cc new library registrar account request",
-        email,
-        request,
-        'email/admin/registrar_request.txt',
-        {
-            "name": pending_registrar.name,
-            "email": pending_registrar.email,
-            "requested_by_email": email,
-            "host": host,
-            "confirmation_route": reverse('user_management_approve_pending_registrar', args=[pending_registrar.id])
-        }
-    )
-
-
-def email_approved_registrar_user(request, user):
-    """
-    Send email to newly approved registrar accounts for folks requesting library accounts
-    """
-    host = request.get_host()
-    send_user_email(
-        user.raw_email,
-        "email/library_approved.txt",
-        {
-            "host": host,
-            "account_route": reverse('user_management_manage_organization')
-        }
-    )
-
-
-def email_court_request(request, user):
-    """
-    Send email to Perma.cc admins when a court requests an account
-    """
-    try:
-        target_user = LinkUser.objects.get(email=user.email)
-    except LinkUser.DoesNotExist:
-        target_user = None
-    send_admin_email(
-        "Perma.cc new library court account information request",
-        user.raw_email,
-        request,
-        "email/admin/court_request.txt",
-        {
-            "first_name": user.first_name,
-            "last_name": user.last_name,
-            "court_name": user.requested_account_note,
-            "has_account": target_user,
-            "email": user.raw_email
-        }
-    )
-
-def email_firm_request(request: HttpRequest, user: LinkUser):
-    """
-    Send email to Perma.cc admins when a firm requests an account
-    """
-    organization_form = FirmOrganizationForm(request.POST)
-    usage_form = FirmUsageForm(request.POST)
-    user_form = CreateUserFormWithFirm(request.POST)
-
-    # Validate form values; this should rarely or never arise in practice, but the `cleaned_data`
-    # attribute is only populated after checking
-    if organization_form.errors or usage_form.errors:
-        return HttpResponseBadRequest('Form data contains validation errors')
-
-    try:
-        existing_user = LinkUser.objects.get(email=user_form.data['e-address'].casefold())
-    except LinkUser.DoesNotExist:
-        existing_user = None
-
-    send_admin_email(
-        'Perma.cc new law firm account information request',
-        user.raw_email,
-        request,
-        'email/admin/firm_request.txt',
-        {
-            'existing_user': existing_user,
-            'organization_form': organization_form,
-            'usage_form': usage_form,
-            'user_form': user_form,
-        },
-    )
-
-def email_premium_request(request, user):
-    """
-    Send email to Perma.cc admins when a user requests a premium account
-    """
-    send_admin_email(
-        "Perma.cc premium account request",
-        user.raw_email,
-        request,
-        "email/admin/premium_request.txt",
-        {
-            "first_name": user.first_name,
-            "last_name": user.last_name,
-            "email": user.raw_email
-        }
-    )
-
-

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -1,0 +1,472 @@
+import logging
+import re
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.tokens import default_token_generator
+from django.db import transaction
+from django.db.models.manager import BaseManager
+from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from ratelimit.decorators import ratelimit
+
+from perma.email import send_admin_email, send_user_email
+from perma.forms import (
+    CreateUserFormWithCourt,
+    CreateUserFormWithFirm,
+    FirmOrganizationForm,
+    FirmUsageForm,
+    LibraryRegistrarForm,
+    UserForm,
+    check_honeypot,
+)
+from perma.models import (
+    LinkUser,
+    Registrar,
+)
+from perma.utils import (
+    ratelimit_ip_key,
+    user_passes_test_or_403,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
+def libraries(request):
+    """
+    Info for libraries, allow them to request accounts
+    """
+    if request.method == 'POST':
+
+        if something_took_the_bait := check_honeypot(request, 'register_library_instructions', 'a-telephone', check_js=True):
+            return something_took_the_bait
+
+        registrar_form = LibraryRegistrarForm(request.POST, request.FILES, prefix ="b")
+        if request.user.is_authenticated:
+            user_form = None
+        else:
+            user_form = UserForm(request.POST, prefix = "a")
+            user_form.fields['email'].label = "Your email"
+        user_email = request.POST.get('a-e-address', '').lower()
+        try:
+            target_user = LinkUser.objects.get(email=user_email)
+        except LinkUser.DoesNotExist:
+            target_user = None
+        if target_user:
+            messages.add_message(request, messages.INFO, "You already have a Perma account, please sign in to request an account for your library.")
+            request.session['request_data'] = registrar_form.data
+            return HttpResponseRedirect('/login?next=/libraries/')
+
+        # test if both form objects that comprise the signup form are valid
+        if user_form:
+            form_is_valid = user_form.is_valid() and registrar_form.is_valid()
+        else:
+            form_is_valid = registrar_form.is_valid()
+        if form_is_valid:
+            new_registrar = registrar_form.save()
+            email_registrar_request(request, new_registrar)
+            if user_form:
+                new_user = user_form.save(commit=False)
+                new_user.pending_registrar = new_registrar
+                new_user.save()
+                email_pending_registrar_user(request, new_user)
+                return HttpResponseRedirect(reverse('register_library_instructions'))
+            else:
+                request.user.pending_registrar = new_registrar
+                request.user.save()
+                return HttpResponseRedirect(reverse('settings_affiliations'))
+    else:
+        request_data = request.session.get('request_data','')
+        user_form = None
+        if not request.user.is_authenticated:
+            user_form = UserForm(prefix="a")
+            user_form.fields['email'].label = "Your email"
+        if request_data:
+            registrar_form = LibraryRegistrarForm(request_data, prefix="b")
+        else:
+            registrar_form = LibraryRegistrarForm(prefix="b")
+
+    return render(request, "registration/sign-up-libraries.html",
+        {'user_form':user_form, 'registrar_form':registrar_form})
+
+@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
+def sign_up(request):
+    """
+    Register a new user
+    """
+    if request.method == 'POST':
+
+        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
+            return something_took_the_bait
+
+        form = UserForm(request.POST)
+        if form.is_valid():
+            new_user = form.save()
+            email_new_user(request, new_user)
+            return HttpResponseRedirect(reverse('register_email_instructions'))
+    else:
+        form = UserForm()
+
+    return render(request, "registration/sign-up.html", {'form': form})
+
+
+@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
+def sign_up_courts(request):
+    """
+    Register a new court user
+    """
+    if request.method == 'POST':
+
+        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
+            return something_took_the_bait
+
+        form = CreateUserFormWithCourt(request.POST)
+        submitted_email = request.POST.get('e-address', '').lower()
+
+        try:
+            target_user = LinkUser.objects.get(email=submitted_email)
+        except LinkUser.DoesNotExist:
+            target_user = None
+
+        if target_user:
+            requested_account_note = request.POST.get('requested_account_note', None)
+            target_user.requested_account_type = 'court'
+            target_user.requested_account_note = requested_account_note
+            target_user.save()
+            email_court_request(request, target_user)
+            return HttpResponseRedirect(reverse('court_request_response'))
+
+        if form.is_valid():
+            new_user = form.save(commit=False)
+            new_user.requested_account_type = 'court'
+            create_account = request.POST.get('create_account', None)
+            if create_account:
+                new_user.save()
+                email_new_user(request, new_user)
+                email_court_request(request, new_user)
+                messages.add_message(request, messages.INFO, "We will shortly follow up with more information about how Perma.cc could work in your court.")
+                return HttpResponseRedirect(reverse('register_email_instructions'))
+            else:
+                email_court_request(request, new_user)
+                return HttpResponseRedirect(reverse('court_request_response'))
+
+    else:
+        form = CreateUserFormWithCourt()
+
+    return render(request, "registration/sign-up-courts.html", {'form': form})
+
+
+@ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
+def sign_up_firm(request):
+    """
+    Register a new law firm user
+    """
+    if request.method == 'POST':
+
+        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
+            return something_took_the_bait
+
+        user_form = CreateUserFormWithFirm(request.POST)
+        user_email = request.POST.get('e-address', '').lower()
+
+        try:
+            existing_user = LinkUser.objects.get(email=user_email)
+        except LinkUser.DoesNotExist:
+            existing_user = None
+
+        # If user email in form matches an existing user in database, update user record to include
+        # organization name under `LinkUser.requested_account_note` field
+        if existing_user is not None:
+            organization_name = request.POST.get('name', None)
+            existing_user.requested_account_type = 'firm'
+            existing_user.requested_account_note = organization_name
+            existing_user.save()
+            email_firm_request(request, existing_user)
+            return HttpResponseRedirect(reverse('firm_request_response'))
+
+        # Otherwise, validate the user form, create a new user account (if requested), and email a
+        # firm request to Perma administrators
+        elif user_form.is_valid():
+            new_user = user_form.save(commit=False)
+            new_user.requested_account_type = 'firm'
+            create_account = request.POST.get('create_account', None)
+            if create_account:
+                new_user.save()
+                email_new_user(request, new_user)
+                email_firm_request(request, new_user)
+                messages.add_message(
+                    request,
+                    messages.INFO,
+                    'We will shortly follow up with more information about how Perma.cc could work in your organization.',
+                )
+                return HttpResponseRedirect(reverse('register_email_instructions'))
+            else:
+                email_firm_request(request, new_user)
+                return HttpResponseRedirect(reverse('firm_request_response'))
+
+        else:
+            organization_form = FirmOrganizationForm()
+            usage_form = FirmUsageForm()
+
+    else:
+        user_form = CreateUserFormWithFirm()
+        organization_form = FirmOrganizationForm()
+        usage_form = FirmUsageForm()
+
+    return render(
+        request,
+        'registration/sign-up-firms.html',
+        {
+            'user_form': user_form,
+            'organization_form': organization_form,
+            'usage_form': usage_form,
+        },
+    )
+
+
+@user_passes_test_or_403(lambda user: user.is_staff)
+def approve_pending_registrar(request, registrar_id):
+    """Perma admins can approve account requests from libraries"""
+
+    target_registrar = get_object_or_404(Registrar, id=registrar_id)
+    target_registrar_user = target_registrar.pending_users.first()
+
+    if request.method == 'POST':
+        with transaction.atomic():
+            new_status = request.POST.get('status')
+            if new_status in ['approved', 'denied']:
+                target_registrar.status = new_status
+                target_registrar.save()
+
+                if new_status == 'approved':
+                    target_registrar_user.registrar = target_registrar
+                    target_registrar_user.pending_registrar = None
+                    target_registrar_user.save()
+                    email_approved_registrar_user(request, target_registrar_user)
+
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f'<h4>Registrar approved!</h4> <strong>{target_registrar_user.email}</strong> will receive a notification email with further instructions.',
+                        extra_tags='safe',
+                    )
+                else:
+                    messages.add_message(
+                        request,
+                        messages.SUCCESS,
+                        f'Registrar request for <strong>{target_registrar}</strong> denied. Please inform {target_registrar_user.email} if appropriate.',
+                        extra_tags='safe',
+                    )
+
+        return HttpResponseRedirect(reverse('user_management_manage_registrar'))
+
+    return render(
+        request,
+        'user_management/approve_pending_registrar.html',
+        {
+            'target_registrar': target_registrar,
+            'target_registrar_user': target_registrar_user,
+            'this_page': 'users_registrars',
+        },
+    )
+
+
+def register_email_instructions(request):
+    """
+    After the user has registered, give the instructions for confirming
+    """
+    return render(request, 'registration/check_email.html')
+
+
+def register_library_instructions(request):
+    """
+    After the user requested a library account, give instructions
+    """
+    return render(request, 'registration/check_email_library.html')
+
+
+def court_request_response(request):
+    """
+    After the user has requested info about a court account
+    """
+    return render(request, 'registration/court_request.html')
+
+
+def firm_request_response(request):
+    """
+    After the user has requested info about a firm account
+    """
+    return render(request, 'registration/firm_request.html')
+
+
+def suggest_registrars(user: LinkUser, limit: int = 5) -> BaseManager[Registrar]:
+    """Suggest potential registrars for a user based on email domain.
+
+    This queries the database for registrars whose website matches the
+    base domain from the user's email address. For example, if the
+    user's email is `username@law.harvard.edu`, this will suggest
+    registrars whose domains end with `harvard.edu`.
+    """
+    _, email_domain = user.email.split('@')
+    base_domain = '.'.join(email_domain.rsplit('.', 2)[-2:])
+    pattern = f'^https?://([a-zA-Z0-9\\-\\.]+\\.)?{re.escape(base_domain)}(/.*)?$'
+    registrars = (
+        Registrar.objects.exclude(status='pending')
+        .filter(website__iregex=pattern)
+        .order_by('-link_count', 'name')[:limit]
+    )
+    return registrars
+
+
+def email_new_user(request, user, template='email/new_user.txt', context=None):
+    """
+    Send email to newly created accounts
+    """
+    # This uses the forgot-password flow; logic is borrowed from auth_forms.PasswordResetForm.save()
+    activation_route = request.build_absolute_uri(reverse('password_reset_confirm', args=[
+        urlsafe_base64_encode(force_bytes(user.pk)),
+        default_token_generator.make_token(user),
+    ]))
+
+    # Include context variables
+    template_is_default = template == 'email/new_user.txt'
+    context = context if context is not None else {}
+    context.update(
+        {
+            'activation_expires': settings.PASSWORD_RESET_TIMEOUT,
+            'activation_route': activation_route,
+            'request': request,
+            # Only query DB if we're using the default template; otherwise there's no need
+            'suggested_registrars': suggest_registrars(user) if template_is_default else [],
+        }
+    )
+
+    send_user_email(
+        user.raw_email,
+        template,
+        context
+    )
+
+
+def email_pending_registrar_user(request, user):
+    """
+    Send email to newly created accounts for folks requesting library accounts
+    """
+    email_new_user(request, user, template='email/pending_registrar.txt')
+
+
+def email_registrar_request(request, pending_registrar):
+    """
+    Send email to Perma.cc admins when a library requests an account
+    """
+    host = request.get_host()
+    try:
+        email = request.user.raw_email
+    except AttributeError:
+        # User did not have an account
+        email = request.POST.get('a-e-address')
+
+    send_admin_email(
+        "Perma.cc new library registrar account request",
+        email,
+        request,
+        'email/admin/registrar_request.txt',
+        {
+            "name": pending_registrar.name,
+            "email": pending_registrar.email,
+            "requested_by_email": email,
+            "host": host,
+            "confirmation_route": reverse('user_sign_up_approve_pending_registrar', args=[pending_registrar.id])
+        }
+    )
+
+
+def email_approved_registrar_user(request, user):
+    """
+    Send email to newly approved registrar accounts for folks requesting library accounts
+    """
+    host = request.get_host()
+    send_user_email(
+        user.raw_email,
+        "email/library_approved.txt",
+        {
+            "host": host,
+            "account_route": reverse('user_management_manage_organization')
+        }
+    )
+
+
+def email_court_request(request, user):
+    """
+    Send email to Perma.cc admins when a court requests an account
+    """
+    try:
+        target_user = LinkUser.objects.get(email=user.email)
+    except LinkUser.DoesNotExist:
+        target_user = None
+    send_admin_email(
+        "Perma.cc new library court account information request",
+        user.raw_email,
+        request,
+        "email/admin/court_request.txt",
+        {
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "court_name": user.requested_account_note,
+            "has_account": target_user,
+            "email": user.raw_email
+        }
+    )
+
+
+def email_firm_request(request: HttpRequest, user: LinkUser):
+    """
+    Send email to Perma.cc admins when a firm requests an account
+    """
+    organization_form = FirmOrganizationForm(request.POST)
+    usage_form = FirmUsageForm(request.POST)
+    user_form = CreateUserFormWithFirm(request.POST)
+
+    # Validate form values; this should rarely or never arise in practice, but the `cleaned_data`
+    # attribute is only populated after checking
+    if organization_form.errors or usage_form.errors:
+        return HttpResponseBadRequest('Form data contains validation errors')
+
+    try:
+        existing_user = LinkUser.objects.get(email=user_form.data['e-address'].casefold())
+    except LinkUser.DoesNotExist:
+        existing_user = None
+
+    send_admin_email(
+        'Perma.cc new law firm account information request',
+        user.raw_email,
+        request,
+        'email/admin/firm_request.txt',
+        {
+            'existing_user': existing_user,
+            'organization_form': organization_form,
+            'usage_form': usage_form,
+            'user_form': user_form,
+        },
+    )
+
+
+def email_premium_request(request, user):
+    """
+    Send email to Perma.cc admins when a user requests a premium account
+    """
+    send_admin_email(
+        "Perma.cc premium account request",
+        user.raw_email,
+        request,
+        "email/admin/premium_request.txt",
+        {
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.raw_email
+        }
+    )


### PR DESCRIPTION
Following on @rebeccacremona's work in https://github.com/harvard-lil/perma/pull/3607, this breaks the sign-up views off of `user_management.py` and puts them into their own module, `user_sign_up.py`.

There are some functions such as `approve_pending_registrar` that fall somewhere in between "user management" and "sign-up" in terms of functionality; in such cases, I did my best to minimize import dependencies between modules and keep functions alongside their associated views. Open to feedback though.