### PR TITLE
Disallow firm names that are too long and cause database errors

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -102,6 +102,9 @@ class LibraryRegistrarForm(ModelForm):
 ### FIRM (OTHER ORG) QUOTE FORMS ###
 
 class FirmRegistrarForm(ModelForm):
+    # Ensure firm name doesn't throw a DataError when we write it to LinkUser.requested_account_note
+    name = forms.CharField(max_length=LinkUser.requested_account_note.field.max_length)
+
     class Meta:
         model = Registrar
         fields = ['name', 'email', 'website']

--- a/perma_web/perma/models.py
+++ b/perma_web/perma/models.py
@@ -1,57 +1,62 @@
 import calendar
 from contextlib import contextmanager
+from datetime import datetime
+from datetime import timezone as tz
 from decimal import Decimal
-from datetime import datetime, timezone as tz
-from dateutil.relativedelta import relativedelta
 import hashlib
+import hmac
+import itertools
 import json
-import os
 import logging
+import os
 import random
 import re
-from urllib.parse import urlparse
-import simple_history
-import requests
-import itertools
 import time
-import hmac
+from urllib.parse import urlparse
 import uuid
-from psycopg2.extras import DateTimeTZRange
 import zipfile
 
-from rest_framework.settings import api_settings
-from simple_history.models import HistoricalRecords
-from tree_queries.models import TreeNode
-from tree_queries.query import TreeQuerySet
-
-import django.contrib.auth.models
-from django.contrib.auth.models import BaseUserManager, AbstractBaseUser, PermissionsMixin
-from django.contrib.postgres.fields import ArrayField, DateTimeRangeField
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
+import django.contrib.auth.models
+from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
+from django.contrib.postgres.fields import ArrayField, DateTimeRangeField
+from django.contrib.postgres.indexes import GinIndex, GistIndex, OpClass
 from django.core.files.storage import storages
 from django.db import models, transaction
-from django.db.models import Q, Max, Count, Sum, JSONField, F, Exists, OuterRef, When, Case
-from django.db.models.functions import Now, Upper, TruncDate
+from django.db.models import Case, Count, Exists, F, JSONField, Max, OuterRef, Q, Sum, When
+from django.db.models.functions import Now, TruncDate, Upper
 from django.db.models.query import QuerySet
-from django.contrib.postgres.indexes import GistIndex, GinIndex, OpClass
 from django.template.defaultfilters import truncatechars
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.views.decorators.debug import sensitive_variables
 from model_utils import FieldTracker
+from psycopg2.extras import DateTimeTZRange
+import requests
+from rest_framework.settings import api_settings
+import simple_history
+from simple_history.models import HistoricalRecords
 import surt
 from taggit.managers import TaggableManager
 from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
+from tree_queries.models import TreeNode
+from tree_queries.query import TreeQuerySet
 
-from .exceptions import PermaPaymentsCommunicationException, InvalidTransmissionException
-from .utils import (tz_datetime,
-    prep_for_perma_payments, process_perma_payments_transmission,
+from perma.exceptions import InvalidTransmissionException, PermaPaymentsCommunicationException
+from perma.utils import (
+    first_day_of_next_month,
     pp_date_from_post,
-    first_day_of_next_month, today_next_year, preserve_perma_warc,
+    prep_for_perma_payments,
+    preserve_perma_warc,
+    process_perma_payments_transmission,
+    protocol,
+    remove_control_characters,
+    today_next_year,
+    tz_datetime,
     write_resource_record_from_asset,
-    protocol, remove_control_characters)
-
+)
 
 logger = logging.getLogger(__name__)
 

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -4,10 +4,10 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm
-from django.http import HttpResponseRedirect, Http404, HttpResponseForbidden
+from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
+from django.shortcuts import render
 from django.urls import reverse
 from django.utils import timezone
-from django.shortcuts import render
 from django.views.decorators.debug import sensitive_variables
 from django.views.decorators.http import require_http_methods
 

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -24,10 +24,7 @@ from perma.forms import (
     UserForm,
     check_honeypot,
 )
-from perma.models import (
-    LinkUser,
-    Registrar,
-)
+from perma.models import LinkUser, Registrar
 from perma.utils import (
     apply_pagination,
     apply_search_query,


### PR DESCRIPTION
This fixes an obscure bug (see LIL-2915) wherein submitting a firm name longer than 45 characters caused a `DataError: value too long for type character varying(45)`.

The reason for the bug is that we stick proposed registrar names in a couple different fields as part of the Firms and Courts sign-up processes, notably `Registrar.name` (max length = 400 chars) and `LinkUser.requested_account_name` (max length = 45 chars). As a result, some extra care must be taken when passing registrar names around.

After considering a few approaches, it seemed best to just make Firms consistent with the way we do it on Courts, i.e. disallow names longer than 45 chars (even though `Registrar.name` technically allows for 400). This prevents users from even typing invalid names into the form field and thus stops the potential issue at the source.