### PR TITLE
Fix bookmarklet URL encoding issue (#3601)

### DIFF
--- a/perma_web/perma/tests/test_bookmarklet_service.py
+++ b/perma_web/perma/tests/test_bookmarklet_service.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class BookmarkletServiceTest(TestCase):
+    """Test the bookmarklet service endpoint."""
+    
+    def test_bookmarklet_redirect_simple_url(self):
+        """Test bookmarklet redirect with a simple URL."""
+        response = self.client.get('/service/bookmarklet-create/', {
+            'v': '1',
+            'url': 'https://example.com/page'
+        })
+        
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/manage/create/?url=https%3A%2F%2Fexample.com%2Fpage')
+    
+    def test_bookmarklet_redirect_url_with_query(self):
+        """Test bookmarklet redirect with URL containing query parameters."""
+        response = self.client.get('/service/bookmarklet-create/', {
+            'v': '1',
+            'url': 'https://example.com/page?search=test&page=2'
+        })
+        
+        self.assertEqual(response.status_code, 302)
+        # Query parameters should be encoded
+        self.assertIn('url=https%3A%2F%2Fexample.com%2Fpage%3Fsearch%3Dtest%26page%3D2', response.url)
+    
+    def test_bookmarklet_redirect_url_with_fragment(self):
+        """Test bookmarklet redirect with URL containing fragment."""
+        response = self.client.get('/service/bookmarklet-create/', {
+            'v': '1',
+            'url': 'https://example.com/page#section'
+        })
+        
+        self.assertEqual(response.status_code, 302)
+        # Fragment should be encoded
+        self.assertIn('url=https%3A%2F%2Fexample.com%2Fpage%23section', response.url)
+    
+    def test_bookmarklet_redirect_without_url(self):
+        """Test bookmarklet redirect without URL parameter."""
+        response = self.client.get('/service/bookmarklet-create/', {
+            'v': '1'
+        })
+        
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/manage/create/')
+    
+    def test_bookmarklet_redirect_empty_url(self):
+        """Test bookmarklet redirect with empty URL parameter."""
+        response = self.client.get('/service/bookmarklet-create/', {
+            'v': '1',
+            'url': ''
+        })
+        
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/manage/create/')

--- a/perma_web/perma/views/service.py
+++ b/perma_web/perma/views/service.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from django.shortcuts import redirect
+from urllib.parse import urlencode
 
 
 def bookmarklet_create(request):
@@ -16,5 +17,9 @@ def bookmarklet_create(request):
     ...and passes the query string values to /manage/create/
     '''
     tocapture = request.GET.get('url', '')
-    add_url = f"{reverse('create_link')}?url={tocapture}"
+    if tocapture:
+        params = urlencode({'url': tocapture})
+        add_url = f"{reverse('create_link')}?{params}"
+    else:
+        add_url = reverse('create_link')
     return redirect(add_url)


### PR DESCRIPTION
## Fix bookmarklet URL encoding issue

### Problem
The bookmarklet was failing for URLs containing special characters (`?`, `&`, `#`) because the URL parameter wasn't being properly encoded when constructing the redirect URL in the `bookmarklet_create` view.

### Example of the issue:
When trying to save a URL like `https://example.com/page?search=legal+documents&page=2`:

1. User clicks bookmarklet
2. Bookmarklet sends: `/service/bookmarklet-create/?v=1&url=https%3A%2F%2Fexample.com%2Fpage%3Fsearch%3Dlegal%2Bdocuments%26page%3D2`
3. **Before fix**: Server redirects to `/manage/create/?url=https://example.com/page?search=legal+documents&page=2`
4. Django interprets this incorrectly as:
   - `url` = `"https://example.com/page"` ❌
   - `search` = `"legal documents"` (misinterpreted as separate parameter)
   - `page` = `"2"` (misinterpreted as separate parameter)
5. **Result**: Only the base URL gets saved, query parameters are lost!

### Solution
Added proper URL encoding using `urllib.parse.urlencode()` to ensure special characters don't interfere with Django's URL parsing.

```python
# Before:
add_url = f"{reverse('create_link')}?url={tocapture}"

# After:
from urllib.parse import urlencode
params = urlencode({'url': tocapture})
add_url = f"{reverse('create_link')}?{params}"
```

### Visual Demonstration

<details>
<summary>Click to see before/after comparison</summary>

#### ❌ Before Fix (Broken)
```
URL: https://example.com/search?q=test&page=2
Redirect: /manage/create/?url=https://example.com/search?q=test&page=2
Django sees: url="https://example.com/search" (rest is lost!)
```

#### ✅ After Fix (Working)
```
URL: https://example.com/search?q=test&page=2
Redirect: /manage/create/?url=https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dtest%26page%3D2
Django sees: url="https://example.com/search?q=test&page=2" (complete!)
```

</details>

### Testing
Added comprehensive unit tests in `test_bookmarklet_service.py` to verify:
- Simple URLs work correctly
- URLs with query parameters are properly encoded
- URLs with fragments are properly encoded
- Empty/missing URLs are handled gracefully

### How to test manually
1. Install the Perma bookmarklet
2. Try to save a URL with query parameters (e.g., `https://example.com/search?q=test`)
3. Verify the complete URL appears in the create form

Fixes #3601