### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:123-e618c756ba407d232769a2eeb038867d
+    image: registry.lil.tools/harvardlil/scoop-rest-api:124-f89c580766f587f5156b10f873972ea8
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API version](https://github.com/harvard-lil/perma-scoop-api/commit/2f6349f235df9af76b3c17bb9af0f5f308fbf6a6): 0.6.42.