### PR TITLE
Fix potential form ID discrepancy between search form text input and button

### DIFF
--- a/perma_web/perma/templates/user_management/includes/search_form.html
+++ b/perma_web/perma/templates/user_management/includes/search_form.html
@@ -3,6 +3,6 @@
     <div class="form-group fg-inline fg-search">
       <input aria-label="Enter your search query here" type="text" name="q" value="{{ search_query|default:"" }}" placeholder="{{ search_placeholder|default:"Search" }}" class="search-query"{% if form_id %} form="{{ form_id }}"{% endif %}/>
     </div>
-    <button aria-label="Submit" type="submit" name="submit" value="1" class="btn btn-default btn-inline btn-search"><span class="icon-search"></span></button>
+    <button aria-label="Submit" type="submit" name="submit" value="1" class="btn btn-default btn-inline btn-search"{% if form_id %} form="{{ form_id }}"{% endif %}><span class="icon-search"></span></button>
   </fieldset>
 </form>


### PR DESCRIPTION
In https://github.com/harvard-lil/perma/pull/3659 we modified the `search_form.html` template so the search text input can point to an arbitrary form. (This is useful on the paid registrar approval page, because there are two forms that submit data using different methods.)

I missed one detail: if an arbitrary `form_id` is supplied, the search submission button needs to point to it as well. Otherwise, hitting <kbd>Enter</kbd> within the text input and clicking the submit button may produce unexpectedly different results.