### PR TITLE
Add sampling task

### DIFF
--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1433,7 +1433,10 @@ def sample_objects(ctx, n=1000):
         ).e_tag.strip('"')
 
     # obtain a sample of size n
-    links = Link.objects.filter(cached_can_play_back=True).order_by("?")[:n]
+    links = (
+        Link.objects.filter(warc_size__gt=0) |
+        Link.objects.filter(wacz_size__gt=0)
+    ).order_by("?")[:n]
 
     # build a list of paths
     objects = [

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timezone as tz
 from dateutil.relativedelta import relativedelta
 import hashlib
 from invoke import task
+import inspect
 import internetarchive
 import itertools
 import json
@@ -1411,3 +1412,128 @@ def populate_benchmarked_wacz_sizes(ctx, source_csv):
     links = Link.objects.filter(guid__in=guids).values_list('guid', flat=True)
     for link in links.iterator():
         populate_wacz_size.delay(link)
+
+
+@task
+def sample_objects(ctx, n=1000):
+    """
+    Produce a sample of archive paths and etags for assessing completeness
+    of mirroring; because the comparison happens on the mirror, which doesn't
+    know anything about Perma, it produces a Python program to run on the
+    mirror.
+
+    The sample size, n, must be of a size to produce at least ten failures,
+    given an expected proportion of failures.
+    """
+    def get_etag(bucket, path):
+        return storages[bucket].connection.Object(
+            bucket_name=storages[bucket].bucket_name,
+            key=os.path.join(settings.MEDIA_ROOT, path)
+        ).e_tag.strip('"')
+
+    # obtain a sample of size n
+    links = Link.objects.filter(cached_can_play_back=True).order_by("?")[:n]
+
+    # build a list of paths
+    objects = [
+        {
+            "warc": {
+                "path": link.warc_storage_file() if link.warc_size else None,
+                "etag": None
+            },
+            "wacz": {
+                "path": link.wacz_storage_file() if link.wacz_size else None,
+                "etag": None
+            }
+        }
+        for link in links
+    ]
+
+    buckets = {
+        "warc": settings.WARC_STORAGE,
+        "wacz": settings.WACZ_STORAGE
+    }
+
+    # add etags
+    for o in tqdm(objects):
+        for archive in ["warc", "wacz"]:
+            if o[archive]["path"]:
+                o[archive]["etag"] = get_etag(
+                    buckets[archive], o[archive]["path"]
+                )
+
+    # write to output file
+    filename = f"/tmp/sample-{n}-{datetime.isoformat(datetime.now())}.py"
+    with open(filename, "w") as f:
+        f.write(f"objects = {objects}\n")
+        f.write(inspect.getsource(check_mirror))
+        f.write('if __name__ == "__main__":\n    check_mirror()\n')
+
+    print(f"Sample of size {n} written into script {filename}")
+    print("Check it, then copy to the mirror and run it, e.g. with")
+    print(f"python3 {filename} {10 / n} <mirror directory> <...>")
+
+
+def check_mirror():
+    """
+    This is intended for use on the mirror as a main function.
+    The first argument on the command line is the expected proportion of
+    failures, expressed as a float.
+    The remaining arguments on the command line are directories containing
+    the folder "generated".
+    """
+    import hashlib
+    import math
+    from pathlib import Path
+
+    p = float(sys.argv[1])
+    directories = sys.argv[2:]
+
+    n = len(objects)  # noqa
+    successes = 0
+    failures = 0
+    blocksize = 2 ** 20
+
+    for o in objects:  # noqa
+        success = 0
+        failure = 0
+        for archive in ["warc", "wacz"]:
+            if o[archive]["path"]:
+                for d in directories:
+                    full_path = Path(d) / "generated" / o[archive]["path"]
+                    if full_path.exists():
+                        m = hashlib.md5()
+                        with open(full_path, "rb") as f:
+                            while True:
+                                buf = f.read(blocksize)
+                                if not buf:
+                                    break
+                                m.update(buf)
+                        if m.hexdigest() != o[archive]["etag"]:
+                            failure += 1
+                            print(
+                                f'etag mismatch for {o[archive]["path"]}'
+                            )
+                        else:
+                            success += 1
+        if not success:
+            print(f'no file found for {o[archive]["path"]}')
+        if failure or not success:
+            failures += 1
+        else:
+            successes += 1
+
+    assert successes + failures == n
+
+    p_hat = failures / n
+
+    sd = math.sqrt((p * (1 - p)) / n)
+
+    z = (p_hat - p) / sd
+
+    print(f"From a sample of {n} links:")
+    print(f"{successes} successes, {failures} failures")
+    print(f"Expected proportion is {p}")
+    print(f"Standard deviation is {sd}")
+    print(f"Observed proportion is {p_hat}")
+    print(f"z-score is {z}")

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -30,6 +30,7 @@ from django.utils import timezone
 from perma.celery_tasks import convert_warc_to_wacz, populate_wacz_size
 from perma.email import send_user_email, send_self_email, registrar_users, registrar_users_plus_stats
 from perma.models import Capture, Folder, HistoricalLink, Link, LinkUser, Organization, Registrar
+from perma.utils import calculate_s3_etag
 
 import logging
 logger = logging.getLogger(__name__)
@@ -1465,7 +1466,9 @@ def sample_objects(ctx, n=1000):
     # write to output file
     filename = f"/tmp/sample-{n}-{datetime.isoformat(datetime.now())}.py"
     with open(filename, "w") as f:
+        f.write("import hashlib\nimport math\nfrom pathlib import Path\n\n")
         f.write(f"objects = {objects}\n")
+        f.write(inspect.getsource(calculate_s3_etag))
         f.write(inspect.getsource(check_mirror))
         f.write('if __name__ == "__main__":\n    check_mirror()\n')
 
@@ -1482,10 +1485,6 @@ def check_mirror():
     The remaining arguments on the command line are directories containing
     the folder "generated".
     """
-    import hashlib
-    import math
-    from pathlib import Path
-
     p = float(sys.argv[1])
     directories = sys.argv[2:]
 
@@ -1502,14 +1501,9 @@ def check_mirror():
                 for d in directories:
                     full_path = Path(d) / "generated" / o[archive]["path"]
                     if full_path.exists():
-                        m = hashlib.md5()
                         with open(full_path, "rb") as f:
-                            while True:
-                                buf = f.read(blocksize)
-                                if not buf:
-                                    break
-                                m.update(buf)
-                        if m.hexdigest() != o[archive]["etag"]:
+                            etag = calculate_s3_etag(f, blocksize)
+                        if etag != o[archive]["etag"]:
                             failure += 1
                             print(
                                 f'etag mismatch for {o[archive]["path"]}'

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1433,10 +1433,7 @@ def sample_objects(ctx, n=1000):
         ).e_tag.strip('"')
 
     # obtain a sample of size n
-    links = (
-        Link.objects.filter(warc_size__gt=0) |
-        Link.objects.filter(wacz_size__gt=0)
-    ).order_by("?")[:n]
+    links = Link.objects.filter(cached_can_play_back=True).order_by("?")[:n]
 
     # build a list of paths
     objects = [

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1521,7 +1521,7 @@ def check_mirror():
 
     p_hat = failures / n
 
-    sd = math.sqrt((p * (1 - p)) / n)
+    sd = math.sqrt((p * (1 - p)) / n)  # noqa
 
     z = (p_hat - p) / sd
 


### PR DESCRIPTION
This is an experiment in asserting completeness of a backup of Perma WARC and WACZ files. We've done
something like this before, by enumeration; one brute-force approach is to enumerate all objects in the S3 buckets and record their etags, then see if any are not present on the mirror, or present but not with a matching etag.

Another approach is to enumerate, from Perma's database, all the artifacts that should be present, get their etags from S3, etc. Enumeration obviously becomes a bigger and bigger task as the collection grows, involves redoing work, and I think is somewhat fragile.

My idea is to assert completeness statistically. My first basic notion was something like "The null hypothesis is that at least 1 in x files do not make it to the mirror. To disprove the null hypothesis, you'd sample n in x captured files and, not seeing a failure, show that the chance of not seeing a failure in the sample, given the null hypothesis, falls below the typical value, a little under two percent."

On rereading part of my intro stats book, I think a better way of putting this is in terms of a sampling distribution model for a proportion. The proportion here is the proportion of artifacts that are not present on the mirror; a sampling distribution is a simulation, the distribution of the proportions from all possible samples. The basic idea is that it is normally distributed and so can be characterized like this:

"Provided that the sampled values are independent and the sample size (n) is large enough, the sampling distribution model of p̂ (observed proportion in the sample) is modeled by a Normal model with mean(p̂) = p (model parameter aka hypothesized proportion) and standard deviation of p̂ = the square root of (p * (1 - p)) / n."

The provisos (independent, large enough) translate to the randomization condition (sample is chosen randomly), the 10% condition (sample size is less than 10% of the population), and the success/failure condition (the sample size has to be big enough to expect at least ten successes and ten failures). That is, we can't test for a failure rate of one in five million (roughly, the population size), as we couldn't generate a sample size large enough in any case, let alone keeping it under 10% of the population.

A tenth of five million is 500,000 -- that seems like way too many to test. Let's say n is 1,000, well under 10% of the population. Then, let's pick proportions for success and failure that will produce ten failures; 99% success rate and 1% failure rate would produce ten failures and 990 successes in a sample of 1,000. The standard
deviation is the square root of ((0.99 * 0.01) / 1000), which is 0.00314642654451 or about a third of a percentage point (our unit of measure).

I expect that in a random sample of 1,000 links, the proportion of failures will be at least two standard deviations below the nominal 1% rate we're assuming here -- that is, that less than 2.5% of the time, a sample of this size drawn from a population with a true failure proportion of 1% would show fewer than four failures. In fact, I'm expecting our random sample to have one or zero failures, with only a one percent chance of occurring if the population actually had a 1% failure rate.

This PR adds an invoke task to generate a sample of Links, outputting object paths and etags. It generates a Python script to be run on the mirror, including the sample. That script compares the items in the sample with what is on disk, and reports successes, failures, standard deviation, and z-score; I think a second cut at this will add the probability of the seeing the proportion in the sample, probably using `NormalDist` from `statistics`, but I want to sanity-check this with a probability table first. :)

I am not sure about the pattern of generating a Python script as output; if that seems weird, I could generate the sample as JSON and keep the script somewhere else, maybe in `services/` in this repo. I'm not even that sure about generating the data and putting it in `/tmp`, but we do that in other tasks.

It is quite possible this is wrong. If any of this is confusing, please let me know!