### PR TITLE
Tiny tweaks to form processing

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -499,11 +499,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
             raise forms.ValidationError("CSV file must contain a header row with first_name, last_name and email columns.")
 
         # validate the rows
-        seen = set()
-        row_count = 0
-
         for row in reader:
-            row_count += 1
             email = row.get('email')
             email = email.strip() if email else None
 
@@ -516,7 +512,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
             except ValidationError:
                 raise forms.ValidationError(f"CSV file contains invalid email address: {email}")
 
-            if email in seen:
+            if email in self.user_data:
                 raise forms.ValidationError(f"CSV file cannot contain duplicate users: {email}")
             else:
                 seen.add(email)
@@ -525,7 +521,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
                     'last_name': row.get('last_name', '').strip()
                 }
 
-        if row_count == 0:
+        if not len(self.user_data):
             raise forms.ValidationError("CSV file must contain at least one user.")
 
         file.seek(0)

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -531,18 +531,19 @@ class MultipleUsersFormWithOrganization(ModelForm):
     def save(self, commit=True):
         expires_at = self.cleaned_data['expires_at']
         organization = self.cleaned_data['organizations']
-        affiliations_to_create = []
 
         all_emails = set(self.user_data.keys())
-        existing_users = LinkUser.objects.filter(email__in=all_emails)
+        affiliations_to_create = []
 
+        # find any existing users, and exclude any that are ineligible to become org users
+        existing_users = LinkUser.objects.filter(email__in=all_emails)
         for user in existing_users:
             if user.is_staff or user.is_registrar_user():
                 self.ineligible_users[user.email] = user
             else:
                 self.updated_users[user.email] = user
 
-        # update the expiration date of any affiliations that already exist
+        # update the affiliation expiration date for any already-affiliated users
         preexisting_affiliations = UserOrganizationAffiliation.objects.filter(
             user__in=self.updated_users.values(),
             organization=organization

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -553,7 +553,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
 
         # build affiliation objects for existing users that need them
         users_with_existing_affiliations = set(affiliation.user for affiliation in preexisting_affiliations)
-        users_without_existing_affiliations = set(self.updated_users.values())- users_with_existing_affiliations
+        users_without_existing_affiliations = set(self.updated_users.values()) - users_with_existing_affiliations
         for user in users_without_existing_affiliations:
             affiliations_to_create.append(UserOrganizationAffiliation(
                 user=user,

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -560,16 +560,17 @@ class MultipleUsersFormWithOrganization(ModelForm):
                 expires_at=expires_at
             ))
 
+        # create new users and their affiliation objects
         new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
-
-        if new_user_emails and commit:
+        if new_user_emails:
             for email in new_user_emails:
                 new_user = LinkUser(
                         email=self.user_data[email]['raw_email'],
                         first_name=self.user_data[email]['first_name'],
                         last_name=self.user_data[email]['last_name']
                 )
-                new_user.save()
+                if commit:
+                    new_user.save()
                 self.created_users[email] = new_user
 
                 affiliations_to_create.append(

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -512,11 +512,11 @@ class MultipleUsersFormWithOrganization(ModelForm):
             except ValidationError:
                 raise forms.ValidationError(f"CSV file contains invalid email address: {email}")
 
-            if email in self.user_data:
+            if email.lower() in self.user_data:
                 raise forms.ValidationError(f"CSV file cannot contain duplicate users: {email}")
             else:
-                seen.add(email)
-                self.user_data[email] = {
+                self.user_data[email.lower()] = {
+                    'raw_email': email,
                     'first_name': row.get('first_name', '').strip(),
                     'last_name': row.get('last_name', '').strip()
                 }
@@ -532,10 +532,8 @@ class MultipleUsersFormWithOrganization(ModelForm):
         expires_at = self.cleaned_data['expires_at']
         organization = self.cleaned_data['organizations']
 
-        raw_emails = set(self.user_data.keys())
-        # lower casing the emails to feed into the filter query in order to prevent duplicate user creation
-        lower_case_emails = {email.lower() for email in self.user_data.keys()}
-        existing_users = LinkUser.objects.filter(email__in=lower_case_emails)
+        all_emails = set(self.user_data.keys())
+        existing_users = LinkUser.objects.filter(email__in=all_emails)
         updated_user_affiliations = []
 
         for user in existing_users:
@@ -546,17 +544,16 @@ class MultipleUsersFormWithOrganization(ModelForm):
                     updated_user_affiliations.append(user)
                     self.updated_users[user.email] = user
 
-        new_user_emails = lower_case_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
+        new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
 
         created_user_affiliations = []
 
         if new_user_emails and commit:
             for email in new_user_emails:
-                raw_email = next((raw_email for raw_email in raw_emails if raw_email.lower() == email.lower()), None)
                 new_user = LinkUser(
-                        email=raw_email,
-                        first_name=self.user_data[raw_email]['first_name'],
-                        last_name=self.user_data[raw_email]['last_name']
+                        email=self.user_data[email]['raw_email'],
+                        first_name=self.user_data[email]['first_name'],
+                        last_name=self.user_data[email]['last_name']
                 )
                 new_user.save()
                 self.created_users[email] = new_user

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -562,24 +562,23 @@ class MultipleUsersFormWithOrganization(ModelForm):
 
         # create new users and their affiliation objects
         new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
-        if new_user_emails:
-            for email in new_user_emails:
-                new_user = LinkUser(
-                        email=self.user_data[email]['raw_email'],
-                        first_name=self.user_data[email]['first_name'],
-                        last_name=self.user_data[email]['last_name']
-                )
-                if commit:
-                    new_user.save()
-                self.created_users[email] = new_user
+        for email in new_user_emails:
+            new_user = LinkUser(
+                    email=self.user_data[email]['raw_email'],
+                    first_name=self.user_data[email]['first_name'],
+                    last_name=self.user_data[email]['last_name']
+            )
+            if commit:
+                new_user.save()
+            self.created_users[email] = new_user
 
-                affiliations_to_create.append(
-                    UserOrganizationAffiliation(
-                        user=new_user,
-                        organization=organization,
-                        expires_at=expires_at
-                    )
+            affiliations_to_create.append(
+                UserOrganizationAffiliation(
+                    user=new_user,
+                    organization=organization,
+                    expires_at=expires_at
                 )
+            )
 
         # create new affiliation objects
         if affiliations_to_create and commit:

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -521,7 +521,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
                     'last_name': row.get('last_name', '').strip()
                 }
 
-        if not len(self.user_data):
+        if not self.user_data:
             raise forms.ValidationError("CSV file must contain at least one user.")
 
         file.seek(0)

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -542,6 +542,29 @@ class MultipleUsersFormWithOrganization(ModelForm):
                 else:
                     self.updated_users[user.email] = user
 
+        # update the expiration date of any affiliations that already exist
+        preexisting_affiliations = UserOrganizationAffiliation.objects.filter(
+            user__in=self.updated_users.values(),
+            organization=organization
+        )
+        if preexisting_affiliations and commit:
+            preexisting_affiliations.update(expires_at=expires_at)
+
+        # build affiliation objects for existing users that need them
+        users_with_existing_affiliations = set(affiliation.user for affiliation in preexisting_affiliations)
+        users_without_existing_affiliations = set(self.updated_users.values())- users_with_existing_affiliations
+        new_affiliation_objs = []
+        for user in users_without_existing_affiliations:
+            new_affiliation_objs.append(UserOrganizationAffiliation(
+                user=user,
+                organization=organization,
+                expires_at=expires_at
+            ))
+
+        if new_affiliation_objs and commit:
+            UserOrganizationAffiliation.objects.bulk_create(new_affiliation_objs)
+
+
         new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
 
         created_user_affiliations = []
@@ -567,28 +590,6 @@ class MultipleUsersFormWithOrganization(ModelForm):
         if commit:
             # create the affiliations for new users
             UserOrganizationAffiliation.objects.bulk_create(created_user_affiliations)
-
-            # create or update the affiliations of existing users
-            # affiliations that already exist
-            preexisting_affiliations = (UserOrganizationAffiliation.objects.filter(user__in=self.updated_users.values(),
-                                                                                   organization=organization))
-
-            preexisting_affiliations_set = set(affiliation.user for affiliation in preexisting_affiliations)
-            # new affiliations
-            new_affiliations = set(self.updated_users.values())- preexisting_affiliations_set
-            new_affiliation_objs = []
-
-            for item in new_affiliations:
-                new_affiliation_objs.append(UserOrganizationAffiliation(
-                    user=item,
-                    organization=organization,
-                    expires_at=expires_at
-                ))
-
-            if preexisting_affiliations:
-                preexisting_affiliations.update(expires_at=expires_at)
-            if new_affiliation_objs:
-                UserOrganizationAffiliation.objects.bulk_create(new_affiliation_objs)
 
         return self
 

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -531,6 +531,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
     def save(self, commit=True):
         expires_at = self.cleaned_data['expires_at']
         organization = self.cleaned_data['organizations']
+        affiliations_to_create = []
 
         all_emails = set(self.user_data.keys())
         existing_users = LinkUser.objects.filter(email__in=all_emails)
@@ -553,21 +554,14 @@ class MultipleUsersFormWithOrganization(ModelForm):
         # build affiliation objects for existing users that need them
         users_with_existing_affiliations = set(affiliation.user for affiliation in preexisting_affiliations)
         users_without_existing_affiliations = set(self.updated_users.values())- users_with_existing_affiliations
-        new_affiliation_objs = []
         for user in users_without_existing_affiliations:
-            new_affiliation_objs.append(UserOrganizationAffiliation(
+            affiliations_to_create.append(UserOrganizationAffiliation(
                 user=user,
                 organization=organization,
                 expires_at=expires_at
             ))
 
-        if new_affiliation_objs and commit:
-            UserOrganizationAffiliation.objects.bulk_create(new_affiliation_objs)
-
-
         new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
-
-        created_user_affiliations = []
 
         if new_user_emails and commit:
             for email in new_user_emails:
@@ -579,7 +573,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
                 new_user.save()
                 self.created_users[email] = new_user
 
-                created_user_affiliations.append(
+                affiliations_to_create.append(
                     UserOrganizationAffiliation(
                         user=new_user,
                         organization=organization,
@@ -587,9 +581,9 @@ class MultipleUsersFormWithOrganization(ModelForm):
                     )
                 )
 
-        if commit:
-            # create the affiliations for new users
-            UserOrganizationAffiliation.objects.bulk_create(created_user_affiliations)
+        # create new affiliation objects
+        if affiliations_to_create and commit:
+            UserOrganizationAffiliation.objects.bulk_create(affiliations_to_create)
 
         return self
 

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -532,7 +532,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
         expires_at = self.cleaned_data['expires_at']
         organization = self.cleaned_data['organizations']
 
-        all_emails = set(self.user_data.keys())
+        all_emails = set(self.user_data)
         affiliations_to_create = []
 
         # find any existing users, and exclude any that are ineligible to become org users
@@ -562,7 +562,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
             ))
 
         # create new users and their affiliation objects
-        new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
+        new_user_emails = all_emails - set(self.ineligible_users) - set(self.updated_users)
         for email in new_user_emails:
             new_user = LinkUser(
                     email=self.user_data[email]['raw_email'],

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -534,14 +534,12 @@ class MultipleUsersFormWithOrganization(ModelForm):
 
         all_emails = set(self.user_data.keys())
         existing_users = LinkUser.objects.filter(email__in=all_emails)
-        updated_user_affiliations = []
 
         for user in existing_users:
             if commit:
                 if user.is_staff or user.is_registrar_user():
                     self.ineligible_users[user.email] = user
                 else:
-                    updated_user_affiliations.append(user)
                     self.updated_users[user.email] = user
 
         new_user_emails = all_emails - set(self.ineligible_users.keys()) - set(self.updated_users.keys())
@@ -572,13 +570,12 @@ class MultipleUsersFormWithOrganization(ModelForm):
 
             # create or update the affiliations of existing users
             # affiliations that already exist
-            preexisting_affiliations = (UserOrganizationAffiliation.objects.filter(user__in=updated_user_affiliations,
+            preexisting_affiliations = (UserOrganizationAffiliation.objects.filter(user__in=self.updated_users.values(),
                                                                                    organization=organization))
 
             preexisting_affiliations_set = set(affiliation.user for affiliation in preexisting_affiliations)
-            all_user_affiliations = set(updated_user_affiliations)
             # new affiliations
-            new_affiliations = all_user_affiliations - preexisting_affiliations_set
+            new_affiliations = set(self.updated_users.values())- preexisting_affiliations_set
             new_affiliation_objs = []
 
             for item in new_affiliations:

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -546,7 +546,7 @@ class MultipleUsersFormWithOrganization(ModelForm):
         preexisting_affiliations = UserOrganizationAffiliation.objects.filter(
             user__in=self.updated_users.values(),
             organization=organization
-        )
+        ).select_related('user')
         if preexisting_affiliations and commit:
             preexisting_affiliations.update(expires_at=expires_at)
 

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -537,11 +537,10 @@ class MultipleUsersFormWithOrganization(ModelForm):
         existing_users = LinkUser.objects.filter(email__in=all_emails)
 
         for user in existing_users:
-            if commit:
-                if user.is_staff or user.is_registrar_user():
-                    self.ineligible_users[user.email] = user
-                else:
-                    self.updated_users[user.email] = user
+            if user.is_staff or user.is_registrar_user():
+                self.ineligible_users[user.email] = user
+            else:
+                self.updated_users[user.email] = user
 
         # update the expiration date of any affiliations that already exist
         preexisting_affiliations = UserOrganizationAffiliation.objects.filter(


### PR DESCRIPTION
This PR makes just a few tweaks to the how the new form for adding many users to an organization at a time saves data. 

- it adjusts when `if commit` is checked, so that all the logic except for the actual write operations is run if `commit` is `False`

- it creates new `OrganizationAffiliation` objects all together in one batch, instead of two batches (one for brand new users and one for existing users)

- when retrieving the collection of existing affiliation objects, it uses `select_related('user')`, so that later, when running `set(affiliation.user for affiliation in preexisting_affiliations)`, each call to `affiliation.user` does not trigger a separate call to the database

- it adjusts how we handle potentially mixed/uppercase and cast-to-lowercase email addresses so that a) duplicate emails are detected in the CSV even if they differ in casing, and b) we can retrieve the raw email address from `self.user_data`

I took the liberty of renaming a few variables, adding a few comments, and slightly changing the order of operations, so that existing users are handled first, and then we move on to new users.