### PR TITLE
queue bulk org user emails with celery

### DIFF
--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -1616,11 +1616,12 @@ def send_user_email_from_bulk_addition(user_email, context, template, host=None,
     """
     if is_new_user:
         user = LinkUser.objects.get(raw_email=user_email)
-        activation_route = f'''{host}{reverse('password_reset_confirm', 
-                                              args=[
-                                                urlsafe_base64_encode(force_bytes(user.pk)),
-                                                default_token_generator.make_token(user),
-                                              ])}'''
+        path = reverse('password_reset_confirm',
+                       args=[
+                           urlsafe_base64_encode(force_bytes(user.pk)),
+                           default_token_generator.make_token(user)
+                       ])
+        activation_route = f'{host}{path}'
         context['activation_expires'] = settings.PASSWORD_RESET_TIMEOUT
         context['activation_route'] = activation_route
 

--- a/perma_web/perma/celery_tasks.py
+++ b/perma_web/perma/celery_tasks.py
@@ -28,6 +28,10 @@ from django.db.models import F
 from django.db.models.functions import Greatest, Now
 from django.conf import settings
 from django.utils import timezone
+from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.contrib.auth.tokens import default_token_generator
 from django.template.defaultfilters import pluralize, filesizeformat
 
 from perma.models import LinkUser, Link, Capture, \
@@ -1603,3 +1607,22 @@ def warn_expiring_organization_users(warning_days=None):
                 except Exception:
                     logger.exception(f"Error emailing user {affiliation.user_id}")
                 break
+
+
+@shared_task
+def send_user_email_from_bulk_addition(user_email, context, template, host=None, is_new_user=False):
+    """
+    Handles sending emails to users created/updated via the bulk org user addition form
+    """
+    if is_new_user:
+        user = LinkUser.objects.get(raw_email=user_email)
+        activation_route = f'''{host}{reverse('password_reset_confirm', 
+                                              args=[
+                                                urlsafe_base64_encode(force_bytes(user.pk)),
+                                                default_token_generator.make_token(user),
+                                              ])}'''
+        context['activation_expires'] = settings.PASSWORD_RESET_TIMEOUT
+        context['activation_route'] = activation_route
+
+    send_user_email(user_email, template, context)
+

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -481,7 +481,8 @@ CELERY_TASK_ROUTES = {
     'perma.celery_tasks.deactivate_expired_sponsored_users': {'queue': 'background'},
     'perma.celery_tasks.warn_expiring_sponsored_users': {'queue': 'background'},
     'perma.celery_tasks.remove_expired_organization_user_affiliations': {'queue': 'background'},
-    'perma.celery_tasks.warn_expiring_organization_users': {'queue': 'background'}
+    'perma.celery_tasks.warn_expiring_organization_users': {'queue': 'background'},
+    'perma.celery_tasks.send_bulk_user_creation_emails': {'queue': 'background'}
 }
 
 # Schedule celerybeat jobs.

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -482,7 +482,7 @@ CELERY_TASK_ROUTES = {
     'perma.celery_tasks.warn_expiring_sponsored_users': {'queue': 'background'},
     'perma.celery_tasks.remove_expired_organization_user_affiliations': {'queue': 'background'},
     'perma.celery_tasks.warn_expiring_organization_users': {'queue': 'background'},
-    'perma.celery_tasks.send_bulk_user_creation_emails': {'queue': 'background'}
+    'perma.celery_tasks.send_user_email_from_bulk_addition': {'queue': 'background'}
 }
 
 # Schedule celerybeat jobs.

--- a/perma_web/perma/templates/email/new_user_added_to_org_by_other_from_bulk_form.txt
+++ b/perma_web/perma/templates/email/new_user_added_to_org_by_other_from_bulk_form.txt
@@ -1,0 +1,5 @@
+TITLE: A Perma.cc account has been created for you
+
+A Perma.cc account has been created for you by {{ requester }} on behalf of {{ org }}.
+
+{% include 'email/includes/activation.txt' %}

--- a/perma_web/perma/templates/email/user_added_to_organization_from_bulk_form.txt
+++ b/perma_web/perma/templates/email/user_added_to_organization_from_bulk_form.txt
@@ -1,0 +1,5 @@
+TITLE: Your Perma.cc account is now associated with {{ org }}
+
+Your Perma.cc account has been associated with {{ org }}. You can now manage archives and peers within the organization. If this is a mistake, visit your account settings page to leave {{ org }}.
+
+{{ account_settings_page }}

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -62,6 +62,7 @@ from perma.utils import (
 )
 from perma.views.common import valid_member_sorts, valid_org_sorts, valid_registrar_sorts
 from perma.views.user_sign_up import email_new_user
+from perma.celery_tasks import send_user_email_from_bulk_addition
 from waffle import flag_is_active
 
 logger = logging.getLogger(__name__)
@@ -775,43 +776,51 @@ class BaseAddUserToGroup(UpdateView):
         def add_message(level, title, body):
             messages.add_message(self.request, level, f'<h4>{title}</h4>{body}', extra_tags='safe')
 
-        def send_emails(users, email_function, email_template, extra_context, *args):
+        def send_bulk_addition_emails(users, email_function, template):
+            extra_context = {
+                'org': form.cleaned_data['organizations'].name,
+                'requester': self.request.user.get_full_name(),
+                'account_settings_page': self.request.build_absolute_uri(reverse('settings_profile')),
+            }
+            host = self.request.build_absolute_uri()
+
             for obj in users.values():
                 try:
                     if email_function == 'email_new_user':
-                        email_new_user(*args, obj, email_template, extra_context)
+                        send_user_email_from_bulk_addition.delay(obj.raw_email, extra_context, template, host, is_new_user=True)
                     else:
-                        send_user_email(obj.raw_email, email_template, extra_context)
+                        send_user_email_from_bulk_addition.delay(obj.raw_email, extra_context, template, is_new_user=False)
                 except Exception as e:
                     logger.exception(f"Failed to send email to {obj.raw_email}: {e}")
 
-        context = {'form': form}
-
         if not self.is_batch:
-            user = {self.object.email: self.object}
             if self.is_new:
-                send_emails(user, 'email_new_user', self.user_added_email_template, context, self.request)
+                email_new_user(
+                    self.request,
+                    self.object,
+                    self.user_added_email_template,
+                    {'form': form}
+                )
                 add_message(
                     messages.SUCCESS,
                     "Account created!",
                     f"<strong>{self.object.email}</strong> will receive an email with instructions on how to activate the account and create a password."
                 )
             else:
-                send_emails(
-                    user,
-                    'send_user_email',
+                send_user_email(
+                    self.object.raw_email,
                     self.confirmation_email_template,
                     {
                         'account_settings_page': f"https://{self.request.get_host()}{reverse('settings_profile')}",
-                        'form': form,
-                    },
+                        'form': form
+                    }
                 )
                 add_message(messages.SUCCESS, "Success!", f"<strong>{self.object.email}</strong> added.")
         else:
             if form.created_users:
-                send_emails(form.created_users, 'email_new_user', self.user_added_email_template, context, self.request)
+                send_bulk_addition_emails(form.created_users, 'email_new_user', self.user_added_email_template)
             if form.updated_users:
-                send_emails(form.updated_users, 'send_user_email', self.confirmation_email_template, context)
+                send_bulk_addition_emails(form.updated_users, 'send_user_email', self.confirmation_email_template)
 
             success_message = (
                 "New users will receive an email with instructions on how to activate their accounts and create a password.<br>"
@@ -866,8 +875,8 @@ class AddUserToOrganization(RequireOrgOrRegOrAdminUser, BaseAddUserToGroup):
 class AddMultipleUsersToOrganization(RequireOrgOrRegOrAdminUser, BaseAddUserToGroup):
     template_name = 'user_management/add_multiple_users_to_org.html'
     success_url = reverse_lazy('user_management_manage_organization_user')
-    confirmation_email_template = 'email/user_added_to_organization.txt'
-    user_added_email_template = 'email/new_user_added_to_org_by_other.txt'
+    confirmation_email_template = 'email/user_added_to_organization_from_bulk_form.txt'
+    user_added_email_template = 'email/new_user_added_to_org_by_other_from_bulk_form.txt'
     new_user_form = MultipleUsersFormWithOrganization
     is_batch = True
 
@@ -1067,7 +1076,7 @@ def manage_single_registrar_user_remove(request, user_id):
 
 def toggle_status(request, user_id, registrar_id, status):
     target_user = get_object_or_404(LinkUser, id=user_id)
-    registrar =  get_object_or_404(Registrar, id=registrar_id)
+    registrar = get_object_or_404(Registrar, id=registrar_id)
     sponsorship = get_object_or_404(Sponsorship, user=target_user, registrar=registrar)
 
     # Registrar users can only edit their own sponsored users,


### PR DESCRIPTION
This PR adds the ability to the bulk user addition flow so that the user emails are queued as individual Celery tasks instead of sending them inline. I tested with a form of 500 users and it was instantaneous. 