### PR TITLE
Use latest Scoop.

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -52,7 +52,7 @@ services:
       - scoop_rest_api_internal
 
   scoop-rest-api:
-    image: registry.lil.tools/harvardlil/scoop-rest-api:146-48f0777c53fc265682e851f96ddcb88d
+    image: registry.lil.tools/harvardlil/scoop-rest-api:147-3abe80b078957d293268bc8adf6e2f36
     init: true
     tty: true
     depends_on:

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -449,7 +449,7 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
         self.assertEqual(link.submitted_title, "Test title.")
         self.assertEqual(link.submitted_description, "Test description.")
         self.assertRegex(link.captured_by_software, r'scoop @ harvard library innovation lab: \d+\.\d+.\d+')
-        expected_size = 20897
+        expected_size = 22054
         self.assertLessEqual(abs(link.wacz_size-expected_size), 100)
 
         # check folder


### PR DESCRIPTION
This updates the local Perma Scoop API image, which the latest Scoop, 0.6.58, upgrading yt-dlp and playwright.