### PR TITLE
Fix broken Approve button in registrar approval workflow

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -124,6 +124,7 @@ class ApproveRegistrarForm(ModelForm):
 
     def __init__(self, data: Mapping[str, Any], registrar: Registrar, *args, **kwargs):
         super().__init__(data, *args, **kwargs)
+        self.registrar = registrar
 
         # Populate base rate default value from model
         self.fields['base_rate'].initial = registrar.base_rate
@@ -141,9 +142,10 @@ class ApproveRegistrarForm(ModelForm):
 
     def clean_status(self) -> str | None:
         status = self.cleaned_data.get('status')
-        registrar_user = self.cleaned_data.get('registrar_user')
 
-        if status == 'approved' and not registrar_user:
+        # Only approve registrar if it has an associated registrar user
+        has_registrar_user = self.registrar.pending_users.exists() or self.registrar.users.exists()
+        if status == 'approved' and not has_registrar_user:
             raise ValidationError('To approve a registrar, you must first add a registrar user')
 
         return status


### PR DESCRIPTION
https://github.com/harvard-lil/perma/pull/3731 introduced an inadvertent regression in the behavior of the Approve button on the registrar approval page. The bug occurred because we (well, I) added an invalid condition to `ApproveRegistrarForm.clean_status`, thus ensuring it would always throw a `ValidationError` and fail to approve.

This fixes the issue and restores functionality to the Approve button.