### PR TITLE
Allow admin to deny pending registrar without registrar user

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -139,6 +139,15 @@ class ApproveRegistrarForm(ModelForm):
             self.fields['base_rate'].required = False
             self.fields['status'].required = False
 
+    def clean_status(self) -> str | None:
+        status = self.cleaned_data.get('status')
+        registrar_user = self.cleaned_data.get('registrar_user')
+
+        if status == 'approved' and not registrar_user:
+            raise ValidationError('To approve a registrar, you must first add a registrar user')
+
+        return status
+
     def clean_registrar_user(self) -> str | None:
         """Validate whether a LinkUser matching the supplied email exists."""
         cleaned_value = self.cleaned_data['registrar_user'].lower()

--- a/perma_web/perma/templates/user_management/approve_pending_registrar.html
+++ b/perma_web/perma/templates/user_management/approve_pending_registrar.html
@@ -144,9 +144,11 @@
       {% endif %}
 
       <a class="btn cancel" href="../">Cancel</a>
-      {% if target_registrar_user %}
-        <button type="submit" name="status" value="approved" class="btn">Approve</button>
-        <button type="submit" name="status" value="denied" class="btn delete-confirm">Deny</button>
+      {% if target_registrar_user and target_registrar.status != "approved" %}
+        <button type="submit" name="status" value="approved" class="btn" form="form">Approve</button>
+      {% endif %}
+      {% if target_registrar.status != "denied" %}
+        <button type="submit" name="status" value="denied" class="btn delete-confirm" form="form">Deny</button>
       {% endif %}
     </form>
   {% endif %}

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -287,7 +287,7 @@ def approve_pending_registrar(request: HttpRequest, registrar_id: int):
                     target_registrar.base_rate = form.cleaned_data['base_rate']
                 target_registrar.save()
 
-                if new_status == 'approved':
+                if new_status == 'approved' and target_registrar_user:
                     target_registrar_user.registrar = target_registrar
                     target_registrar_user.pending_registrar = None
                     target_registrar_user.save()
@@ -300,10 +300,13 @@ def approve_pending_registrar(request: HttpRequest, registrar_id: int):
                         extra_tags='safe',
                     )
                 else:
+                    message = f'Registrar request for <strong>{target_registrar}</strong> denied.'
+                    if target_registrar_user:
+                        message += f' Please inform {target_registrar_user.email} if appropriate.'
                     messages.add_message(
                         request,
                         messages.SUCCESS,
-                        f'Registrar request for <strong>{target_registrar}</strong> denied. Please inform {target_registrar_user.email} if appropriate.',
+                        message,
                         extra_tags='safe',
                     )
 


### PR DESCRIPTION
Our team has requested the ability to deny a pending registrar (e.g., one submitted by a bot) without having to first populate a registrar user. This branch implements the logic and also does some cleanup on the conditions for whether to show/hide the Approve and Deny buttons.

To see this in action, run Perma locally and:

1. Submit a paid registrar request via the [Other Orgs sign up form](https://perma.test:8000/sign-up/firms) without setting yourself as administrator on the account
2. View the pending registrar request at `/manage/registrars/approve/xx`, replacing `xx` with the ID for your submitted registrar

## Before

<img width="1784" height="573" alt="image" src="https://github.com/user-attachments/assets/fd91e781-a4d9-46ef-8011-85b873f3e0b3" />

## After

<img width="1784" height="573" alt="image" src="https://github.com/user-attachments/assets/92153414-8ecb-4c7d-91b8-95c1427eac1c" />
