### PR TITLE
Fix sign-up form inconsistency for logged-in users

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -195,8 +195,8 @@ class UserForm(forms.ModelForm):
         """
         return (
             hasattr(self, 'request')
-            and hasattr(self.request, 'user')
-            and isinstance(self.request.user, LinkUser)
+            and hasattr(self.request, 'user')  # noqa: W503
+            and isinstance(self.request.user, LinkUser)  # noqa: W503
         )
 
 

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -303,10 +303,18 @@ class CreateUserFormWithFirm(UserForm):
 
     def __init__(self, *args, **kwargs):
         super(CreateUserFormWithFirm, self).__init__(*args, **kwargs)
-        self.fields['first_name'].label = "Your first name"
-        self.fields['last_name'].label = "Your last name"
-        self.fields['email'].label = "Your email"
+
+        self.fields['first_name'].label = 'Your first name'
+        self.fields['last_name'].label = 'Your last name'
+        self.fields['email'].label = 'Your email'
         self.fields['would_be_org_admin'].label = 'Would you be an administrator on this account?'
+
+        # Populate from logged-in user
+        if hasattr(self, 'request') and hasattr(self.request, 'user'):
+            fields = ['first_name', 'last_name', 'email']
+            for field in fields:
+                self.fields[field].initial = getattr(self.request.user, field, None)
+                self.fields[field].widget = self.fields[field].hidden_widget()
 
 
 class CreateUserFormWithUniversity(UserForm):

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -283,10 +283,23 @@ class CreateUserFormWithCourt(UserForm):
 
     def __init__(self, *args, **kwargs):
         super(CreateUserFormWithCourt, self).__init__(*args, **kwargs)
+
         self.fields['requested_account_note'].label = "Your court"
         self.fields['first_name'].label = "Your first name"
         self.fields['last_name'].label = "Your last name"
         self.fields['email'].label = "Your email"
+
+        # Populate and set visibility of fields based on whether user is logged in
+        user_is_logged_in = (
+            hasattr(self, 'request')
+            and hasattr(self.request, 'user')
+            and isinstance(self.request.user, LinkUser)
+        )
+        if user_is_logged_in:
+            fields = ['first_name', 'last_name', 'email']
+            for field in fields:
+                self.fields[field].widget = self.fields[field].hidden_widget()
+
 
 class CreateUserFormWithFirm(UserForm):
     """

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -309,11 +309,15 @@ class CreateUserFormWithFirm(UserForm):
         self.fields['email'].label = 'Your email'
         self.fields['would_be_org_admin'].label = 'Would you be an administrator on this account?'
 
-        # Populate from logged-in user
-        if hasattr(self, 'request') and hasattr(self.request, 'user'):
+        # Populate and set visibility of fields based on whether user is logged in
+        user_is_logged_in = (
+            hasattr(self, 'request')
+            and hasattr(self.request, 'user')
+            and isinstance(self.request.user, LinkUser)
+        )
+        if user_is_logged_in:
             fields = ['first_name', 'last_name', 'email']
             for field in fields:
-                self.fields[field].initial = getattr(self.request.user, field, None)
                 self.fields[field].widget = self.fields[field].hidden_widget()
 
 

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -187,6 +187,19 @@ class UserForm(forms.ModelForm):
         user = forms.ModelForm.save(self, commit)
         return user
 
+    def user_is_logged_in(self) -> bool:
+        """Determine whether there is a currently logged-in user.
+
+        This may be useful for determining, e.g., whether or not to
+        display certain user registration fields.
+        """
+        return (
+            hasattr(self, 'request')
+            and hasattr(self.request, 'user')
+            and isinstance(self.request.user, LinkUser)
+        )
+
+
 class UserFormWithAdmin(UserForm):
     """
         User form that causes the created user to be an admin.
@@ -290,12 +303,7 @@ class CreateUserFormWithCourt(UserForm):
         self.fields['email'].label = "Your email"
 
         # Populate and set visibility of fields based on whether user is logged in
-        user_is_logged_in = (
-            hasattr(self, 'request')
-            and hasattr(self.request, 'user')
-            and isinstance(self.request.user, LinkUser)
-        )
-        if user_is_logged_in:
+        if self.user_is_logged_in():
             fields = ['first_name', 'last_name', 'email']
             for field in fields:
                 self.fields[field].widget = self.fields[field].hidden_widget()
@@ -323,12 +331,7 @@ class CreateUserFormWithFirm(UserForm):
         self.fields['would_be_org_admin'].label = 'Would you be an administrator on this account?'
 
         # Populate and set visibility of fields based on whether user is logged in
-        user_is_logged_in = (
-            hasattr(self, 'request')
-            and hasattr(self.request, 'user')
-            and isinstance(self.request.user, LinkUser)
-        )
-        if user_is_logged_in:
+        if self.user_is_logged_in():
             fields = ['first_name', 'last_name', 'email']
             for field in fields:
                 self.fields[field].widget = self.fields[field].hidden_widget()

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -614,7 +614,7 @@ USE_ANALYTICS_VIEWS = [
     'dev_docs',
     'sign_up',
     'sign_up_courts',
-    'sign_up_firm',
+    'sign_up_firms',
     'sign_up_libraries'
 ]
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -615,7 +615,7 @@ USE_ANALYTICS_VIEWS = [
     'sign_up',
     'sign_up_courts',
     'sign_up_firm',
-    'libraries'
+    'sign_up_libraries'
 ]
 
 # If USE_SENTRY is True, SENTRY_DSN must be set

--- a/perma_web/perma/templates/about.html
+++ b/perma_web/perma/templates/about.html
@@ -96,7 +96,7 @@ Perma.cc prevents link rot.
       <div class="col-sm-6">
         <div class="content">
           <p class="body-text">Perma.cc was built by Harvard’s <a href="http://librarylab.law.harvard.edu">Library Innovation Lab</a> and is backed by the power of libraries. We’re both in the forever business: libraries already look after physical and digital materials — now we can do the same for links.</p>
-          <p class="body-text"><a href="{% url 'libraries' %}" class="btn btn-large">Try Perma.cc for libraries</a></p>
+          <p class="body-text"><a href="{% url 'sign_up_libraries' %}" class="btn btn-large">Try Perma.cc for libraries</a></p>
         </div>
       </div><!--col-sm-6-->
       <div class="col-sm-6">

--- a/perma_web/perma/templates/docs/accounts.html
+++ b/perma_web/perma/templates/docs/accounts.html
@@ -64,7 +64,7 @@ This section of the user guide describes how Perma accounts work.
       <h2 id="usage-plans" class="body-ah">Usage Plans</h2>
 
       <h3 id="free-usage-plans" class="body-bh">Free Usage Plans</h3>
-      <p class="body-text">Perma is free for academic use. If you are a member of an academic community (current student, faculty or staff) and your library is a Perma registrar, contact your library to request affiliation. If your library is not yet a Perma registrar, they can learn more and sign up for free using this page: <a href="{% url 'libraries' %}">https://perma.cc/libraries</a>.</p>
+      <p class="body-text">Perma is free for academic use. If you are a member of an academic community (current student, faculty or staff) and your library is a Perma registrar, contact your library to request affiliation. If your library is not yet a Perma registrar, they can learn more and sign up for free using this page: <a href="{% url 'sign_up_libraries' %}">https://perma.cc/libraries</a>.</p>
       <p class="body-text">Perma also is free for use by state and federal courts and their employees, including reporters of decisions, judges, clerks and other court staff. If your court is interested in using Perma, you can use this page to learn more and contact us about signing up: <a href="{% url 'sign_up_courts' %}">https://perma.cc/signup/courts</a>.</p>
 
       <h3 id="paid-usage-groups" class="body-bh">Paid Usage Plans for Groups</h3>

--- a/perma_web/perma/templates/docs/accounts.html
+++ b/perma_web/perma/templates/docs/accounts.html
@@ -68,7 +68,7 @@ This section of the user guide describes how Perma accounts work.
       <p class="body-text">Perma also is free for use by state and federal courts and their employees, including reporters of decisions, judges, clerks and other court staff. If your court is interested in using Perma, you can use this page to learn more and contact us about signing up: <a href="{% url 'sign_up_courts' %}">https://perma.cc/signup/courts</a>.</p>
 
       <h3 id="paid-usage-groups" class="body-bh">Paid Usage Plans for Groups</h3>
-      <p class="body-text">Law firms, publishers, news organizations and other entities may become registrars through a paid usage plan, which will give them access to Perma's collaboration and administrative tools and allow them to make Perma available to their employees. To learn more about paid plans, please <a href="{% url 'sign_up_firm' %}">contact us</a>.</p>
+      <p class="body-text">Law firms, publishers, news organizations and other entities may become registrars through a paid usage plan, which will give them access to Perma's collaboration and administrative tools and allow them to make Perma available to their employees. To learn more about paid plans, please <a href="{% url 'sign_up_firms' %}">contact us</a>.</p>
 
       <h3 id="paid-usage-individuals" class="body-bh">Paid Usage Plans for Individuals</h3>
       <p class="body-text">For individuals who are not affiliated with Perma registrars, or who want independent access to Perma, we offer paid usage plans. There are two options, based on different types of usage:</p>

--- a/perma_web/perma/templates/docs/faq.html
+++ b/perma_web/perma/templates/docs/faq.html
@@ -73,7 +73,7 @@ This section of the user guide provides answers to common questions about Perma.
 
       <h3 class="body-bh">Can my library become a Perma.cc partner library?</h3>
       <div class="faq-answer">
-        <p class="body-text">Any academic or government library can become a Perma.cc partner library for free. If you're interested, please let us know via this <a href="{% url 'libraries' %}">signup form</a>.
+        <p class="body-text">Any academic or government library can become a Perma.cc partner library for free. If you're interested, please let us know via this <a href="{% url 'sign_up_libraries' %}">signup form</a>.
         <p class="body-text">Other libraries should <a href="{% url 'contact' %}?subject=Our%20Library%20Would%20Like%20to%20Use%20Perma">contact us</a> to learn more about the options currently available for your patrons and staff.</p>
       </div>
 

--- a/perma_web/perma/templates/docs/libraries.html
+++ b/perma_web/perma/templates/docs/libraries.html
@@ -59,7 +59,7 @@ This section of the user guide describes the Perma.cc library consortium and the
       <p class="body-text">Perma.cc is administered by a network of libraries and other trusted entities that act as registrars. Each registrar manages its own community of affiliated individuals and groups.</p>
 
       <h3 id="becoming-registrar" class="body-bh">Becoming a registrar</h3>
-      <p class="body-text">All academic libraries and courts are invited to become registrars for free and to extend free Perma service to those within their communities. If you are interested, please contact us via this <a href="{% url 'libraries' %}">inquiry form</a> and we will follow up to learn more about your institution and what kinds of users and usage you intend to support.</p>
+      <p class="body-text">All academic libraries and courts are invited to become registrars for free and to extend free Perma service to those within their communities. If you are interested, please contact us via this <a href="{% url 'sign_up_libraries' %}">inquiry form</a> and we will follow up to learn more about your institution and what kinds of users and usage you intend to support.</p>
       <p class="body-text">Other entities can become registrars by signing up for a paid usage plan. For more info, please visit our <a href="{% url 'docs_accounts' %}">accounts page.</a></p>
 
       <h3 id="libraries-authority" class="body-bh">Authority and responsibilities</h3>

--- a/perma_web/perma/templates/landing.html
+++ b/perma_web/perma/templates/landing.html
@@ -29,7 +29,7 @@
           <a href="{% url 'create_link' %}" class="btn btn-large">Create and manage your Perma Links</a>
         {% else %}
           <a href="{% url 'sign_up' %}" class="btn btn-large">Sign up and use Perma.cc</a>
-          <a href="{% url 'libraries' %}" class="btn btn-large-alt">How can my library get involved?</a>
+          <a href="{% url 'sign_up_libraries' %}" class="btn btn-large-alt">How can my library get involved?</a>
         {% endif %}
       </div>
     </div>
@@ -286,7 +286,7 @@
       <div class="col-xs-12 col-sm-3 _isCentered signup-module">
         <img class="img-responsive signup-image" loading="lazy" src="{{ STATIC_URL }}img/signup-libraries-bg.png" aria-hidden="true" alt="" />
         <p class="caption"><strong>Libraries<span class="_verbose">.</span></strong> Libraries play a critical role in powering and supporting Perma.cc.</p>
-        <a href="{% url 'libraries' %}" class="btn btn-small center">Perma.cc for libraries</a>
+        <a href="{% url 'sign_up_libraries' %}" class="btn btn-small center">Perma.cc for libraries</a>
       </div>
       <div class="col-xs-12 col-sm-3 _isCentered signup-module">
         <img class="img-responsive signup-image" loading="lazy" src="{{ STATIC_URL }}img/signup-courts-bg.png" aria-hidden="true" alt="" />

--- a/perma_web/perma/templates/landing.html
+++ b/perma_web/perma/templates/landing.html
@@ -296,7 +296,7 @@
       <div class="col-xs-12 col-sm-3 _isCentered signup-module">
         <img class="img-responsive signup-image" loading="lazy" src="{{ STATIC_URL }}img/signup-everyone-bg.png" aria-hidden="true" alt="" />
         <p class="caption"><strong>Other organizations<span class="_verbose">.</span></strong> There are wide-ranging applications for Perma.cc tools.</p>
-        <a href="{% url 'sign_up_firm' %}" class="btn btn-small center">Perma.cc for other orgs</a>
+        <a href="{% url 'sign_up_firms' %}" class="btn btn-small center">Perma.cc for other orgs</a>
       </div>
       <div class="col-xs-12 col-sm-3 _isCentered signup-module">
         <img class="img-responsive signup-image" loading="lazy" src="{{ STATIC_URL }}img/signup-individuals-bg.png" aria-hidden="true" alt="" />

--- a/perma_web/perma/templates/registration/includes/sign-up-navigation.html
+++ b/perma_web/perma/templates/registration/includes/sign-up-navigation.html
@@ -7,8 +7,8 @@
           <p class="overview-module-description">Anyone can create an account and start creating Perma Links.</p>
         </a>
       </div>
-      <div class="col col-sm-by4 overview-module col-no-gutter {% if this_page == 'libraries' %}_active{% endif %}">
-        <a class="overview-module-content" href="{% url 'libraries' %}">
+      <div class="col col-sm-by4 overview-module col-no-gutter {% if this_page == 'sign_up_libraries' %}_active{% endif %}">
+        <a class="overview-module-content" href="{% url 'sign_up_libraries' %}">
           <strong class="overview-module-title">Libraries</strong>
           <p class="overview-module-description">Libraries play a critical role in powering and supporting Perma.cc.</p>
         </a>

--- a/perma_web/perma/templates/registration/includes/sign-up-navigation.html
+++ b/perma_web/perma/templates/registration/includes/sign-up-navigation.html
@@ -20,7 +20,7 @@
         </a>
       </div>
       <div class="col col-sm-by4 overview-module col-no-gutter {% if this_page == 'firms' %}_active{% endif %}">
-        <a class="overview-module-content" href="{% url 'sign_up_firm' %}">
+        <a class="overview-module-content" href="{% url 'sign_up_firms' %}">
           <strong class="overview-module-title">Other Organizations</strong>
           <p class="overview-module-description">There are many applications for Perma.cc citation preservation tools.</p>
         </a>

--- a/perma_web/perma/templates/registration/sign-up-courts.html
+++ b/perma_web/perma/templates/registration/sign-up-courts.html
@@ -26,16 +26,18 @@
         <h3 class="body-bh">Your court information</h3>
         <fieldset>
           {% for field in form %}
-            {% if field.name == 'requested_account_note' or not request.user.is_authenticated %}
-            <div class="form-group{% if field.errors %} _error{% endif %}">
-              <label for="id_{{ field.name }}">{{ field.label }}</label>
+            {% if field in form.visible_fields %}
+              <div class="form-group{% if field.errors %} _error{% endif %}">
+                <label for="id_{{ field.name }}">{{ field.label }}</label>
+                {{ field }}
+                {% if field.errors %}
+                  {% for error in field.errors %}<span class="field-error">{{ error }}</span>{% endfor %}
+                {% elif field.help_text %}
+                  <span class="help-inline">{{ field.help_text }}</span>
+                {% endif %}
+              </div>
+            {% else %}
               {{ field }}
-              {% if field.errors %}
-                {% for error in field.errors %}<span class="field-error">{{ error }}</span>{% endfor %}
-              {%elif field.help_text %}
-                <span class="help-inline">{{ field.help_text }}</span>
-              {% endif %}
-            </div>
             {% endif %}
           {% endfor %}
           {% if not request.user.is_authenticated %}

--- a/perma_web/perma/templates/registration/sign-up-courts.html
+++ b/perma_web/perma/templates/registration/sign-up-courts.html
@@ -23,8 +23,10 @@
       <h2 class="body-ah">Request information for courts</h2>
       <form method="post" action="">
         {% csrf_token %}
+        <h3 class="body-bh">Your court information</h3>
         <fieldset>
           {% for field in form %}
+            {% if field.name == 'requested_account_note' or not request.user.is_authenticated %}
             <div class="form-group{% if field.errors %} _error{% endif %}">
               <label for="id_{{ field.name }}">{{ field.label }}</label>
               {{ field }}
@@ -34,7 +36,9 @@
                 <span class="help-inline">{{ field.help_text }}</span>
               {% endif %}
             </div>
+            {% endif %}
           {% endfor %}
+          {% if not request.user.is_authenticated %}
           <div class="checkbox">
             <label>
               <input id="id_create_account" name="create_account" type="checkbox" checked /> Create a free personal account to try Perma.cc
@@ -42,6 +46,7 @@
           </div>
           {% if form.non_field_errors %}<span class="field-error">{{ form.non_field_errors }}</span>{% endif %}
           <p class="terms-statement"><small>By registering, you agree to the <a href="{% url 'terms_of_service' %}">terms of service</a>.</small></p>
+          {% endif %}
         </fieldset>
         <button type="submit" class="btn">Send request</button>
       </form>

--- a/perma_web/perma/templates/registration/sign-up-firms.html
+++ b/perma_web/perma/templates/registration/sign-up-firms.html
@@ -28,6 +28,7 @@
         <h3 class="body-bh">Estimated usage information</h3>
         <p>Quotes are based on the expected volume of use by your whole team.</p>
         {% include "includes/fieldset.html" with form=usage_form %}
+        {% if user_form %}
         <h3 class="body-bh">Your information</h3>
         <fieldset>
           {% for field in user_form %}
@@ -49,6 +50,7 @@
           {% if form.non_field_errors %}<span class="field-error">{{ form.non_field_errors }}</span>{% endif %}
           <p class="terms-statement"><small>By registering, you agree to the <a href="{% url 'terms_of_service' %}">terms of service</a>.</small></p>
         </fieldset>
+        {% endif %}
         <button type="submit" class="btn">Send request</button>
       </form>
     </div>

--- a/perma_web/perma/templates/registration/sign-up-firms.html
+++ b/perma_web/perma/templates/registration/sign-up-firms.html
@@ -28,29 +28,33 @@
         <h3 class="body-bh">Estimated usage information</h3>
         <p>Quotes are based on the expected volume of use by your whole team.</p>
         {% include "includes/fieldset.html" with form=usage_form %}
-        {% if user_form %}
         <h3 class="body-bh">Your information</h3>
         <fieldset>
           {% for field in user_form %}
-            <div class="form-group{% if field.errors %} _error{% endif %}">
-              <label for="id_{{ field.name }}">{{ field.label }}</label>
+            {% if field in user_form.visible_fields %}
+              <div class="form-group{% if field.errors %} _error{% endif %}">
+                <label for="id_{{ field.name }}">{{ field.label }}</label>
+                {{ field }}
+                {% if field.errors %}
+                  {% for error in field.errors %}<span class="field-error">{{ error }}</span>{% endfor %}
+                {% elif field.help_text %}
+                  <span class="help-inline">{{ field.help_text }}</span>
+                {% endif %}
+              </div>
+            {% else %}
               {{ field }}
-              {% if field.errors %}
-                {% for error in field.errors %}<span class="field-error">{{ error }}</span>{% endfor %}
-              {%elif field.help_text %}
-                <span class="help-inline">{{ field.help_text }}</span>
-              {% endif %}
-            </div>
+            {% endif %}
           {% endfor %}
-          <div class="checkbox">
-            <label>
-              <input id="id_create_account" name="create_account" type="checkbox" checked /> Create a free personal account to try Perma.cc
-            </label>
-          </div>
-          {% if form.non_field_errors %}<span class="field-error">{{ form.non_field_errors }}</span>{% endif %}
+          {% if not request.user.is_authenticated %}
+            <div class="checkbox">
+              <label>
+                <input id="id_create_account" name="create_account" type="checkbox" checked /> Create a free personal account to try Perma.cc
+              </label>
+            </div>
+            {% if form.non_field_errors %}<span class="field-error">{{ form.non_field_errors }}</span>{% endif %}
           <p class="terms-statement"><small>By registering, you agree to the <a href="{% url 'terms_of_service' %}">terms of service</a>.</small></p>
+          {% endif %}
         </fieldset>
-        {% endif %}
         <button type="submit" class="btn">Send request</button>
       </form>
     </div>

--- a/perma_web/perma/templates/registration/sign-up-libraries.html
+++ b/perma_web/perma/templates/registration/sign-up-libraries.html
@@ -15,7 +15,7 @@
   </div>
 </div>
 
-{% include "registration/includes/sign-up-navigation.html" with this_page="libraries" %}
+{% include "registration/includes/sign-up-navigation.html" with this_page="sign_up_libraries" %}
 
 <div class="container cont-reading cont-fixed">
   <div class="row signup-info">

--- a/perma_web/perma/templates/registration/sign-up.html
+++ b/perma_web/perma/templates/registration/sign-up.html
@@ -35,7 +35,7 @@
       <p class="body-text">Many organizations qualify for free, unlimited service. To see if your organization qualifies, check out our <a href="{% url 'docs_accounts' %}">accounts page</a>.</p>
 
       <h3 class="body-bh">Contact your library for an affiliated account</h3>
-      <p class="body-text">If your library or organization is already registered with us, we’ll let you know in your welcome email so you can contact them for an affiliation. If not, invite your library to visit our <a href="{% url 'libraries' %}">library resource page</a> to request membership, and we’ll help them get started.</p>
+      <p class="body-text">If your library or organization is already registered with us, we’ll let you know in your welcome email so you can contact them for an affiliation. If not, invite your library to visit our <a href="{% url 'sign_up_libraries' %}">library resource page</a> to request membership, and we’ll help them get started.</p>
     </div>
   </div>
 </div>

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1745,6 +1745,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                 'a-telephone': "I'm a bot.",
                 **firm_organization_form,
                 **firm_usage_form,
+                'a-would_be_org_admin': True,
             },
             success_url=reverse('register_email_instructions'),
         )

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1634,7 +1634,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # Existing user's email address, no firm info (should not succeed due to missing values)
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={'a-e-address': self.randomize_capitalization(existing_user['email'])},
             success_url=reverse('firm_request_response'),
         )
@@ -1643,7 +1643,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # Existing user's email address + firm info
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={
                 'a-e-address': self.randomize_capitalization(existing_user['email']),
                 'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
@@ -1658,7 +1658,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address, don't create account
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={
                 'a-e-address': firm_user_form['raw_email'],
                 'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
@@ -1673,7 +1673,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # New user email address, create account
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={
                 'a-e-address': firm_user_form['raw_email'],
                 'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
@@ -1696,7 +1696,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # (This succeeds and creates a new account; see issue 1749)
         firm_user_form = self.create_firm_user_form()
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={
                 'a-e-address': firm_user_form['raw_email'],
                 'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
@@ -1717,7 +1717,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Existing user's email address, not that of the user logged in.
         # (This is odd; see issue 1749)
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={
                 'a-e-address': self.randomize_capitalization(existing_user['email']),
                 'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
@@ -1738,7 +1738,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         firm_usage_form = self.create_firm_usage_form()
         firm_user_form = self.create_firm_user_form()
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={
                 'a-e-address': firm_user_form['raw_email'],
                 'create_account': True,
@@ -1761,7 +1761,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         '''
         # Not logged in, blank submission reports correct fields required
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={},
             form_keys=['organization_form', 'usage_form', 'user_form'],
             error_keys=['email', 'would_be_org_admin'],
@@ -1771,7 +1771,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Logged in, blank submission reports same fields required
         # (This is odd; see issue 1749)
         self.submit_form(
-            'sign_up_firm',
+            'sign_up_firms',
             data={},
             form_keys=['organization_form', 'usage_form', 'user_form'],
             user='test_user@example.com',

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1267,7 +1267,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # Registrar and user forms are displayed,
         # inputs are blank, and labels are customized as expected
-        response = self.get('libraries').content
+        response = self.get('sign_up_libraries').content
         soup = BeautifulSoup(response, 'html.parser')
         self.check_library_labels(soup)
         self.check_lib_user_labels(soup)
@@ -1293,7 +1293,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                                     'a-last_name': new_lib_user['last'],
                                     'csrfmiddlewaretoken': '11YY3S2DgOw2DHoWVEbBArnBMdEA2svu' }
         session.save()
-        response = self.get('libraries').content
+        response = self.get('sign_up_libraries').content
         soup = BeautifulSoup(response, 'html.parser')
         self.check_library_labels(soup)
         self.check_lib_user_labels(soup)
@@ -1308,7 +1308,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                 self.assertFalse(input.get('value', ''))
 
         # If there's an unsuccessful submission, field labels are still as expected.
-        response = self.post('libraries').content
+        response = self.post('sign_up_libraries').content
         soup = BeautifulSoup(response, 'html.parser')
         self.check_library_labels(soup)
         self.check_lib_user_labels(soup)
@@ -1317,7 +1317,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # Registrar form is displayed, but user form is not,
         # inputs are blank, and labels are still customized as expected
-        response = self.get('libraries', user="test_user@example.com").content
+        response = self.get('sign_up_libraries', user="test_user@example.com").content
         soup = BeautifulSoup(response, 'html.parser')
         self.check_library_labels(soup)
         inputs = soup.select('input')
@@ -1339,7 +1339,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Not logged in, submit all fields sans first and last name
         new_lib = self.new_lib()
         new_lib_user = self.new_lib_user()
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = { 'b-email': new_lib['email'],
                                    'b-website': new_lib['website'],
                                    'b-name': new_lib['name'],
@@ -1353,7 +1353,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Not logged in, submit all fields including first and last name
         new_lib = self.new_lib()
         new_lib_user = self.new_lib_user()
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = { 'b-email': new_lib['email'],
                                    'b-website': new_lib['website'],
                                    'b-name': new_lib['name'],
@@ -1372,7 +1372,7 @@ class UserManagementViewsTestCase(PermaTestCase):
             'raw_email': 'test_user@example.com',
             'normalized_email': 'test_user@example.com',
         }
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = { 'b-email': new_lib['email'],
                                    'b-website': new_lib['website'],
                                    'b-name': new_lib['name'] },
@@ -1386,7 +1386,7 @@ class UserManagementViewsTestCase(PermaTestCase):
     def test_new_library_form_honeypot(self):
         new_lib = self.new_lib()
         new_lib_user = self.new_lib_user()
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = { 'b-email': new_lib['email'],
                                    'b-website': new_lib['website'],
                                    'b-name': new_lib['name'],
@@ -1409,14 +1409,14 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Not logged in, blank submission reports correct fields required
         # ('email' catches both registrar and user email errors, unavoidably,
         # so test with just that missing separately)
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = {},
                           form_keys = ['registrar_form', 'user_form'],
                           error_keys = ['website', 'name', 'email'])
         self.assertEqual(len(mail.outbox), 0)
 
         # (checking user email missing separately)
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = {'b-email': new_lib['email'],
                                   'b-website': new_lib['website'],
                                   'b-name': new_lib['name']},
@@ -1429,7 +1429,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                 'b-website': new_lib['website'],
                 'b-name': new_lib['name'],
                 'a-e-address': self.randomize_capitalization(existing_lib_user['email'])}
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = data,
                           form_keys = ['registrar_form', 'user_form'],
                           success_url = '/login?next=/libraries/')
@@ -1440,7 +1440,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # (actually, this doesn't currently fail)
 
         # Logged in, blank submission reports all fields required
-        self.submit_form('libraries',
+        self.submit_form('sign_up_libraries',
                           data = {},
                           user = existing_lib_user['email'],
                           error_keys = ['website', 'name', 'email'])

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1635,7 +1635,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Existing user's email address, no firm info (should not succeed due to missing values)
         self.submit_form(
             'sign_up_firm',
-            data={'e-address': self.randomize_capitalization(existing_user['email'])},
+            data={'a-e-address': self.randomize_capitalization(existing_user['email'])},
             success_url=reverse('firm_request_response'),
         )
         expected_emails_sent += 0
@@ -1645,8 +1645,8 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form(
             'sign_up_firm',
             data={
-                'e-address': self.randomize_capitalization(existing_user['email']),
-                'would_be_org_admin': firm_user_form['would_be_org_admin'],
+                'a-e-address': self.randomize_capitalization(existing_user['email']),
+                'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
                 **firm_organization_form,
                 **firm_usage_form,
             },
@@ -1660,8 +1660,8 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form(
             'sign_up_firm',
             data={
-                'e-address': firm_user_form['raw_email'],
-                'would_be_org_admin': firm_user_form['would_be_org_admin'],
+                'a-e-address': firm_user_form['raw_email'],
+                'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
                 **firm_organization_form,
                 **firm_usage_form,
             },
@@ -1675,8 +1675,8 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form(
             'sign_up_firm',
             data={
-                'e-address': firm_user_form['raw_email'],
-                'would_be_org_admin': firm_user_form['would_be_org_admin'],
+                'a-e-address': firm_user_form['raw_email'],
+                'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
                 **firm_organization_form,
                 **firm_usage_form,
                 'create_account': True,
@@ -1698,8 +1698,8 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form(
             'sign_up_firm',
             data={
-                'e-address': firm_user_form['raw_email'],
-                'would_be_org_admin': firm_user_form['would_be_org_admin'],
+                'a-e-address': firm_user_form['raw_email'],
+                'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
                 **firm_organization_form,
                 **firm_usage_form,
                 'create_account': True,
@@ -1719,8 +1719,8 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form(
             'sign_up_firm',
             data={
-                'e-address': self.randomize_capitalization(existing_user['email']),
-                'would_be_org_admin': firm_user_form['would_be_org_admin'],
+                'a-e-address': self.randomize_capitalization(existing_user['email']),
+                'a-would_be_org_admin': firm_user_form['would_be_org_admin'],
                 **firm_organization_form,
                 **firm_usage_form,
                 'create_account': True,
@@ -1740,9 +1740,9 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form(
             'sign_up_firm',
             data={
-                'e-address': firm_user_form['raw_email'],
+                'a-e-address': firm_user_form['raw_email'],
                 'create_account': True,
-                'telephone': "I'm a bot.",
+                'a-telephone': "I'm a bot.",
                 **firm_organization_form,
                 **firm_usage_form,
             },

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
-from django.urls import re_path
+from django.urls import re_path, reverse_lazy
 from django.views.generic import RedirectView
 
 from perma.views.user_management import AddUserToOrganization, AddUserToRegistrar, AddSponsoredUserToRegistrar, AddUserToAdmin, AddRegularUser
@@ -68,7 +68,13 @@ urlpatterns = [
     re_path(r'^sign-up/?$', user_sign_up.sign_up, name='sign_up'),
     re_path(r'^sign-up/courts/?$', user_sign_up.sign_up_courts, name='sign_up_courts'),
     re_path(r'^sign-up/firms/?$', user_sign_up.sign_up_firm, name='sign_up_firm'),
-    re_path(r'^libraries/?$', user_sign_up.sign_up_libraries, name='sign_up_libraries'),
+    re_path(r'^sign-up/libraries/?$', user_sign_up.sign_up_libraries, name='sign_up_libraries'),
+    # Redirect from /libraries to /sign-up/libraries with an HTTP 301 for consistency
+    re_path(
+        r'^libraries/?$',
+        RedirectView.as_view(url=reverse_lazy('sign_up_libraries'), permanent=True),
+        name='libraries'
+    ),
     re_path(r'^register/email/?$', user_sign_up.register_email_instructions, name='register_email_instructions'),
     re_path(r'^register/library/?$', user_sign_up.register_library_instructions, name='register_library_instructions'),
     re_path(r'^register/court/?$', user_sign_up.court_request_response, name='court_request_response'),

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -67,7 +67,7 @@ urlpatterns = [
     # Sign-up/registration
     re_path(r'^sign-up/?$', user_sign_up.sign_up, name='sign_up'),
     re_path(r'^sign-up/courts/?$', user_sign_up.sign_up_courts, name='sign_up_courts'),
-    re_path(r'^sign-up/firms/?$', user_sign_up.sign_up_firm, name='sign_up_firm'),
+    re_path(r'^sign-up/firms/?$', user_sign_up.sign_up_firms, name='sign_up_firms'),
     re_path(r'^sign-up/libraries/?$', user_sign_up.sign_up_libraries, name='sign_up_libraries'),
     # Redirect from /libraries to /sign-up/libraries with an HTTP 301 for consistency
     re_path(

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -64,10 +64,11 @@ urlpatterns = [
     # Users with old-style activation links should get redirected so they can generate a new one
     re_path(r'^register/password/(?P<token>.*)/?$', user_management.redirect_to_reset, name='redirect_to_reset'),
 
+    # Sign-up/registration
     re_path(r'^sign-up/?$', user_sign_up.sign_up, name='sign_up'),
     re_path(r'^sign-up/courts/?$', user_sign_up.sign_up_courts, name='sign_up_courts'),
     re_path(r'^sign-up/firms/?$', user_sign_up.sign_up_firm, name='sign_up_firm'),
-    re_path(r'^libraries/?$', user_sign_up.libraries, name='libraries'),
+    re_path(r'^libraries/?$', user_sign_up.sign_up_libraries, name='sign_up_libraries'),
     re_path(r'^register/email/?$', user_sign_up.register_email_instructions, name='register_email_instructions'),
     re_path(r'^register/library/?$', user_sign_up.register_library_instructions, name='register_library_instructions'),
     re_path(r'^register/court/?$', user_sign_up.court_request_response, name='court_request_response'),

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -161,10 +161,8 @@ def sign_up_courts(request):
 
 
 @ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
-def sign_up_firm(request):
-    """
-    Register a new law firm user
-    """
+def sign_up_firms(request: HttpRequest):
+    """Display the sign-up page for submitting a firm/other org request."""
     if request.method == 'POST':
         something_took_the_bait = check_honeypot(
             request, 'register_email_instructions', honey_pot_fieldname='a-telephone', check_js=True

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -213,7 +213,11 @@ def sign_up_firm(request):
             usage_form = FirmUsageForm()
 
     else:
-        user_form = CreateUserFormWithFirm(prefix='a', request=request)
+        initial = {}
+        if hasattr(request, 'user'):
+            fields = ['first_name', 'last_name', 'email']
+            initial = {field: getattr(request.user, field, None) for field in fields}
+        user_form = CreateUserFormWithFirm(initial=initial, prefix='a', request=request)
         organization_form = FirmOrganizationForm()
         usage_form = FirmUsageForm()
 

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 @ratelimit(rate=settings.REGISTER_MINUTE_LIMIT, block=True, key=ratelimit_ip_key)
-def libraries(request):
+def sign_up_libraries(request):
     """
     Info for libraries, allow them to request accounts
     """

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -170,8 +170,8 @@ def sign_up_firm(request):
         if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
             return something_took_the_bait
 
-        user_form = CreateUserFormWithFirm(request.POST)
-        user_email = request.POST.get('e-address', '').lower()
+        user_form = CreateUserFormWithFirm(request.POST, prefix='a')
+        user_email = request.POST.get('a-e-address', '').lower()
 
         try:
             existing_user = LinkUser.objects.get(email=user_email)
@@ -213,9 +213,7 @@ def sign_up_firm(request):
             usage_form = FirmUsageForm()
 
     else:
-        # TODO: Consider relocating would_be_org_admin field from user form to organization form so
-        # we don't have to do any special handling to display that field in template when logged in
-        user_form = None if request.user.is_authenticated else CreateUserFormWithFirm()
+        user_form = CreateUserFormWithFirm(prefix='a', request=request)
         organization_form = FirmOrganizationForm()
         usage_form = FirmUsageForm()
 
@@ -431,7 +429,7 @@ def email_firm_request(request: HttpRequest, user: LinkUser):
     """
     organization_form = FirmOrganizationForm(request.POST)
     usage_form = FirmUsageForm(request.POST)
-    user_form = CreateUserFormWithFirm(request.POST)
+    user_form = CreateUserFormWithFirm(request.POST, prefix='a')
 
     # Validate form values; this should rarely or never arise in practice, but the `cleaned_data`
     # attribute is only populated after checking
@@ -439,7 +437,7 @@ def email_firm_request(request: HttpRequest, user: LinkUser):
         return HttpResponseBadRequest('Form data contains validation errors')
 
     try:
-        existing_user = LinkUser.objects.get(email=user_form.data['e-address'].casefold())
+        existing_user = LinkUser.objects.get(email=user_form.data['a-e-address'].casefold())
     except LinkUser.DoesNotExist:
         existing_user = None
 

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -213,7 +213,9 @@ def sign_up_firm(request):
             usage_form = FirmUsageForm()
 
     else:
-        user_form = CreateUserFormWithFirm()
+        # TODO: Consider relocating would_be_org_admin field from user form to organization form so
+        # we don't have to do any special handling to display that field in template when logged in
+        user_form = None if request.user.is_authenticated else CreateUserFormWithFirm()
         organization_form = FirmOrganizationForm()
         usage_form = FirmUsageForm()
 

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -166,8 +166,10 @@ def sign_up_firm(request):
     Register a new law firm user
     """
     if request.method == 'POST':
-
-        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
+        something_took_the_bait = check_honeypot(
+            request, 'register_email_instructions', honey_pot_fieldname='a-telephone', check_js=True
+        )
+        if something_took_the_bait:
             return something_took_the_bait
 
         user_form = CreateUserFormWithFirm(request.POST, prefix='a')

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -120,8 +120,10 @@ def sign_up_courts(request):
     Register a new court user
     """
     if request.method == 'POST':
-
-        if something_took_the_bait := check_honeypot(request, 'register_email_instructions', check_js=True):
+        something_took_the_bait = check_honeypot(
+            request, 'register_email_instructions', check_js=True
+        )
+        if something_took_the_bait:
             return something_took_the_bait
 
         form = CreateUserFormWithCourt(request.POST)
@@ -155,7 +157,11 @@ def sign_up_courts(request):
                 return HttpResponseRedirect(reverse('court_request_response'))
 
     else:
-        form = CreateUserFormWithCourt()
+        initial = {}
+        if hasattr(request, 'user'):
+            fields = ['first_name', 'last_name', 'email']
+            initial = {field: getattr(request.user, field, None) for field in fields}
+        form = CreateUserFormWithCourt(initial=initial, request=request)
 
     return render(request, "registration/sign-up-courts.html", {'form': form})
 


### PR DESCRIPTION
Per https://github.com/harvard-lil/perma/issues/1749 (from back in 2016), Perma's sign-up forms do not behave in a predictable or consistent way for logged-in users. This attempts to fix the form weirdness, which will in turn unblock the Other Org form workflow improvements I've got on another branch.

Before:
* [Libraries](https://perma.cc/libraries) form does not display user fields (first name, last name, email) when user is logged-in
* [Courts](https://perma.cc/sign-up/courts) and [Other Org](https://perma.cc/sign-up/firms) forms do display user fields even when user is logged-in, leading to confusing UX

After:
* For all three forms, the behavior is the same: display user fields for logged-out user, do not display them for logged-in user
* I also tweaked a few view names/paths for better consistency, namely:
  + `libraries` view is now `sign_up_libraries`, to match the other views
  + `/libraries` URL now redirects to `/sign-up/libraries`, to match the other URLs
  + `sign_up_firm` view is now `sign_up_firms`, to match the other views