### PR TITLE
disable selecting past dates

### DIFF
--- a/perma_web/perma/templates/user_management/add_multiple_users_to_org.html
+++ b/perma_web/perma/templates/user_management/add_multiple_users_to_org.html
@@ -17,18 +17,22 @@
     </form>
 
     <script>
-      const checkbox = document.getElementById("id_a-indefinite_affiliation");
-      const datetimeField = document.getElementById("id_a-expires_at");
-      const datetimeFieldLabel = document.querySelector('label[for="id_a-expires_at"]');
+      document.addEventListener("DOMContentLoaded", function () {
+        const checkbox = document.getElementById("id_a-indefinite_affiliation");
+        const datetimeField = document.getElementById("id_a-expires_at");
+        const datetimeFieldLabel = document.querySelector('label[for="id_a-expires_at"]');
+        const today = new Date().toISOString().split('T')[0];
+        datetimeField.setAttribute('min', today);
 
-      const toggleExpirationDateField = () => {
-        const displayStyle = checkbox.checked ? "none" : "block";
-        datetimeField.style.display = displayStyle;
-        datetimeFieldLabel.style.display = displayStyle;
-      };
+        const toggleExpirationDateField = () => {
+          const displayStyle = checkbox.checked ? "none" : "block";
+          datetimeField.style.display = displayStyle;
+          datetimeFieldLabel.style.display = displayStyle;
+        };
 
-      document.addEventListener("DOMContentLoaded", toggleExpirationDateField);
-      checkbox.addEventListener("change", toggleExpirationDateField);
+        toggleExpirationDateField();
+        checkbox.addEventListener("change", toggleExpirationDateField);
+      });
     </script>
 
   {% endif %}

--- a/perma_web/perma/templates/user_management/manage_organization_affiliation_expiration.html
+++ b/perma_web/perma/templates/user_management/manage_organization_affiliation_expiration.html
@@ -29,6 +29,8 @@
         document.addEventListener("DOMContentLoaded", () => {
             const checkbox = document.getElementById("indefinite_affiliation");
             const datetimeField = document.getElementById("expires_at");
+            const today = new Date().toISOString().split('T')[0];
+            datetimeField.setAttribute('min', today);
 
             const toggleExpirationDateField = () => {
                 if (checkbox.checked) {

--- a/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
+++ b/perma_web/perma/templates/user_management/manage_sponsorship_affiliation_expiration.html
@@ -29,6 +29,8 @@
         document.addEventListener("DOMContentLoaded", () => {
             const checkbox = document.getElementById("indefinite_sponsorship");
             const datetimeField = document.getElementById("expires_at");
+            const today = new Date().toISOString().split('T')[0];
+            datetimeField.setAttribute('min', today);
 
             const toggleExpirationDateField = () => {
                 if (checkbox.checked) {

--- a/perma_web/perma/templates/user_management/user_add_to_organization_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_to_organization_confirm.html
@@ -26,18 +26,22 @@
     </form>
 
     <script>
-      const checkbox = document.getElementById("id_a-indefinite_affiliation");
-      const datetimeField = document.getElementById("id_a-expires_at");
-      const datetimeFieldLabel = document.querySelector('label[for="id_a-expires_at"]');
+      document.addEventListener("DOMContentLoaded", function () {
+        const checkbox = document.getElementById("id_a-indefinite_affiliation");
+        const datetimeField = document.getElementById("id_a-expires_at");
+        const datetimeFieldLabel = document.querySelector('label[for="id_a-expires_at"]');
+        const today = new Date().toISOString().split('T')[0];
+        datetimeField.setAttribute('min', today);
 
-      const toggleExpirationDateField = () => {
-        const displayStyle = checkbox.checked ? "none" : "block";
-        datetimeField.style.display = displayStyle;
-        datetimeFieldLabel.style.display = displayStyle;
-      };
+        const toggleExpirationDateField = () => {
+          const displayStyle = checkbox.checked ? "none" : "block";
+          datetimeField.style.display = displayStyle;
+          datetimeFieldLabel.style.display = displayStyle;
+        };
 
-      document.addEventListener("DOMContentLoaded", toggleExpirationDateField);
-      checkbox.addEventListener("change", toggleExpirationDateField);
+        toggleExpirationDateField();
+        checkbox.addEventListener("change", toggleExpirationDateField);
+      });
     </script>
 
   {% endif %}

--- a/perma_web/perma/templates/user_management/user_add_to_sponsoring_registrar_confirm.html
+++ b/perma_web/perma/templates/user_management/user_add_to_sponsoring_registrar_confirm.html
@@ -21,18 +21,22 @@
       <a href="{% url 'user_management_manage_sponsored_user' %}" class="btn cancel">Cancel</a>
     </form>
     <script>
-      const checkbox = document.getElementById("id_a-indefinite_sponsorship");
-      const datetimeField = document.getElementById("id_a-expires_at");
-      const datetimeFieldLabel = document.querySelector('label[for="id_a-expires_at"]');
+      document.addEventListener("DOMContentLoaded", function () {
+        const checkbox = document.getElementById("id_a-indefinite_sponsorship");
+        const datetimeField = document.getElementById("id_a-expires_at");
+        const datetimeFieldLabel = document.querySelector('label[for="id_a-expires_at"]');
+        const today = new Date().toISOString().split('T')[0];
+        datetimeField.setAttribute('min', today);
 
-      const toggleExpirationDateField = () => {
-        const displayStyle = checkbox.checked ? "none" : "block";
-        datetimeField.style.display = displayStyle;
-        datetimeFieldLabel.style.display = displayStyle;
-      };
+        const toggleExpirationDateField = () => {
+          const displayStyle = checkbox.checked ? "none" : "block";
+          datetimeField.style.display = displayStyle;
+          datetimeFieldLabel.style.display = displayStyle;
+        };
 
-      document.addEventListener("DOMContentLoaded", toggleExpirationDateField);
-      checkbox.addEventListener("change", toggleExpirationDateField);
+        toggleExpirationDateField();
+        checkbox.addEventListener("change", toggleExpirationDateField);
+      });
     </script>
 
   {% endif %}


### PR DESCRIPTION
This PR prevents the users from selecting past dates in the organization user, sponsored user, and bulk org user addition forms' affiliation expiration field. 

**Example form with disabled dates:**

<img width="641" alt="image" src="https://github.com/user-attachments/assets/679fcfad-203b-4f48-920b-50fb16652d70" />
