### PR TITLE
Fix broken Firefox extension

### DIFF
--- a/extras/perma-firefox/src/bg.js
+++ b/extras/perma-firefox/src/bg.js
@@ -1,7 +1,5 @@
-chrome.browserAction.onClicked.addListener(function(tab){
-  chrome.tabs.create({
-    "url": chrome.extension.getURL('https://perma.cc/service/bookmarklet-create/?v=1&url=' + encodeURIComponent(tab.url))
+browser.browserAction.onClicked.addListener(function(tab){
+  browser.tabs.create({
+    "url": "https://perma.cc/service/bookmarklet-create/?v=1&url=" + encodeURIComponent(tab.url)
   });
 });
-
-

--- a/extras/perma-firefox/src/manifest.json
+++ b/extras/perma-firefox/src/manifest.json
@@ -1,18 +1,14 @@
 {
   "manifest_version": 2,
-
   "name": "Perma.cc",
   "description": "Enter any URL to preserve it forever.",
-  "version": "1.0.0",
+  "version": "1.0.1resigned1",
   "applications": {
     "gecko": {
       "id": "firefox@perma.cc"
-      }
+    }
   },
-  "permissions": [
-    "activeTab"
-  ],
-
+  "permissions": ["activeTab"],
   "icons": {
     "16": "infinity16.png",
     "48": "infinity48.png",

--- a/extras/perma-firefox/src/manifest.json
+++ b/extras/perma-firefox/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Perma.cc",
   "description": "Enter any URL to preserve it forever.",
-  "version": "1.0.1resigned1",
+  "version": "1.0.2",
   "applications": {
     "gecko": {
       "id": "firefox@perma.cc"


### PR DESCRIPTION
Before:
* The [Perma.cc extension](https://addons.mozilla.org/en-US/firefox/addon/perma-cc/) for Firefox was broken. It would fail on every URL with an error like `Firefox can’t find the file at moz-extension://5f641aec-6742-443d-b1c3-feeefc2e0419/https://perma.cc/service/bookmarklet-create/?v=1&url=https://example.com/`.
* The error happened because we pass the (absolute) target URL into `getURL`, which is only meant for relative paths (see [[1]](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL), [[2]](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL)). Seems like it only worked by accident before, or maybe they changed the API at some point.

After:
* We no longer use `getURL`, so the extension now connects to Perma.cc as expected.

## How to test

1. In Firefox, go to `about:debugging`
2. Click "This Firefox" at left
3. Click the "Load Temporary Add-on…" button and select the `extras/perma-firefox/src/manifest.json` file from this branch
4. Now the local extension should be loaded; navigate to a website and click the Perma.cc extension button to test it out