### PR TITLE
raise validation error for non utf-8 encoded csv files

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -1,7 +1,7 @@
 import logging
 import secrets
 import csv
-from io import TextIOWrapper
+from io import StringIO
 import string
 from typing import Any, Mapping
 
@@ -502,8 +502,14 @@ class MultipleUsersFormWithOrganization(ModelForm):
         if not file.name.endswith('.csv'):
             raise forms.ValidationError("The file must be a CSV.")
 
-        file = TextIOWrapper(file, encoding='utf-8')
-        reader = csv.DictReader(file)
+        # validate for encoding errors
+        try:
+            raw_contents = file.read().decode('utf-8')
+        except UnicodeDecodeError:
+            raise forms.ValidationError("CSV file must be encoded with UTF-8.")
+        
+        csv_file = StringIO(raw_contents)
+        reader = csv.DictReader(csv_file)
 
         # validate the headers
         headers = reader.fieldnames

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -694,8 +694,8 @@ class UserManagementViewsTestCase(PermaTestCase):
                          ).exists())
 
     def test_add_multiple_org_users_via_csv(self):
-        def create_csv_file(filename, content):
-            return SimpleUploadedFile(filename, content.encode('utf-8'), content_type='text/csv')
+        def create_csv_file(filename, content, encoding):
+            return SimpleUploadedFile(filename, content.encode(encoding), content_type='text/csv')
 
         def initialize_form(csv_file, data=None):
             data = {'organizations': selected_organization.pk, 'indefinite_affiliation': True}
@@ -707,11 +707,12 @@ class UserManagementViewsTestCase(PermaTestCase):
         invalid_csv_data = 'name\nJohn Doe'
         another_invalid_csv_data = 'first_name,last_name,email\nJohn,Doe,\nJane,Smith,janesmith@example.com'
 
-        valid_csv_file = create_csv_file('users.csv', csv_data)
-        another_valid_csv_file = create_csv_file('another_valid_users.csv', another_csv_data)
-        one_more_valid_csv_file = create_csv_file('one_more_valid_users.csv', csv_data)
-        invalid_csv_file = create_csv_file('invalid_users.csv', invalid_csv_data)
-        another_invalid_csv_file = create_csv_file('another_invalid_users.csv', another_invalid_csv_data)
+        valid_csv_file = create_csv_file('users.csv', csv_data, 'utf-8')
+        another_valid_csv_file = create_csv_file('another_valid_users.csv', another_csv_data, 'utf-8')
+        one_more_valid_csv_file = create_csv_file('one_more_valid_users.csv', csv_data, 'utf-8')
+        invalid_csv_file = create_csv_file('invalid_users.csv', invalid_csv_data, 'utf-8')
+        another_invalid_csv_file = create_csv_file('another_invalid_users.csv', another_invalid_csv_data, 'utf-8')
+        one_more_invalid_csv_file = create_csv_file('users.csv', csv_data, 'utf-16')
 
         request = RequestFactory().get('/')
         request.user = self.registrar_user
@@ -741,6 +742,12 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.assertFalse(form3.is_valid())
         self.assertTrue("Each row in the CSV file must contain email."
                         in form3.errors['csv_file'])
+
+        # invalid csv - non utf-8 encoding
+        form4 = initialize_form(one_more_invalid_csv_file)
+        self.assertFalse(form4.is_valid())
+        self.assertTrue("CSV file must be encoded with UTF-8."
+                        in form4.errors['csv_file'])
 
         # --- test user creation ---
         self.assertTrue(form1.is_valid())

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -712,7 +712,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         one_more_valid_csv_file = create_csv_file('one_more_valid_users.csv', csv_data)
         invalid_csv_file = create_csv_file('invalid_users.csv', invalid_csv_data)
         another_invalid_csv_file = create_csv_file('another_invalid_users.csv', another_invalid_csv_data)
-        one_more_invalid_csv_file = create_csv_file('users.csv', csv_data, 'utf-16')
+        csv_file_with_invalid_encoding = create_csv_file('users.csv', csv_data, 'utf-16')
 
         request = RequestFactory().get('/')
         request.user = self.registrar_user
@@ -744,7 +744,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                         in form3.errors['csv_file'])
 
         # invalid csv - non utf-8 encoding
-        form4 = initialize_form(one_more_invalid_csv_file)
+        form4 = initialize_form(csv_file_with_invalid_encoding)
         self.assertFalse(form4.is_valid())
         self.assertTrue("CSV file must be encoded with UTF-8."
                         in form4.errors['csv_file'])

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -694,7 +694,7 @@ class UserManagementViewsTestCase(PermaTestCase):
                          ).exists())
 
     def test_add_multiple_org_users_via_csv(self):
-        def create_csv_file(filename, content, encoding):
+        def create_csv_file(filename, content, encoding='utf-8'):
             return SimpleUploadedFile(filename, content.encode(encoding), content_type='text/csv')
 
         def initialize_form(csv_file, data=None):
@@ -707,11 +707,11 @@ class UserManagementViewsTestCase(PermaTestCase):
         invalid_csv_data = 'name\nJohn Doe'
         another_invalid_csv_data = 'first_name,last_name,email\nJohn,Doe,\nJane,Smith,janesmith@example.com'
 
-        valid_csv_file = create_csv_file('users.csv', csv_data, 'utf-8')
-        another_valid_csv_file = create_csv_file('another_valid_users.csv', another_csv_data, 'utf-8')
-        one_more_valid_csv_file = create_csv_file('one_more_valid_users.csv', csv_data, 'utf-8')
-        invalid_csv_file = create_csv_file('invalid_users.csv', invalid_csv_data, 'utf-8')
-        another_invalid_csv_file = create_csv_file('another_invalid_users.csv', another_invalid_csv_data, 'utf-8')
+        valid_csv_file = create_csv_file('users.csv', csv_data)
+        another_valid_csv_file = create_csv_file('another_valid_users.csv', another_csv_data)
+        one_more_valid_csv_file = create_csv_file('one_more_valid_users.csv', csv_data)
+        invalid_csv_file = create_csv_file('invalid_users.csv', invalid_csv_data)
+        another_invalid_csv_file = create_csv_file('another_invalid_users.csv', another_invalid_csv_data)
         one_more_invalid_csv_file = create_csv_file('users.csv', csv_data, 'utf-16')
 
         request = RequestFactory().get('/')


### PR DESCRIPTION
With this change, instead of throwing a 500 error, the form will raise a validation error if the CSV file isn't encoded with UTF-8 standard. 

<img width="633" height="570" alt="Screenshot 2025-08-21 at 10 11 03 AM" src="https://github.com/user-attachments/assets/58c09ff3-f4ef-4f41-87dc-1ee0e348d512" />
