### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:114-3fce3766dcb4fc615ddf470a202914a0
+    image: registry.lil.tools/harvardlil/scoop-rest-api:115-b5a7074a9cc60e0ec6037f960dab7d80
     init: true
     tty: true
     depends_on:

--- a/services/docker/scoop-rest-api/config.py
+++ b/services/docker/scoop-rest-api/config.py
@@ -1,4 +1,4 @@
-# This is the default config.py from the Scoop REST API as of 11/12/2024
+# This is the default config.py from the Scoop REST API as of 11/19/2024
 # https://github.com/harvard-lil/perma-scoop-api/blob/main/scoop_rest_api/config.py
 # We use it to:
 # - override the blocklist, to allow the capturing of docker-hosted pages in our test suite;


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API version](https://github.com/harvard-lil/perma-scoop-api/commit/97a68ef1582fd7fb7f4abcc1ec71b3992f94184b).