### PR TITLE
Modify organization affiliation expiration

### DIFF
--- a/perma_web/perma/templates/user_management/manage_organization_affiliation_expiration.html
+++ b/perma_web/perma/templates/user_management/manage_organization_affiliation_expiration.html
@@ -1,0 +1,47 @@
+{% extends "admin-layout.html" %}
+
+{% block title %} | Modify affiliation expiration of user {% endblock %}
+
+{% block adminContent %}
+
+    <h3 class="body-bh">Modify affiliation expiration of {{ user }}</h3>
+
+    <form method="POST" action="{% url 'user_management_manage_single_organization_user_expiration_date' user_id=user.id organization_id=organization_id %}">
+        {% csrf_token %}
+        <fieldset>
+            <div class="checkbox">
+            <label for="indefinite_affiliation">
+                <input type="checkbox" name="indefinite_affiliation" id="indefinite_affiliation">
+                    Set permanent affiliation
+                </input>
+            </label>
+            </div>
+            <div class="form-group">
+                <label for="expires_at">Or set a new expiration date:
+                    <input type="date" name="expires_at" id="expires_at"/>
+                </label>
+            </div>
+        </fieldset>
+        <button type="submit" class="btn">Update</button>
+        <a href="{% url 'user_management_manage_single_organization_user' user_id=user.id %}" class="btn cancel">Cancel</a>
+    </form>
+    <script>
+        document.addEventListener("DOMContentLoaded", () => {
+            const checkbox = document.getElementById("indefinite_affiliation");
+            const datetimeField = document.getElementById("expires_at");
+
+            const toggleExpirationDateField = () => {
+                if (checkbox.checked) {
+                    datetimeField.value = '';
+                    datetimeField.disabled = true;
+                } else {
+                    datetimeField.disabled = false;
+                }
+            };
+
+            checkbox.addEventListener("change", toggleExpirationDateField);
+            toggleExpirationDateField();
+        });
+    </script>
+
+{% endblock %}

--- a/perma_web/perma/templates/user_management/manage_single_user.html
+++ b/perma_web/perma/templates/user_management/manage_single_user.html
@@ -31,20 +31,25 @@
     </div>
   {% elif this_page == 'users_organization_users' and affiliations %}
     <div class="orgs-list-container">
-      <h3 class="body-bh">Remove from organization</h3>
+      <h3 class="body-bh">Edit organization affiliation</h3>
       <p class="page-dek"><strong>{{ target_user.raw_email }}</strong> is a member of the following organization{{ affiliations|pluralize }}:</p>
-      <form action="{% url 'user_management_manage_single_organization_user_remove' user_id=target_user.id %}" method="POST">
-        {% csrf_token %}
-        {% for aff in affiliations %}
-          <div class="settings-block">
-            <p>{{ aff.organization.name }}</p>
+      {% for aff in affiliations %}
+        <div class="settings-block org-user-actions">
+          <p>{{ aff.organization.name }}</p><br>
+          <p>
+          {% if aff.expires_at %}
+            Expiration: {{ aff.expires_at }}
+          {% else %}
+            Permanent affiliation
+          {% endif %}
+          </p>
+          <form action="{% url 'user_management_manage_single_organization_user_remove' user_id=target_user.id %}" method="POST">
+            {% csrf_token %}
             <button name="affiliation" value="{{ aff.id }}" class="btn btn-default btn-xs leave-org-btn" data-toggle="tooltip">Remove</button>
-            {% if aff.expires_at %}
-              <br><p>Expiration date: {{ aff.expires_at }}</p>
-            {% endif %}
-          </div>
-        {% endfor %}
-      </form>
+          </form>
+          <a href="{% url 'user_management_manage_single_organization_user_expiration_date' user_id=target_user.id organization_id=aff.organization_id %}" class="btn btn-xs modify-org-exp-btn">Update</a>
+        </div>
+      {% endfor %}
     </div>
   {% endif %}
   {% if request.user.is_staff %}

--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -112,6 +112,12 @@ def test_permissions(client, admin_user, registrar_user, org_user, link_user_fac
         },
         {
             'urls': [
+                ['user_management_manage_single_organization_user_expiration_date', {'kwargs': {'user_id': org_user.id, 'organization_id': org_user_org.id}}]
+            ],
+            'allowed': {admin_user, org_user_registrar_user},
+        },
+        {
+            'urls': [
                 ['user_management_manage_single_registrar_user_remove', {'kwargs':{'user_id': registrar_user.id}}],
             ],
             'allowed': {registrar_user}

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -954,7 +954,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form('user_management_manage_single_organization_user_remove',
                          data={'affiliation': self.user_organization_affiliation.pk},
                          reverse_kwargs={'args': [self.organization_user.pk]},
-                         success_url=reverse('user_management_manage_organization_user'))
+                         success_url=reverse('user_management_manage_single_organization_user', args=[self.organization_user.pk]))
         self.assertFalse(self.organization_user.organizations.filter(pk=self.user_organization_affiliation.pk).exists())
 
     def test_registrar_cannot_remove_unrelated_user_from_organization(self):
@@ -978,6 +978,38 @@ class UserManagementViewsTestCase(PermaTestCase):
                          reverse_kwargs={'args': [self.organization_user.pk]},
                          success_url=reverse('create_link'))
         self.assertFalse(self.organization_user.organizations.filter(pk=self.user_organization_affiliation.pk).exists())
+
+    ### MODIFYING ORG USER AFFILIATION EXPIRATION DATES ###
+
+    def test_admin_user_can_modify_affiliation_of_existing_org_user(self):
+        self.log_in_user(self.admin_user)
+        affiliation = UserOrganizationAffiliation.objects.get(user=self.organization_user, organization=self.organization)
+        affiliation.expires_at = '2025-12-29'
+        affiliation.save()
+        self.submit_form('user_management_manage_single_organization_user_expiration_date',
+                         reverse_kwargs={'args': [self.organization_user.id, self.organization.id]},
+                         data={'expires_at': ''},
+                         success_url=reverse('user_management_manage_single_organization_user', args=[self.organization_user.id]))
+        affiliation.refresh_from_db()
+        self.assertEqual(affiliation.expires_at, None)
+
+    def test_registrar_user_can_modify_affiliation_of_existing_org_user(self):
+        # can only modify user affiliations if registrar is affiliated with the same org
+        self.log_in_user(self.registrar_user)
+        affiliation = UserOrganizationAffiliation.objects.get(user=self.organization_user, organization=self.organization)
+        expires_at = '2025-04-30T00:00:00+00:00'
+        self.submit_form('user_management_manage_single_organization_user_expiration_date',
+                         reverse_kwargs={'args': [self.organization_user.id, self.organization.id]},
+                         data={'expires_at': expires_at},
+                         success_url=reverse('user_management_manage_single_organization_user', args=[self.organization_user.id]))
+        affiliation.refresh_from_db()
+        self.assertEqual(affiliation.expires_at, datetime.strptime(expires_at, "%Y-%m-%dT%H:%M:%S%z"))
+
+        # cannot modify user affiliations if registrar isn't affiliated with the same org
+        self.log_in_user(self.registrar_user)
+        self.submit_form('user_management_manage_single_organization_user_expiration_date',
+                         reverse_kwargs={'args': [self.organization_user.id, self.unrelated_organization.id]},
+                         require_status_code=403)
 
     ### ADDING NEW USERS TO REGISTRARS AS SPONSORED USERS ###
 

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -984,7 +984,7 @@ class UserManagementViewsTestCase(PermaTestCase):
     def test_admin_user_can_modify_affiliation_of_existing_org_user(self):
         self.log_in_user(self.admin_user)
         affiliation = UserOrganizationAffiliation.objects.get(user=self.organization_user, organization=self.organization)
-        affiliation.expires_at = '2025-12-29'
+        affiliation.expires_at = datetime.strptime('2025-04-30T00:00:00+00:00', "%Y-%m-%dT%H:%M:%S%z")
         affiliation.save()
         self.submit_form('user_management_manage_single_organization_user_expiration_date',
                          reverse_kwargs={'args': [self.organization_user.id, self.organization.id]},

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -154,6 +154,7 @@ urlpatterns = [
     re_path(r'^manage/organization-users/(?P<user_id>\d+)/delete/?$', user_management.manage_single_organization_user_delete, name='user_management_manage_single_organization_user_delete'),
     re_path(r'^manage/organization-users/(?P<user_id>\d+)/reactivate/?$', user_management.manage_single_organization_user_reactivate, name='user_management_manage_single_organization_user_reactivate'),
     re_path(r'^manage/organization-users/(?P<user_id>\d+)/remove/?$', user_management.manage_single_organization_user_remove, name='user_management_manage_single_organization_user_remove'),
+    re_path(r'^manage/organization-users/(?P<user_id>\d+)/modify/(?P<organization_id>\d+)/?$', user_management.manage_single_organization_user_expiration_date, name='user_management_manage_single_organization_user_expiration_date'),
 
     re_path(r'^manage/sponsored-users/?$', user_management.manage_sponsored_user, name='user_management_manage_sponsored_user'),
     re_path(r'^manage/sponsored-users/export/?$', user_management.manage_sponsored_user_export_user_list, name='user_management_manage_sponsored_user_export_user_list'),

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1043,7 +1043,31 @@ def manage_single_organization_user_remove(request, user_id):
         if request.user == target_user and not target_user.organizations.exists():
             return HttpResponseRedirect(reverse('create_link'))
 
-    return HttpResponseRedirect(reverse('user_management_manage_organization_user'))
+    return HttpResponseRedirect(reverse('user_management_manage_single_organization_user', args=[user_id]))
+
+
+@user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
+def manage_single_organization_user_expiration_date(request, user_id, organization_id):
+    """
+        Modify the affiliation expiration date of an org user
+    """
+    target_user = get_object_or_404(LinkUser, id=user_id)
+    organization = get_object_or_404(Organization, id=organization_id)
+    affiliation = get_object_or_404(UserOrganizationAffiliation, organization=organization, user=target_user)
+
+    if not request.user.shares_scope_with_user(target_user):
+        return HttpResponseForbidden()
+    
+    if request.method == 'POST':
+        expires_at = request.POST.get("expires_at") or None
+        affiliation.expires_at = expires_at
+        affiliation.save()
+        return HttpResponseRedirect(reverse('user_management_manage_single_organization_user', args=[user_id]))
+
+    return render(request, 'user_management/manage_organization_affiliation_expiration.html', {
+        'user': target_user,
+        'organization_id': organization.id
+    })
 
 
 @user_passes_test_or_403(lambda user: user.is_registrar_user())

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -2983,7 +2983,7 @@ div.checkbox {
   padding-left: 36px;
 }
 
-div.checkbox:has(#id_a-indefinite_sponsorship), div.checkbox:has(#indefinite_sponsorship), div.checkbox:has(#id_a-indefinite_affiliation) {
+div.checkbox:has(#id_a-indefinite_sponsorship), div.checkbox:has(#indefinite_sponsorship), div.checkbox:has(#id_a-indefinite_affiliation), div.checkbox:has(#indefinite_affiliation) {
   background-color: inherit;
   padding-left: 0;
   margin-right: 0;
@@ -3184,6 +3184,10 @@ button#addlink,
       bottom: -2px;
     }
   }
+}
+
+.org-user-actions form {
+  display: inline;
 }
 
 // special styling for subscription forms
@@ -6034,4 +6038,13 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
+}
+
+.modify-org-exp-btn {
+  width: 100%;
+  margin-top: 6px !important;
+  @include respond-tablet {
+    width: auto;
+    margin-top: 0 !important;
+  }
 }


### PR DESCRIPTION
This PR adds the ability to revise an organization user's affiliation expiration date through the manage organization users view.

Admin users can see all affiliations, while registrar users can see user affiliations linked to the same org they are associated with.

Here is the before and after of how the **manage/organization-users/<user_id>** page will look:

**Before:**

![Screenshot 2025-04-23 at 11 53 06 AM](https://github.com/user-attachments/assets/66457841-d8a2-4d52-bfc6-92b459c93cd0)

**After:**

![Screenshot 2025-04-23 at 11 51 41 AM](https://github.com/user-attachments/assets/21c396a0-6235-4eb0-9d4b-b1662deeb71e)

Notice the new button next to the Remove button. 

Another change I made in this view is that previously, we weren't displaying affiliation information for permanent affiliations, and with this change, I added a permanent affiliation text. I thought this would make it clearer to the admins/registrars that permanent affiliations are also modifiable. 

Here is how the form to update the date looks like:

![Screenshot 2025-04-23 at 11 54 05 AM](https://github.com/user-attachments/assets/95ea1d08-ad3f-4915-b7fd-680830d816bc)

If the user checks the Set permanent affiliation box, the date selection input will be disabled. Only when the user deselects the checkbox will the date selection be re-enabled:

![image](https://github.com/user-attachments/assets/91facd5f-fc7a-4c8e-8ead-08d1b6d41aae)

I also made a small tweak to the Remove affiliation flow. Previously, the action redirected to `manage/organization-users` view, but I changed it to redirect to `manage/organization-users/<user_id>` as it seemed more intuitive to me. Let me know if I missed a nuance there. 