### PR TITLE
Require auth for GUI-mediated downloads.

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -224,7 +224,7 @@
         {% if request.user.is_staff %}
           <a href="?embed=False" class="btn btn-ui-small btn-dashboard">Show playback controls</a>
         {% endif %}
-        {% if link.can_play_back %}
+        {% if link.can_play_back and request.user.is_authenticated %}
           <a href="{% url 'single_permalink' guid=link.guid %}?type=warc_download" role="button" class="btn btn-ui-small btn-dashboard" title="download">Download WARC</a>
             {% if link.wacz_size %}
               <a href="{% url 'single_permalink' guid=link.guid %}?type=wacz_download" role="button" class="btn btn-ui-small btn-dashboard" title="download">Download WACZ</a>

--- a/perma_web/perma/tests/test_views_playback.py
+++ b/perma_web/perma/tests/test_views_playback.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from warcio.timeutils import datetime_to_http_date
 
 from django.urls import reverse
@@ -310,3 +311,36 @@ def test_replacement_link_redirects(client, link_factory):
     response = get_playback(client, link.guid, expect_iframe=False)
     assert response.status_code == 302
     assert response.headers['location'] == reverse('single_permalink', kwargs={'guid': to_replace.guid})
+
+
+@pytest.mark.parametrize(
+    "download_format",
+    [
+        'warc',
+        'wacz',
+    ]
+)
+def test_can_download_if_logged_in(link_user, complete_link, client, mocker, download_format):
+    get_warc = mocker.patch('perma.models.Link.get_warc', autospec=True)
+    get_wacz = mocker.patch('perma.models.Link.get_wacz', autospec=True)
+    get_warc.return_value = StringIO("warc placeholder")
+    get_wacz.return_value = StringIO("wacz placeholder")
+
+    client.force_login(link_user)
+    url = reverse('single_permalink', kwargs={'guid': complete_link.guid}) + f"?type={download_format}_download"
+    response = client.get(url, secure=True)
+    assert response.status_code == 200
+    assert response.get('Content-Disposition', '').startswith("attachment; filename=")
+
+
+@pytest.mark.parametrize(
+    "download_format",
+    [
+        'warc',
+        'wacz',
+    ]
+)
+def test_cannot_download_if_logged_out(complete_link, client, download_format):
+    url = reverse('single_permalink', kwargs={'guid': complete_link.guid}) + f"?type={download_format}_download"
+    response = client.get(url, secure=True)
+    assert response.status_code == 401

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -841,6 +841,9 @@ def stream_archive(link, stream=True, file_format='warc'):
 
 
 def stream_archive_if_permissible(link, user, stream=True, file_format='warc'):
+    if not user.is_authenticated:
+        return HttpResponse('Unauthenticated.', status=401)
+
     if user.can_view(link):
         return stream_archive(link, stream, file_format)
     return HttpResponseForbidden('Private archive.')


### PR DESCRIPTION
Only logged in users can download using `?type=warc_download` or `?type=wacz_download` URLs.