### PR TITLE
Update Scoop API image for new node

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:131-84d0f560364ad4e80cbc3c0914d49e86
+    image: registry.lil.tools/harvardlil/scoop-rest-api:132-9d9c0a40f82d9eecce503f784b65f852
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This is a point version update to node: https://github.com/harvard-lil/perma-scoop-api/pull/192