### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:139-938068a487dd23e38bc28fa562375cd3
+    image: registry.lil.tools/harvardlil/scoop-rest-api:140-e56f2df628696f18c8b6c8494f3023ce
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/d59089221c5dbd642a3efbe450f2792ad5393a45).