### PR TITLE
Refactor how capture jobs are finished

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -91,15 +91,9 @@ def inc_progress(capture_job, inc, description):
     print(f"{capture_job.link.guid} step {capture_job.step_count}: {capture_job.step_description}")
 
 
-
 ### CAPTURE COMPLETION ###
 
-def save_scoop_capture(link, capture_job, data):
-
-    #
-    # Download Archive
-    #
-
+def save_scoop_archive(link, capture_job, data):
     inc_progress(capture_job, 1, "Downloading web archive file (WACZ)")
 
     # mode set to 'ab+' as a workaround for https://github.com/python/cpython/issues/69528
@@ -145,12 +139,12 @@ def save_scoop_capture(link, capture_job, data):
             tmp_file, link.wacz_storage_file(), overwrite=True
         )
 
+
+def save_archive_metadata(link, capture_job, data):
+
     inc_progress(capture_job, 1, "Saving metadata")
 
-    #
-    # PRIMARY CAPTURE
-    #
-
+    # Primary capture
     link.primary_capture.status = 'success'
     link.primary_capture.content_type = data['scoop_capture_summary']['targetUrlContentType']
     link.primary_capture.save(update_fields=['status', 'content_type'])
@@ -182,10 +176,7 @@ def save_scoop_capture(link, capture_job, data):
                 'private_reason'
             ])
 
-    #
     # Provenance
-    #
-
     provenance_filename = data['scoop_capture_summary']['attachments'].get("provenanceSummary")
     if provenance_filename:
         Capture(
@@ -209,10 +200,7 @@ def save_scoop_capture(link, capture_job, data):
         link.tags.add('scoop-missing-provenance')
         logger.warning(f"{capture_job.link_id}: Scoop warc does not contain provenance summary ({data['id_capture']}).")
 
-    #
-    # OTHER ATTACHMENTS
-    #
-
+    # Other attachments
     supported_attachments = {
         "screenshot": {
             'attr': 'screenshot',
@@ -243,9 +231,6 @@ def save_scoop_capture(link, capture_job, data):
                 url=f"file:///{attachment_filename}",
                 content_type=supported_attachments[attachment_type]['content_type'],
             ).save()
-
-
-    capture_job.mark_completed()
 
 
 def clean_up_failed_captures():
@@ -397,7 +382,9 @@ def capture_with_scoop(capture_job):
     finally:
         try:
             if success:
-                save_scoop_capture(link, capture_job, poll_data)
+                save_scoop_archive(link, capture_job, poll_data)
+                save_archive_metadata(link, capture_job, poll_data)
+                capture_job.mark_completed()
                 print(f"{capture_job.link_id} capture succeeded.")
             else:
                 print(f"{capture_job.link_id} capture failed.")

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -17,7 +17,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from celery.signals import task_failure
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from urllib3.exceptions import ProtocolError
+from urllib3.exceptions import ProtocolError, ReadTimeoutError
 from zipfile import ZipFile
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
@@ -32,7 +32,7 @@ from django.template.defaultfilters import pluralize, filesizeformat
 
 from perma.models import LinkUser, Link, Capture, \
     CaptureJob, InternetArchiveItem, InternetArchiveFile, Folder, Sponsorship, UserOrganizationAffiliation
-from perma.exceptions import PermaPaymentsCommunicationException, ScoopAPINetworkException
+from perma.exceptions import PermaPaymentsCommunicationException, ScoopAPINetworkException, ScoopAPIException
 from perma.utils import (
     remove_whitespace,
     get_ia_session, ia_global_task_limit_approaching,
@@ -127,9 +127,18 @@ def save_scoop_capture(link, capture_job, data):
             link.wacz_size = tmp_file.tell()
             link.save(update_fields=['wacz_size'])
 
-        # See Linear issue LIL-2877 for discussion of `ProtocolError`s
-        retry_on_exception(download_wacz, exception=ProtocolError, attempts=settings.SCOOP_WACZ_DOWNLOAD_RETRIES)
-
+        # See Linear issue LIL-2877 for discussion of these exceptions
+        retry_on_exception(
+            download_wacz,
+            exception=(
+                ProtocolError,
+                ReadTimeoutError,
+                ScoopAPINetworkException,
+                ScoopAPIException,
+                SoftTimeLimitExceeded
+            ),
+            attempts=settings.SCOOP_WACZ_DOWNLOAD_RETRIES
+        )
         inc_progress(capture_job, 1, "Saving web archive file (WACZ)")
         tmp_file.seek(0)
         storages[settings.WACZ_STORAGE].store_file(

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -96,6 +96,46 @@ def inc_progress(capture_job, inc, description):
 
 def save_scoop_capture(link, capture_job, data):
 
+    #
+    # Download Archive
+    #
+
+    inc_progress(capture_job, 1, "Downloading web archive file (WACZ)")
+
+    # mode set to 'ab+' as a workaround for https://github.com/python/cpython/issues/69528
+    with tempfile.TemporaryFile('ab+') as tmp_file:
+
+        def download_wacz():
+
+            # Send the API request
+            response, _ = send_to_scoop(
+                method="get",
+                path=f"artifact/{data['id_capture']}/archive.wacz",
+                valid_if=lambda code, _: code == 200,
+                stream=True
+            )
+
+            # Write the response, chunk by chunk, into the temp file.
+            # Use the raw response, because Python requests standard methods gunzip the file
+            tmp_file.seek(0)
+            for chunk in response.raw.stream(10 * 1024, decode_content=False):
+                if chunk:
+                    tmp_file.write(chunk)
+
+            # Record the file size
+            tmp_file.flush()
+            link.wacz_size = tmp_file.tell()
+            link.save(update_fields=['wacz_size'])
+
+        # See Linear issue LIL-2877 for discussion of `ProtocolError`s
+        retry_on_exception(download_wacz, exception=ProtocolError, attempts=settings.SCOOP_WACZ_DOWNLOAD_RETRIES)
+
+        inc_progress(capture_job, 1, "Saving web archive file (WACZ)")
+        tmp_file.seek(0)
+        storages[settings.WACZ_STORAGE].store_file(
+            tmp_file, link.wacz_storage_file(), overwrite=True
+        )
+
     inc_progress(capture_job, 1, "Saving metadata")
 
     #
@@ -195,45 +235,6 @@ def save_scoop_capture(link, capture_job, data):
                 content_type=supported_attachments[attachment_type]['content_type'],
             ).save()
 
-
-    #
-    # Download Archive
-    #
-    inc_progress(capture_job, 1, "Downloading web archive file (WACZ)")
-
-    # mode set to 'ab+' as a workaround for https://github.com/python/cpython/issues/69528
-    with tempfile.TemporaryFile('ab+') as tmp_file:
-
-        def download_wacz():
-
-            # Send the API request
-            response, _ = send_to_scoop(
-                method="get",
-                path=f"artifact/{data['id_capture']}/archive.wacz",
-                valid_if=lambda code, _: code == 200,
-                stream=True
-            )
-
-            # Write the response, chunk by chunk, into the temp file.
-            # Use the raw response, because Python requests standard methods gunzip the file
-            tmp_file.seek(0)
-            for chunk in response.raw.stream(10 * 1024, decode_content=False):
-                if chunk:
-                    tmp_file.write(chunk)
-
-            # Record the file size
-            tmp_file.flush()
-            link.wacz_size = tmp_file.tell()
-            link.save(update_fields=['wacz_size'])
-
-        # See Linear issue LIL-2877 for discussion of `ProtocolError`s
-        retry_on_exception(download_wacz, exception=ProtocolError, attempts=settings.SCOOP_WACZ_DOWNLOAD_RETRIES)
-
-        inc_progress(capture_job, 1, "Saving web archive file (WACZ)")
-        tmp_file.seek(0)
-        storages[settings.WACZ_STORAGE].store_file(
-            tmp_file, link.wacz_storage_file(), overwrite=True
-        )
 
     capture_job.mark_completed()
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -102,8 +102,9 @@ def save_scoop_capture(link, capture_job, data):
     # PRIMARY CAPTURE
     #
 
+    link.primary_capture.status = 'success'
     link.primary_capture.content_type = data['scoop_capture_summary']['targetUrlContentType']
-    link.primary_capture.save(update_fields=['content_type'])
+    link.primary_capture.save(update_fields=['status', 'content_type'])
 
     if 'pageInfo' in data['scoop_capture_summary']:
         title = data['scoop_capture_summary']['pageInfo'].get('title')
@@ -288,6 +289,7 @@ def capture_with_scoop(capture_job):
         # Basic setup
         link = capture_job.link
         target_url = link.ascii_safe_url
+        success = False
 
         # Get started, unless the user has deleted the capture in the meantime
         inc_progress(capture_job, 0, "Starting capture")
@@ -352,8 +354,7 @@ def capture_with_scoop(capture_job):
         capture_job.save(update_fields=['scoop_logs', 'scoop_state'])
 
         if poll_data['status'] == 'success':
-            link.primary_capture.status = 'success'
-            link.primary_capture.save(update_fields=['status'])
+            success = True
         else:
             didnt_load = "ERROR Navigation to page failed (about:blank)"
             proxy_error = "ERROR An error occurred during capture setup"
@@ -385,7 +386,7 @@ def capture_with_scoop(capture_job):
         logger.exception(f"Exception while capturing job {capture_job.link_id}:")
     finally:
         try:
-            if link.primary_capture.status == 'success':
+            if success:
                 save_scoop_capture(link, capture_job, poll_data)
                 print(f"{capture_job.link_id} capture succeeded.")
             else:


### PR DESCRIPTION
See LIL-2904.

We have found that occasionally, there are network blips when Perma attempts to download artifacts from the Scoop API. Our code didn't originally account for that possibility. This PR is a followup to https://github.com/harvard-lil/perma/pull/3656, where we added retries. 

It:
- retries on a larger set of exceptions, which I collected by looking at the full set of errors that took place while downloads were attempted in the last year;
- it switches the order of operations, so that we download the artifact _before_ we save any metadata claiming that the job has succeeded; and
- separates the downloading and metadata saving steps into two separate functions, for improved readability.