### PR TITLE
Annotate query results with QuerySet instead of BaseManager

### DIFF
--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -24,7 +24,7 @@ from django.core.files.storage import storages
 from django.core.paginator import EmptyPage, Page, Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Q
-from django.db.models.manager import BaseManager
+from django.db.models.query import QuerySet
 from django.http import (
     Http404,
     HttpRequest,
@@ -118,8 +118,8 @@ class AlphaNumericValidator:
 ### list view helpers ###
 
 def apply_search_query(
-    request: HttpRequest, queryset: BaseManager[T], fields: list[str]
-) -> tuple[BaseManager[T], str]:
+    request: HttpRequest, queryset: QuerySet[T], fields: list[str]
+) -> tuple[QuerySet[T], str]:
     """
     For the given `queryset`,
     apply consecutive .filter()s such that each word
@@ -146,10 +146,10 @@ def apply_search_query(
 
 def apply_sort_order(
     request: HttpRequest,
-    queryset: BaseManager[T],
+    queryset: QuerySet[T],
     valid_sorts: list[str],
     default_sort: str | None = None,
-) -> tuple[BaseManager[T], str]:
+) -> tuple[QuerySet[T], str]:
     """
         For the given `queryset`,
         apply sort order based on request.GET['sort'].
@@ -165,7 +165,7 @@ def apply_sort_order(
         sort = default_sort
     return queryset.order_by(sort), sort
 
-def apply_pagination(request: HttpRequest, queryset: BaseManager[T]) -> Page:
+def apply_pagination(request: HttpRequest, queryset: QuerySet[T]) -> Page:
     """
         For the given `queryset`,
         apply pagination based on request.GET['page'].
@@ -185,7 +185,7 @@ def apply_pagination(request: HttpRequest, queryset: BaseManager[T]) -> Page:
 
 
 def export_queryset(
-    queryset: BaseManager[T],
+    queryset: QuerySet[T],
     export_format: Literal['csv', 'json'],
     field_names: list[str],
     filename: str = 'export',

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -8,7 +8,7 @@ from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, F, Max, Sum
 from django.db.models.functions import Coalesce, Greatest
-from django.db.models.manager import BaseManager
+from django.db.models.query import QuerySet
 from django.http import (
     Http404,
     HttpRequest,
@@ -578,7 +578,7 @@ def list_users_in_group(request: HttpRequest, group_name: str, export: bool = Fa
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
 def list_sponsored_users(
     request: HttpRequest, group_name: str = 'sponsored_user', export: bool = False
-) -> HttpResponse | BaseManager[LinkUser]:
+) -> HttpResponse | QuerySet[LinkUser]:
     """
     Show list of sponsored users. Adapted from `list_users_in_group` for improved performance.
 

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
-from django.db.models.manager import BaseManager
+from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -386,7 +386,7 @@ def firm_request_response(request):
     return render(request, 'registration/firm_request.html')
 
 
-def suggest_registrars(user: LinkUser, limit: int = 5) -> BaseManager[Registrar]:
+def suggest_registrars(user: LinkUser, limit: int = 5) -> QuerySet[Registrar]:
     """Suggest potential registrars for a user based on email domain.
 
     This queries the database for registrars whose website matches the


### PR DESCRIPTION
In https://github.com/harvard-lil/perma/pull/3659, we discussed finding a better type annotation for Django ORM querysets than `BaseManager`.

I had the impression we'd need to add an external dependency for this, but it turns out we can in fact do `QuerySet[LinkUser]` and so on. Moreover, [django-stubs](https://github.com/typeddjango/django-stubs) seems to have its own nuances (and only supports Mypy?); seems not worth bringing in at present.

This branch swaps `QuerySet` type hints in for all our existing `BaseManager`s. There should be zero impact on Perma functionality, as this is purely a dev-side change.