### PR TITLE
Use latest Scoop

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:145-6b78e2c3d7f3ddbe0b0fd7e0f278b9c3
+    image: registry.lil.tools/harvardlil/scoop-rest-api:146-48f0777c53fc265682e851f96ddcb88d
     init: true
     tty: true
     depends_on:


### PR DESCRIPTION
This [updates the Perma Scoop API image](https://github.com/harvard-lil/perma-scoop-api/compare/baea153...main), using the [latest Scoop, 0.6.57](https://github.com/harvard-lil/scoop/releases/tag/0.6.57), which [upgrades yt-dlp](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.04.30).