### PR TITLE
Modify sponsorship expiration

### DIFF
--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -12,12 +12,20 @@
           <div class="settings-block">
             <p>{{ sponsorship.registrar.name }}</p>
             {% if sponsorship.status == 'active' %}
+              <!-- <br><p><strong>Expiration date:</strong> {{ sponsorship.expires_at }}</p> -->
+              <br>
+              <p>
+                <strong>Expiration:</strong>
+                {% if sponsorship.expires_at %}
+                  {{ sponsorship.expires_at }}
+                {% else %}
+                  Permanent affiliation
+                {% endif %}
+              </p>
               <a href="{% url 'user_management_manage_single_sponsored_user_remove' user_id=target_user.id registrar_id=sponsorship.registrar.id %}" class="btn cancel btn-xs leave-org-btn">Deactivate sponsorship</a>
-            {% else %}
+              <a href="{% url 'user_management_manage_single_sponsored_user_expiration_date' user_id=target_user.id registrar_id=sponsorship.registrar.id %}" class="btn btn-xs update-affiliation-btn">Update sponsorship</a>
+              {% else %}
               <a href="{% url 'user_management_manage_single_sponsored_user_readd' user_id=target_user.id registrar_id=sponsorship.registrar.id %}" name="registrar" class="btn btn-default btn-xs leave-org-btn">Reactivate</a>
-            {% endif %}
-            {% if sponsorship.expires_at %}
-              <br><p>Expiration date: {{ sponsorship.expires_at }}</p>
             {% endif %}
           </div>
         {% endfor %}

--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -22,7 +22,7 @@
               </p>
               <a href="{% url 'user_management_manage_single_sponsored_user_remove' user_id=target_user.id registrar_id=sponsorship.registrar.id %}" class="btn cancel btn-xs leave-org-btn">Deactivate sponsorship</a>
               <a href="{% url 'user_management_manage_single_sponsored_user_expiration_date' user_id=target_user.id registrar_id=sponsorship.registrar.id %}" class="btn btn-xs update-affiliation-btn">Update sponsorship</a>
-              {% else %}
+            {% else %}
               <a href="{% url 'user_management_manage_single_sponsored_user_readd' user_id=target_user.id registrar_id=sponsorship.registrar.id %}" name="registrar" class="btn btn-default btn-xs leave-org-btn">Reactivate</a>
             {% endif %}
           </div>

--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -13,8 +13,8 @@
             <p>{{ sponsorship.registrar.name }}</p>
             {% if sponsorship.status == 'active' %}<br>
               <p>
-                Expiration: 
                 {% if sponsorship.expires_at %}
+                Expiration:
                   {{ sponsorship.expires_at }}
                 {% else %}
                   Permanent affiliation

--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -13,7 +13,7 @@
             <p>{{ sponsorship.registrar.name }}</p>
             {% if sponsorship.status == 'active' %}<br>
               <p>
-                <strong>Expiration:</strong>
+                Expiration: 
                 {% if sponsorship.expires_at %}
                   {{ sponsorship.expires_at }}
                 {% else %}

--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -11,9 +11,7 @@
         {% for sponsorship in status.list %}
           <div class="settings-block">
             <p>{{ sponsorship.registrar.name }}</p>
-            {% if sponsorship.status == 'active' %}
-              <!-- <br><p><strong>Expiration date:</strong> {{ sponsorship.expires_at }}</p> -->
-              <br>
+            {% if sponsorship.status == 'active' %}<br>
               <p>
                 <strong>Expiration:</strong>
                 {% if sponsorship.expires_at %}

--- a/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
+++ b/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
@@ -1,0 +1,47 @@
+{% extends "admin-layout.html" %}
+
+{% block title %} | Modify affiliation expiration of user {% endblock %}
+
+{% block adminContent %}
+
+    <h3 class="body-bh">Modify affiliation expiration of {{  user }}</h3>
+
+    <form method="POST" action="{% url 'user_management_manage_single_sponsored_user_expiration_date' user_id=user.id registrar_id=registrar_id %}">
+        {% csrf_token %}
+        <fieldset>
+            <div class="checkbox">
+            <label for="indefinite_sponsorship">
+                <input type="checkbox" name="indefinite_sponsorship" id="indefinite_sponsorship">
+                    Sponsor permanently
+                </input>
+            </label>
+            </div>
+            <div class="form-group">
+                <label for="expires_at">Or set a new expiration date
+                    <input type="date" name="expires_at" id="expires_at"/>
+                </label>
+            </div>
+        </fieldset>
+        <button type="submit" class="btn">Update</button>
+        <a href="../" class="btn cancel">Cancel</a>
+    </form>
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+            const checkbox = document.getElementById("indefinite_sponsorship");
+            const datetimeField = document.getElementById("expires_at");
+
+            const toggleExpirationDateField = () => {
+                if (checkbox.checked) {
+                    datetimeField.value = '';
+                    datetimeField.disabled = true;
+                } else {
+                    datetimeField.disabled = false;
+                }
+            };
+
+            checkbox.addEventListener("change", toggleExpirationDateField);
+            toggleExpirationDateField();
+        });
+    </script>
+
+{% endblock %}

--- a/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
+++ b/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
@@ -1,10 +1,10 @@
 {% extends "admin-layout.html" %}
 
-{% block title %} | Modify affiliation expiration of user {% endblock %}
+{% block title %} | Modify sponsorship expiration of user {% endblock %}
 
 {% block adminContent %}
 
-    <h3 class="body-bh">Modify affiliation expiration of {{  user }}</h3>
+    <h3 class="body-bh">Modify sponsorship expiration of {{ user }}</h3>
 
     <form method="POST" action="{% url 'user_management_manage_single_sponsored_user_expiration_date' user_id=user.id registrar_id=registrar_id %}">
         {% csrf_token %}
@@ -17,7 +17,7 @@
             </label>
             </div>
             <div class="form-group">
-                <label for="expires_at">Or set a new expiration date
+                <label for="expires_at">Or set a new expiration date:
                     <input type="date" name="expires_at" id="expires_at"/>
                 </label>
             </div>

--- a/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
+++ b/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
@@ -23,7 +23,7 @@
             </div>
         </fieldset>
         <button type="submit" class="btn">Update</button>
-        <a href="../" class="btn cancel">Cancel</a>
+        <a href="{% url 'user_management_manage_single_sponsored_user' user_id=user.id %}" class="btn cancel">Cancel</a>
     </form>
     <script>
         document.addEventListener("DOMContentLoaded", () => {

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -84,7 +84,8 @@ def test_permissions(client, admin_user, registrar_user, org_user, link_user_fac
                 ['user_management_manage_single_sponsored_user', {'kwargs':{'user_id': sponsored_user.id}}],
                 ['user_management_manage_single_sponsored_user_remove', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}],
                 ['user_management_manage_single_sponsored_user_readd', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}],
-                ['user_management_manage_single_sponsored_user_links', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}]
+                ['user_management_manage_single_sponsored_user_links', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}],
+                ['user_management_manage_single_sponsored_user_expiration_date', {'kwargs':{'user_id': sponsored_user.id, 'registrar_id': sponsored_user_registrar.id}}]
             ],
             'allowed': {admin_user, sponsored_user_registrar_user},
         },

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -7,6 +7,7 @@ from random import random, getrandbits
 import re
 
 from bs4 import BeautifulSoup
+from datetime import datetime
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.core import mail
@@ -1097,21 +1098,20 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.assertEqual(sponsorship.expires_at, None)
 
         
-    def test_registrar_user_can_modify_sponsorship_of_existing_user(self):
-        # can only modify users affiliated with itself
+    def test_registrar_user_can_modify_sponsorship_of_existing_affiliated_user(self):
+        # can only modify sponsorships affiliated withitself
         self.log_in_user(self.registrar_user)
         sponsorship = Sponsorship.objects.get(user=self.sponsored_user, registrar=self.registrar, status='active')
-        sponsorship.expires_at = '2025-12-29'
-        sponsorship.save()
+        expires_at = '2025-04-30T00:00:00+00:00'
         self.submit_form('user_management_manage_single_sponsored_user_expiration_date',
                          reverse_kwargs={'args': [self.sponsored_user.id, self.registrar.id]},
-                         data={'expires_at': ''},
+                         data={'expires_at': expires_at},
                          success_url=reverse('user_management_manage_single_sponsored_user', args=[self.sponsored_user.id]),
                          success_query=LinkUser.objects.filter(pk=self.regular_user.pk, sponsoring_registrars=self.registrar))
         sponsorship.refresh_from_db()
-        self.assertEqual(sponsorship.expires_at, None)
+        self.assertEqual(sponsorship.expires_at, datetime.strptime(expires_at, "%Y-%m-%dT%H:%M:%S%z"))
 
-        # cannot modify users affiliated with another registrar
+        # cannot modify sponsorships affiliated with another registrar
         self.log_in_user(self.registrar_user)
         self.submit_form('user_management_manage_single_sponsored_user_expiration_date',
                          reverse_kwargs={'args': [self.sponsored_user.id, self.unrelated_registrar.pk]},

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1099,7 +1099,7 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         
     def test_registrar_user_can_modify_sponsorship_of_existing_affiliated_user(self):
-        # can only modify sponsorships affiliated withitself
+        # can only modify sponsorships affiliated with itself
         self.log_in_user(self.registrar_user)
         sponsorship = Sponsorship.objects.get(user=self.sponsored_user, registrar=self.registrar, status='active')
         expires_at = '2025-04-30T00:00:00+00:00'

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1081,6 +1081,42 @@ class UserManagementViewsTestCase(PermaTestCase):
                          error_keys=['sponsoring_registrars'])
         self.assertFalse(LinkUser.objects.filter(pk=self.regular_user.pk, sponsoring_registrars=self.unrelated_registrar).exists())
 
+    ### MODIFYING SPONSORSHIPS ###
+
+    def test_admin_user_can_modify_sponsorship_of_existing_user(self):
+        self.log_in_user(self.admin_user)
+        sponsorship = Sponsorship.objects.get(user=self.sponsored_user, registrar=self.registrar, status='active')
+        sponsorship.expires_at = '2025-12-29'
+        sponsorship.save()
+        self.submit_form('user_management_manage_single_sponsored_user_expiration_date',
+                         reverse_kwargs={'args': [self.sponsored_user.id, self.registrar.id]},
+                         data={'expires_at': ''},
+                         success_url=reverse('user_management_manage_single_sponsored_user', args=[self.sponsored_user.id]),
+                         success_query=LinkUser.objects.filter(pk=self.regular_user.pk, sponsoring_registrars=self.registrar))
+        sponsorship.refresh_from_db()
+        self.assertEqual(sponsorship.expires_at, None)
+
+        
+    def test_registrar_user_can_modify_sponsorship_of_existing_user(self):
+        # can only modify users affiliated with itself
+        self.log_in_user(self.registrar_user)
+        sponsorship = Sponsorship.objects.get(user=self.sponsored_user, registrar=self.registrar, status='active')
+        sponsorship.expires_at = '2025-12-29'
+        sponsorship.save()
+        self.submit_form('user_management_manage_single_sponsored_user_expiration_date',
+                         reverse_kwargs={'args': [self.sponsored_user.id, self.registrar.id]},
+                         data={'expires_at': ''},
+                         success_url=reverse('user_management_manage_single_sponsored_user', args=[self.sponsored_user.id]),
+                         success_query=LinkUser.objects.filter(pk=self.regular_user.pk, sponsoring_registrars=self.registrar))
+        sponsorship.refresh_from_db()
+        self.assertEqual(sponsorship.expires_at, None)
+
+        # cannot modify users affiliated with another registrar
+        self.log_in_user(self.registrar_user)
+        self.submit_form('user_management_manage_single_sponsored_user_expiration_date',
+                         reverse_kwargs={'args': [self.sponsored_user.id, self.unrelated_registrar.pk]},
+                         require_status_code=403)
+
     ### TOGGLING THE STATUS OF SPONSORSHIPS ###
 
     def test_admin_user_can_deactivate_active_sponsorship(self):
@@ -1144,7 +1180,8 @@ class UserManagementViewsTestCase(PermaTestCase):
         sponsorship.refresh_from_db()
         self.assertEqual(sponsorship.status, 'inactive')
 
-    ### ADDING NEW USERS TO REGISTRARS AS REGISTRAR USERS) ###
+
+    ### ADDING NEW USERS TO REGISTRARS AS REGISTRAR USERS ###
 
     def test_admin_user_can_add_new_user_to_registrar(self):
         address = self.randomize_capitalization('doesnotexist@example.com')

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -164,6 +164,7 @@ urlpatterns = [
     re_path(r'^manage/sponsored-users/(?P<user_id>\d+)/remove/(?P<registrar_id>\d+)/?$', user_management.manage_single_sponsored_user_remove, name='user_management_manage_single_sponsored_user_remove'),
     re_path(r'^manage/sponsored-users/(?P<user_id>\d+)/readd/(?P<registrar_id>\d+)/?$', user_management.manage_single_sponsored_user_readd, name='user_management_manage_single_sponsored_user_readd'),
     re_path(r'^manage/sponsored-users/(?P<user_id>\d+)/links/(?P<registrar_id>\d+)/?$', user_management.manage_single_sponsored_user_links, name='user_management_manage_single_sponsored_user_links'),
+    re_path(r'^manage/sponsored-users/(?P<user_id>\d+)/modify/(?P<registrar_id>\d+)/?$', user_management.manage_single_sponsored_user_expiration_date, name='user_management_manage_single_sponsored_user_expiration_date'),
 
     re_path(r'^manage/account/leave-organization/(?P<org_id>\d+)/?$', user_management.organization_user_leave_organization, name='user_management_organization_user_leave_organization'),
 

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1124,6 +1124,33 @@ def manage_single_sponsored_user_links(request, user_id, registrar_id):
     })
 
 
+@user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
+def manage_single_sponsored_user_expiration_date(request, user_id, registrar_id):
+    """
+        Modify the sponsorship expiration date of a user
+    """
+    target_user = get_object_or_404(LinkUser, id=user_id)
+    registrar = get_object_or_404(Registrar, id=registrar_id)
+    sponsorship = get_object_or_404(Sponsorship, user=target_user, registrar=registrar)
+
+    # Registrar users can only edit their own sponsored users
+    if request.user.is_registrar_user() and \
+        (request.user.registrar not in target_user.sponsoring_registrars.all() or
+         str(request.user.registrar_id) != registrar_id):
+        return HttpResponseForbidden()
+    
+    if request.method == 'POST':
+        expires_at = request.POST.get("expires_at") or None
+        sponsorship.expires_at = expires_at
+        sponsorship.save()
+        return HttpResponseRedirect(reverse('user_management_manage_single_sponsored_user', args=[user_id]))
+
+    return render(request, 'user_management/manage_sponsorship_affiliation_expiration.html', {
+        'user': target_user,
+        'registrar_id': registrar_id
+    })
+
+
 @user_passes_test_or_403(lambda user: user.is_staff)
 def manage_single_admin_user_remove(request, user_id):
     """

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -1242,7 +1242,7 @@ div.col-right {
       background-color: $color-active !important;
     }
   }
-  &.cancel {
+  &.cancel, &.update-affiliation-btn {
     border-color: $color-orange;
     color: $color-orange;
     background-color: white;
@@ -1256,6 +1256,12 @@ div.col-right {
       background-color: white !important;
       border-color: $color-black;
       color: $color-black !important;
+    }
+  }
+  &.update-affiliation-btn {
+    &:hover, &:focus {
+      color: $color-green !important;
+      border-color: $color-green;
     }
   }
   &.btn-bookmarklet {
@@ -2977,7 +2983,7 @@ div.checkbox {
   padding-left: 36px;
 }
 
-div.checkbox:has(#id_a-indefinite_sponsorship),  div.checkbox:has(#id_a-indefinite_affiliation) {
+div.checkbox:has(#id_a-indefinite_sponsorship), div.checkbox:has(#indefinite_sponsorship), div.checkbox:has(#id_a-indefinite_affiliation) {
   background-color: inherit;
   padding-left: 0;
   margin-right: 0;


### PR DESCRIPTION
This PR adds the ability to revise a sponsored user's affiliation expiration date through the manage sponsored user view. 

Admin users can see all sponsorships, while registrar users can only see the sponsorships that are affiliated with their own registrar.

Here is the before and after of how the `manage/sponsored-users/<user_id>` page will look:

**Before:**

![image](https://github.com/user-attachments/assets/32867c08-a8d2-47dd-8f8e-c75cc62cfe4b)

**After:**

![Screenshot 2025-04-16 at 8 34 53 AM](https://github.com/user-attachments/assets/468eb7cc-eead-4d14-96a8-9e34ae68f876)

![Screenshot 2025-04-16 at 8 35 02 AM](https://github.com/user-attachments/assets/02c73f40-9844-4c3c-9fc3-a0f5621a43b4)

Notice that I added a new button next to the `Deactivate sponsorship` button. They both have the same initial orange bordered styling, but the `Update sponsorship` button turns green on hover and focus events while the deactivate button turns red. 

Another change I made in this view is that previously, we weren't displaying affiliation information for permanent affiliations, and with this change, I added a permanent affiliation text. I thought this would make it clearer to the admins/registrars that permanent affiliations are also modifiable. I also removed the expiration info from inactive sponsorships (which I am fine with adding back; I thought this made more sense).

**Here is how the form to update the date looks like:**

![Screenshot 2025-04-11 at 9 42 25 AM](https://github.com/user-attachments/assets/c3c5ac3d-1661-4424-9716-b470399a31c4)

If the user checks the `Sponsor permanently` box, the date selection input will be disabled. Only when the user de-selects the checkbox will the date selection be re-enabled:

![image](https://github.com/user-attachments/assets/9b36a905-a758-4881-a217-2fdbd4a8ecae)

Just a note that I haven't run this by Clare yet; I am planning to when she returns. So there might be changes to wording, styling, and overall behavior. 