### PR TITLE
Minimal upgrade to Postgres 16

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -91,7 +91,7 @@ services:
       - perma_payments
 
   perma-payments:
-    image: registry.lil.tools/harvardlil/perma-payments:19-feb5e21507118e85975cc35a5e15c5c4
+    image: registry.lil.tools/harvardlil/perma-payments:20-cd472eae28bb3affe3b6da1880ff17a2
     # hack: sleep to give the database time to start up
     command: >
       sh -c "sleep 5 && ./manage.py migrate && invoke run"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -82,11 +82,11 @@ services:
   # Perma Payments
   #
   pp_db:
-    image: registry.lil.tools/library/postgres:12.8
+    image: registry.lil.tools/library/postgres:16.6
     environment:
       - POSTGRES_PASSWORD=example
     volumes:
-      - pp_db_data:/var/lib/postgresql/data:delegated
+      - pp_db_data_16:/var/lib/postgresql/data:delegated
     networks:
       - perma_payments
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,10 +140,9 @@ services:
 
 volumes:
   node_modules:
-  postgres_data:
   postgres_data_16:
   redis_data:
-  pp_db_data:
+  pp_db_data_16:
   scoop_redis_data:
   scoop_postgres_data:
   scoop_access_key:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ services:
     volumes:
       - redis_data:/data:delegated
   db:
-    image: registry.lil.tools/library/postgres:12.11
+    image: registry.lil.tools/library/postgres:16.6
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: perma
       POSTGRES_USER: perma
     volumes:
-      - postgres_data:/var/lib/postgresql/data:delegated
+      - postgres_data_16:/var/lib/postgresql/data:delegated
     networks:
       - default
       - superset
@@ -141,6 +141,7 @@ services:
 volumes:
   node_modules:
   postgres_data:
+  postgres_data_16:
   redis_data:
   pp_db_data:
   scoop_redis_data:


### PR DESCRIPTION
Tests pass locally.

See the PG release notes for versions [13](https://www.postgresql.org/docs/13/release-13.html), [14](https://www.postgresql.org/docs/14/release.html), [15](https://www.postgresql.org/docs/15/release.html), and [16](https://www.postgresql.org/docs/16/release.html).

The RDS upgrade path from 12.19, which is what we are running now, does not extend directly to 16.6, so I took the liberty of upgrading our stage instance from 12.19 to 12.22, and then to 16.6; we can kick the tires on stage. The upgrades took some minutes; we'll go into maintenance mode when it's time to upgrade the production instances.