### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:135-bca20c88732d59d545172443da96d5d6
+    image: registry.lil.tools/harvardlil/scoop-rest-api:136-8dce250da090998ff3e3d7a6beb6a3bc
     init: true
     tty: true
     depends_on:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:134-2f1cedc8724d15e9e8c30c70a878a194
+    image: registry.lil.tools/harvardlil/scoop-rest-api:135-bca20c88732d59d545172443da96d5d6
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/6c5bc5f12337483332e6dfc81d44168ce5e2be12).