### PR TITLE
fix pwd reset url

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -782,7 +782,7 @@ class BaseAddUserToGroup(UpdateView):
                 'requester': self.request.user.get_full_name(),
                 'account_settings_page': self.request.build_absolute_uri(reverse('settings_profile')),
             }
-            host = self.request.build_absolute_uri()
+            host = f"{self.request.scheme}://{self.request.get_host()}"
 
             for obj in users.values():
                 try:


### PR DESCRIPTION
The build_absolute_uri() method was passing the path of the current view to the new user email password reset link. 

This PR modifies that line so that we only pass the root URI to the Celery task, which creates the password reset URL. 