### PR TITLE
use latest scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:143-4d4f6539c1b77ca11d6db21e0c074124
+    image: registry.lil.tools/harvardlil/scoop-rest-api:145-6b78e2c3d7f3ddbe0b0fd7e0f278b9c3
     init: true
     tty: true
     depends_on:

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -449,7 +449,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
         self.assertEqual(link.submitted_title, "Test title.")
         self.assertEqual(link.submitted_description, "Test description.")
         self.assertRegex(link.captured_by_software, r'scoop @ harvard library innovation lab: \d+\.\d+.\d+')
-        expected_size = 21954
+        expected_size = 20897
         self.assertLessEqual(abs(link.wacz_size-expected_size), 100)
 
         # check folder


### PR DESCRIPTION
This PR is to update Perma to use the [new scoop API image](https://github.com/harvard-lil/perma-scoop-api/commit/baea153e3522e055b068984308937e84013a757b).