### PR TITLE
Update payments image

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -91,7 +91,7 @@ services:
       - perma_payments
 
   perma-payments:
-    image: registry.lil.tools/harvardlil/perma-payments:21-fb891216b5f7d0402db430b123b82fa8
+    image: registry.lil.tools/harvardlil/perma-payments:22-e8681cf78456e0ea7ece6e852a7a74c0
     # hack: sleep to give the database time to start up
     command: >
       sh -c "sleep 5 && ./manage.py migrate && invoke run"


### PR DESCRIPTION
This updates the payments image with the same point version update to Django as #3693 -- see https://docs.djangoproject.com/en/5.1/releases/4.2.19/ and https://github.com/harvard-lil/perma-payments/pull/186. 

Note that although the tests for that PR succeeded, but the build on merge failed to push the image to the registry, so the build status of the payments repo is "failed" -- I built and pushed the image locally.