### PR TITLE
add uuids to customer service emails

### DIFF
--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1383,7 +1383,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         id = Registrar.objects.get(email=new_lib['email']).id
         approve_url = "http://testserver{}".format(reverse('user_sign_up_approve_pending_registrar', args=[id]))
         self.assertIn(approve_url, message.body)
-        self.assertEqual(message.subject, "Perma.cc new library registrar account request")
+        self.assertTrue(message.subject.startswith("Perma.cc new library registrar account request"))
         self.assertEqual(message.from_email, our_address)
         self.assertEqual(message.recipients(), [our_address])
         self.assertDictEqual(message.extra_headers, {'Reply-To': user['raw_email']})
@@ -1598,7 +1598,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         our_address = settings.DEFAULT_FROM_EMAIL
 
         # Doesn't check email contents yet; too many variations possible presently
-        self.assertEqual(message.subject, "Perma.cc new library court account information request")
+        self.assertTrue(message.subject.startswith("Perma.cc new library court account information request"))
         self.assertEqual(message.from_email, our_address)
         self.assertEqual(message.recipients(), [our_address])
         self.assertDictEqual(message.extra_headers, {'Reply-To': court_email})
@@ -1743,7 +1743,7 @@ class UserManagementViewsTestCase(PermaTestCase):
     def check_firm_email(self, message: str, firm_email: str):
         perma_admin_email = settings.DEFAULT_FROM_EMAIL
 
-        self.assertEqual(message.subject, 'Perma.cc new paid registrar account request')
+        self.assertTrue(message.subject.startswith('Perma.cc new paid registrar account request'))
         self.assertEqual(message.from_email, perma_admin_email)
         self.assertEqual(message.to, [firm_email.lower()])
         self.assertEqual(message.cc, [perma_admin_email])

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -93,7 +93,7 @@ def test_user_can_request_deletion_once(client, link_user, mailoutbox):
     # Check that admins were emailed about the request
     assert len(mailoutbox) == 1
     message = mailoutbox[0]
-    assert message.subject == 'Perma.cc account deletion request'
+    assert message.subject.startswith('Perma.cc account deletion request')
 
 
 #

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -1,4 +1,5 @@
 import itertools
+import uuid
 
 from django.conf import settings
 from django.contrib import messages
@@ -49,7 +50,7 @@ def delete_account(request):
         request.user.notes = f"Requested account deletion {timezone.now()}\n" + request.user.notes
         request.user.save()
         send_admin_email(
-            "Perma.cc account deletion request",
+            f"Perma.cc account deletion request ({str(uuid.uuid4())})",
             request.user.raw_email,
             request,
             "email/admin/deletion_request.txt",

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import uuid
 
 from django.conf import settings
 from django.contrib import messages
@@ -448,7 +449,7 @@ def email_library_registrar_request(request: HttpRequest, pending_registrar: Reg
         email = request.POST.get('a-e-address')
 
     send_admin_email(
-        'Perma.cc new library registrar account request',
+        f"Perma.cc new library registrar account request ({str(uuid.uuid4())})",
         email,
         request,
         'email/admin/registrar_request.txt',
@@ -485,7 +486,7 @@ def email_court_request(request, user):
     except LinkUser.DoesNotExist:
         target_user = None
     send_admin_email(
-        "Perma.cc new library court account information request",
+        f"Perma.cc new library court account information request ({str(uuid.uuid4())})",
         user.raw_email,
         request,
         "email/admin/court_request.txt",
@@ -530,7 +531,7 @@ def email_firm_request(request: HttpRequest, registrar: Registrar):
         ),
     }
     send_user_email_copy_admins(
-        title='Perma.cc new paid registrar account request',
+        title=f"Perma.cc new paid registrar account request ({str(uuid.uuid4())})",
         from_address=settings.DEFAULT_FROM_EMAIL,
         to_addresses=[user_email],
         request=request,
@@ -544,7 +545,7 @@ def email_premium_request(request, user):
     Send email to Perma.cc admins when a user requests a premium account
     """
     send_admin_email(
-        "Perma.cc premium account request",
+        f"Perma.cc premium account request ({str(uuid.uuid4())})",
         user.raw_email,
         request,
         "email/admin/premium_request.txt",


### PR DESCRIPTION
This PR adds unique subject lines to the below customer service emails so that they get threaded correctly. [Previously](https://linear.app/harvard-lil/issue/ENG-361/perma-contact-emails-and-threading-in-linear) they were added to the contact and report form emails:

- New library registrar account email
- New library court account email
- New paid registrar account email
- Account deletion request email
- Premium account request email (not currently used, but I still added)



