### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:120-2bf1d3670f6835bfd8e9bd1096b5fd7d
+    image: registry.lil.tools/harvardlil/scoop-rest-api:122-bc7f2800f4bcc2b4b91d8c50f9ce50d0
     init: true
     tty: true
     depends_on:

--- a/services/docker/scoop-rest-api/config.py
+++ b/services/docker/scoop-rest-api/config.py
@@ -1,4 +1,4 @@
-# This is the default config.py from the Scoop REST API as of 12/04/2024
+# This is the default config.py from the Scoop REST API as of 12/10/2024
 # https://github.com/harvard-lil/perma-scoop-api/blob/main/scoop_rest_api/config.py
 # We use it to:
 # - override the blocklist, to allow the capturing of docker-hosted pages in our test suite;


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API version](https://github.com/harvard-lil/perma-scoop-api/commit/9614fe96175a5b4af47e670aa7c8ea4ec0639a9b): 0.6.41.