### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:128-e69d59c9a9fa170316eea5548a66f31e
+    image: registry.lil.tools/harvardlil/scoop-rest-api:129-5ccec96933e55cfd3a78fa8abf792f38
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/af91c77321fafc230fb87e7c5b22765336211a0c).