### PR TITLE
feat: added copy link button for a newly created permalink

### DIFF
--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -269,12 +269,17 @@
     {% if new_record %}
       <div class="banner banner-status row _isNewRecord">
         <span class="success">Success!</span>
-        <span class="message verbose">Your new Perma Link is <strong>https://{{ request.get_host }}{% url 'single_permalink' link.guid %}</strong></span>
-        <span class="link-options verbose">
-          <button id="copy-link-btn" class="btn btn-ui-small copy-link" type="button" title="Copy link to clipboard">
-            <span class="copy-text">Copy Link</span>
-            <span class="copied-text" style="display: none;">Copied!</span>
+        <span class="message verbose">
+          Your new Perma Link is <strong id="permalink-url">https://{{ request.get_host }}{% url 'single_permalink' link.guid %}</strong>
+          <button id="copy-link-btn" class="copy-icon-btn" type="button" title="Copy link to clipboard">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+            <span class="sr-only">Copy link</span>
           </button>
+        </span>
+        <span class="link-options verbose">
           <a class="edit-link" style="cursor:pointer;">Edit<span class="_verbose _toDesktop"> link details</span></a>
           <span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span>
         </span>

--- a/perma_web/perma/templates/archive/single-link.html
+++ b/perma_web/perma/templates/archive/single-link.html
@@ -271,6 +271,10 @@
         <span class="success">Success!</span>
         <span class="message verbose">Your new Perma Link is <strong>https://{{ request.get_host }}{% url 'single_permalink' link.guid %}</strong></span>
         <span class="link-options verbose">
+          <button id="copy-link-btn" class="btn btn-ui-small copy-link" type="button" title="Copy link to clipboard">
+            <span class="copy-text">Copy Link</span>
+            <span class="copied-text" style="display: none;">Copied!</span>
+          </button>
           <a class="edit-link" style="cursor:pointer;">Edit<span class="_verbose _toDesktop"> link details</span></a>
           <span class="_verbose _toDesktop"> (Perma Links are permanent after 24 hours)</span>
         </span>

--- a/perma_web/static/css/style-responsive-archive.scss
+++ b/perma_web/static/css/style-responsive-archive.scss
@@ -1577,3 +1577,69 @@ iframe.background {
   min-width: 10px;
   width: 10px;
 }
+
+/* copy link button */
+
+.copy-icon-btn {
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  margin-left: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+  color: #666;
+  vertical-align: middle;
+}
+
+.copy-icon-btn:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+  color: #333;
+}
+
+.copy-icon-btn:focus {
+  outline: 2px solid #007bff;
+  outline-offset: 1px;
+}
+
+.copy-icon-btn:active {
+  background-color: rgba(0, 0, 0, 0.15);
+  transform: scale(0.95);
+}
+
+.copy-icon-btn svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.5;
+}
+
+/* Screen reader only text */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Success feedback animation */
+.copy-icon-btn.copied {
+  color: #28a745;
+}
+
+.copy-icon-btn.copied svg {
+  animation: copySuccess 0.3s ease;
+}
+
+@keyframes copySuccess {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}

--- a/perma_web/static/js/single-link.module.js
+++ b/perma_web/static/js/single-link.module.js
@@ -4,6 +4,10 @@ export var detailsButton = document.getElementById("details-button");
 var detailsTray = document.getElementById("collapse-details");
 var viewMode = document.getElementsByClassName("view-mode")[0];
 
+var copyBtn = document.getElementById('copy-link-btn');
+var copyText = copyBtn?.querySelector('.copy-text');
+var copiedText = copyBtn?.querySelector('.copied-text');
+
 function init () {
   adjustTopMargin();
   var clicked = false;
@@ -13,6 +17,8 @@ function init () {
       handleShowDetails(clicked);
     };
   }
+
+  initCopyLink();
 
   window.onresize = function(){
     if (resizeTimeout != null)
@@ -33,6 +39,65 @@ function adjustTopMargin () {
   if (!wrapper) return;
   wrapper.style.marginTop = `${header.offsetHeight}px`;
   wrapper.style.height = `calc(100% - ${header.offsetHeight}px)`;
+}
+
+function initCopyLink() {
+  if (copyBtn) {
+    copyBtn.addEventListener('click', function() {
+      const permalinkUrl = document.getElementById('permalink-url').textContent;
+      
+      // Modern clipboard API
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(permalinkUrl).then(function() {
+          showCopiedFeedback();
+        }).catch(function(err) {
+          console.error('Failed to copy: ', err);
+          fallbackCopyTextToClipboard(permalinkUrl);
+        });
+      } else {
+        // Fallback for older browsers
+        fallbackCopyTextToClipboard(permalinkUrl);
+      }
+    });
+  }
+}
+
+function showCopiedFeedback() {
+  if (copyText && copiedText) {
+    copyText.style.display = 'none';
+    copiedText.style.display = 'inline';
+    
+    // Reset after 2 seconds
+    setTimeout(function() {
+      copyText.style.display = 'inline';
+      copiedText.style.display = 'none';
+    }, 2000);
+  }
+}
+
+function fallbackCopyTextToClipboard(text) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'fixed';
+  textArea.style.left = '-999999px';
+  textArea.style.top = '-999999px';
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  
+  try {
+    // This is deprecated, but it's a fallback for older browsers 
+    // that don't support the clipboard API. It creates a temporary 
+    // textarea element, copies the text to it, and then removes it.
+    const successful = document.execCommand('copy');
+    if (successful) {
+      showCopiedFeedback();
+    }
+  } catch (err) {
+    console.error('Fallback copy failed: ', err);
+  }
+  
+  document.body.removeChild(textArea);
 }
 
 init();

--- a/perma_web/static/js/single-link.module.js
+++ b/perma_web/static/js/single-link.module.js
@@ -63,14 +63,16 @@ function initCopyLink() {
 }
 
 function showCopiedFeedback() {
-  if (copyText && copiedText) {
-    copyText.style.display = 'none';
-    copiedText.style.display = 'inline';
+  if (copyBtn) {
+    copyBtn.classList.add('copied');
+    
+    const originalTitle = copyBtn.title;
+    copyBtn.title = 'Copied!';
     
     // Reset after 2 seconds
     setTimeout(function() {
-      copyText.style.display = 'inline';
-      copiedText.style.display = 'none';
+      copyBtn.classList.remove('copied');
+      copyBtn.title = originalTitle;
     }, 2000);
   }
 }
@@ -86,9 +88,8 @@ function fallbackCopyTextToClipboard(text) {
   textArea.select();
   
   try {
-    // This is deprecated, but it's a fallback for older browsers 
-    // that don't support the clipboard API. It creates a temporary 
-    // textarea element, copies the text to it, and then removes it.
+    // I know this is deprecated, using it purely as a fallback 
+    // mechanism for browsers that do not support the clipboard api
     const successful = document.execCommand('copy');
     if (successful) {
       showCopiedFeedback();


### PR DESCRIPTION
## Summary

This PR adds a better UX for copying perma links.

## Motivation

This is a solution to the following issue: https://github.com/harvard-lil/perma/issues/3687

## Test Plan

### Setup

I tested this with Docker Desktop 4.41.2 on a Macbook with Apple Silicon. I set up a local instance of perma following the provided [developer guide](https://github.com/harvard-lil/perma/blob/develop/install.md).

### UX Testing

- I navigated to https://perma.test:8000 and created a test account. 
- I created a permalink for https://example.com
- The copy button is visible ✅ 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/d89c236d-3de2-4707-ab47-79bee51ba7c9" />

- The tooltip is correct ✅ 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/edf0650d-694c-4923-9b7c-10517971b750" />

- Copying works ✅ 

## Roll out and Monitoring

- If the reviewers agree with the approach here, I can also send follow-up PRs to add similar copy buttons for the list links page.

- I can commit to providing support for and/or rolling back this feature for the next two weeks in case there are any initial breakages. 


