### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:136-8dce250da090998ff3e3d7a6beb6a3bc
+    image: registry.lil.tools/harvardlil/scoop-rest-api:137-cf15dc5aa091f110c939aa44c7623a34
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/372a513543b89c70ce16fa0a8cacdb8000e96bdc).