### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:112-286f2f3bc1cc7885a9565dba893eb3b1
+    image: registry.lil.tools/harvardlil/scoop-rest-api:114-3fce3766dcb4fc615ddf470a202914a0
     init: true
     tty: true
     depends_on:

--- a/services/docker/scoop-rest-api/config.py
+++ b/services/docker/scoop-rest-api/config.py
@@ -1,5 +1,5 @@
-# This is the default config.py from the Scoop REST API as of 7/19/2024
-# https://github.com/harvard-lil/perma-scoop-api/blob/ac4691f4716ac1481dcecdc87c2b2302406aa3c3/scoop_rest_api/config.py
+# This is the default config.py from the Scoop REST API as of 11/12/2024
+# https://github.com/harvard-lil/perma-scoop-api/blob/main/scoop_rest_api/config.py
 # We use it to:
 # - override the blocklist, to allow the capturing of docker-hosted pages in our test suite;
 # - enable additional attachments
@@ -150,7 +150,7 @@ SCOOP_CLI_OPTIONS = {
     - utils.config_check.EXCLUDED_SCOOP_CLI_OPTIONS
 """
 
-SCOOP_TIMEOUT_FUSE = 90
+SCOOP_TIMEOUT_FUSE = 60
 """ Number of seconds to wait before "killing" a Scoop progress after capture timeout. """
 
 


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API version](https://github.com/harvard-lil/perma-scoop-api/commit/dcc407c30b217866ab85a1b803b393ae2a2290aa).