### PR TITLE
Faster top_level_folders serialization

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import URLValidator
+from django.db.models import F
 import requests
 from rest_framework import serializers
 
@@ -47,8 +48,15 @@ class LinkUserSerializer(BaseSerializer):
         return field_names
 
     def get_top_level_folders(self, user):
-        serializer = FolderSerializer(user.top_level_folders(), many=True)
-        return serializer.data
+        # For users with a lot of top level folders, like admins, building Folder objects and serializing
+        # with FolderSerializer is very slow. Instead, fetch a list of dicts directly with values(). Equivalent to:
+        # return FolderSerializer(user.top_level_folders(), many=True).data
+        return list(user.top_level_folders().annotate(
+            has_children=F('cached_has_children'),
+            path=F('cached_path'),
+        ).values(
+            *FolderSerializer.Meta.fields,
+        ))
 
 
 ### FOLDER ###

--- a/perma_web/api/tests/test_current_user_resource.py
+++ b/perma_web/api/tests/test_current_user_resource.py
@@ -6,8 +6,10 @@ class CurrentUserResourceTestCase(ApiResourceTestCase):
 
     @classmethod
     def setUpTestData(cls):
+        cls.registrar_user = LinkUser.objects.get(pk=2)
         cls.org_user = LinkUser.objects.get(pk=3)
         cls.regular_user = LinkUser.objects.get(pk=4)
+        cls.sponsored_user = LinkUser.objects.get(pk=20)
         cls.detail_url = cls.url_base+'/user/'
         cls.fields = [
             'id',
@@ -19,7 +21,28 @@ class CurrentUserResourceTestCase(ApiResourceTestCase):
         ]
 
     def test_get_self_detail_json(self):
-        self.successful_get(self.detail_url, user=self.org_user, fields=self.fields)
+        cases = [
+            (self.regular_user, [
+                {'id': 25, 'name': 'Personal Links', 'parent': None, 'organization': None, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': True, 'path': '25'},
+            ]),
+            (self.org_user, [
+                {'id': 24, 'name': 'Personal Links', 'parent': None, 'organization': None, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': False, 'path': '24'},
+                {'id': 27, 'name': 'Test Journal', 'parent': None, 'organization': 1, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': True, 'path': '27'}
+            ]),
+            (self.registrar_user, [
+                {'id': 23, 'name': 'Personal Links', 'parent': None, 'organization': None, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': False, 'path': '23'},
+                {'id': 28, 'name': 'Another Journal', 'parent': None, 'organization': 2, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': True, 'path': '28'},
+                {'id': 31, 'name': 'A Third Journal', 'parent': None, 'organization': 3, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': True, 'path': '31'},
+                {'id': 27, 'name': 'Test Journal', 'parent': None, 'organization': 1, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': True, 'path': '27'},
+            ]),
+            (self.sponsored_user, [
+                {'id': 55, 'name': 'Personal Links', 'parent': None, 'organization': None, 'sponsored_by': None, 'is_sponsored_root_folder': False, 'read_only': False, 'has_children': False, 'path': '55'},
+                {'id': 59, 'name': 'Sponsored Links', 'parent': None, 'organization': None, 'sponsored_by': None, 'is_sponsored_root_folder': True, 'read_only': False, 'has_children': True, 'path': '59'},
+            ]),
+        ]
+        for user, top_level_folders in cases:
+            data = self.successful_get(self.detail_url, user=user, fields=self.fields)
+            self.assertEqual(data['top_level_folders'], top_level_folders)
 
     def test_get_archives_json(self):
         self.successful_get(self.detail_url + 'archives/', user=self.org_user, count=17)

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -28,7 +28,7 @@ from django.contrib.postgres.fields import ArrayField, DateTimeRangeField
 from django.conf import settings
 from django.core.files.storage import storages
 from django.db import models, transaction
-from django.db.models import Q, Max, Count, Sum, JSONField, F, Exists, OuterRef
+from django.db.models import Q, Max, Count, Sum, JSONField, F, Exists, OuterRef, When, Case
 from django.db.models.functions import Now, Upper, TruncDate
 from django.db.models.query import QuerySet
 from django.contrib.postgres.indexes import GistIndex, GinIndex, OpClass
@@ -908,11 +908,24 @@ class LinkUser(CustomerModel, AbstractBaseUser, PermissionsMixin):
     def top_level_folders(self):
         """
             Get top level folders for this user, including personal folder, sponsored folder, and shared folders.
+            Returns a queryset of Folders, with personal/sponsored folders first, followed by org folders sorted by name.
         """
-        folders = [self.root_folder]
-        if self.sponsored_root_folder:
-            folders.append(self.sponsored_root_folder)
-        return folders + [org.shared_folder for org in self.get_orgs().select_related('shared_folder').order_by('name') if org]
+        # personal folder first, custom_order = 0
+        folder_ids = [self.root_folder_id]
+        ordering_cases = [When(id=self.root_folder_id, then=0)]
+
+        # sponsored folder second, custom_order = 1
+        if self.sponsored_root_folder_id:
+            folder_ids.append(self.sponsored_root_folder_id)
+            ordering_cases.append(When(id=self.root_folder_id, then=1))
+
+        # then org folders if any, custom_order = 2
+        return Folder.objects.filter(
+            Q(id__in=folder_ids) |
+            Q(id__in=self.get_orgs().values('shared_folder_id'))
+        ).annotate(
+            custom_order=Case(*ordering_cases, default=2)
+        ).order_by('custom_order', 'name')
 
     def all_folder_trees(self):
         """


### PR DESCRIPTION
I did some late-afternoon performance profiling on the Perma dashboard, and found that the primary hotspot for admins is serializing their 3000 top-level folders to json.

This matches something I'd seen with CAP -- if you're returning thousands of items from a DRF endpoint, most of the time goes to turning dictionaries into Django model instances and using a serializer to turn them back into dictionaries. If you go dictionary->dictionary without the objects in the middle that time disappears. This is where python's usability-speed tradeoff wraps around on itself -- faster languages can afford the extra layers of abstraction, but python can't.

So, this PR rewrites user.top_level_folders() to return a Folder queryset instead of a list of folder instances, which takes a little trickiness to get the sorting right. Then the user serializer can fetch the dictionaries it wants directly with values(). I also added a test of the results for various users.

Note I didn't optimize the /folders endpoint yet to go dict->dict, just the /user endpoint, but I think we don't use the top-level folders endpoint for anything in the site itself.

In my local, this speeds up time to render the dashboard from several seconds to 150ms. The dashboard on prod takes about 6 seconds to render, which I'm hoping is also mostly due to this one thing.