### PR TITLE
Suggest only approved registrars to new users

### DIFF
--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -325,7 +325,7 @@ def suggest_registrars(user: LinkUser, limit: int = 5) -> BaseManager[Registrar]
     base_domain = '.'.join(email_domain.rsplit('.', 2)[-2:])
     pattern = f'^https?://([a-zA-Z0-9\\-\\.]+\\.)?{re.escape(base_domain)}(/.*)?$'
     registrars = (
-        Registrar.objects.exclude(status='pending')
+        Registrar.objects.filter(status='approved')
         .filter(website__iregex=pattern)
         .order_by('-link_count', 'name')[:limit]
     )


### PR DESCRIPTION
A user flagged a bug wherein Perma's new "suggest registrars" feature, which lists potentially matching registrars based on a new user's email domain, includes registrars whose status is `denied`.

Fixing our database query to retrieve only objects whose status is `approved` should resolve this issue.