### PR TITLE
Use latest Scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:140-e56f2df628696f18c8b6c8494f3023ce
+    image: registry.lil.tools/harvardlil/scoop-rest-api:141-43c6cfb838485ebec0dc838b93fe93f1
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This updates Perma to use the latest Scoop, 0.6.53:

https://github.com/harvard-lil/perma-scoop-api/commit/195a624f32b23fbe74f3ae165811e75ed8f9a97c

https://github.com/harvard-lil/scoop/commit/5b2934d680ec9e92f43b57adaec49457768c26c8