### PR TITLE
upgrade to new version image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:89-b2e7cae3535cd354e51b1c53f145abac
+    image: registry.lil.tools/harvardlil/scoop-rest-api:104-9516d0e4b57e66ca235d4368969c3037
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API version](https://github.com/harvard-lil/perma-scoop-api/commit/332e19793b0fe241585a907a8ddace8157abd5c6). 