### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:124-f89c580766f587f5156b10f873972ea8
+    image: registry.lil.tools/harvardlil/scoop-rest-api:125-8c5604e61e0335c339b6faedd0d6a378
     init: true
     tty: true
     depends_on:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:125-8c5604e61e0335c339b6faedd0d6a378
+    image: registry.lil.tools/harvardlil/scoop-rest-api:126-5d32e6040e46b6150ef4ee700861b462
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/e8e0ed2aa5603540c49fa5b19cefae30debc408f).