### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:133-618740b28b58bf97ce359cf1d52fdf54
+    image: registry.lil.tools/harvardlil/scoop-rest-api:134-2f1cedc8724d15e9e8c30c70a878a194
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/1a5abbaf30fde27492d404b66ad0b5a1bfced173).