### PR TITLE
Update Scoop REST API image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:127-38b90e2e77026f193615030d56d7de4f
+    image: registry.lil.tools/harvardlil/scoop-rest-api:128-e69d59c9a9fa170316eea5548a66f31e
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This is minor, a point upgrade to node for the Scoop API: https://github.com/harvard-lil/perma-scoop-api/pull/188