### PR TITLE
Revert change to org user removal flow.

### DIFF
--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -961,7 +961,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         self.submit_form('user_management_manage_single_organization_user_remove',
                          data={'affiliation': self.user_organization_affiliation.pk},
                          reverse_kwargs={'args': [self.organization_user.pk]},
-                         success_url=reverse('user_management_manage_single_organization_user', args=[self.organization_user.pk]))
+                         success_url=reverse('user_management_manage_organization_user'))
         self.assertFalse(self.organization_user.organizations.filter(pk=self.user_organization_affiliation.pk).exists())
 
     def test_registrar_cannot_remove_unrelated_user_from_organization(self):

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1043,7 +1043,7 @@ def manage_single_organization_user_remove(request, user_id):
         if request.user == target_user and not target_user.organizations.exists():
             return HttpResponseRedirect(reverse('create_link'))
 
-    return HttpResponseRedirect(reverse('user_management_manage_single_organization_user', args=[user_id]))
+    return HttpResponseRedirect(reverse('user_management_manage_organization_user'))
 
 
 @user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())


### PR DESCRIPTION
This PR restores the previous behavior of the flow to remove users from an organization: after form submission, the submitter is returned to the list of org users.

The tweak to redirect instead to a user-specific page was introduced in https://github.com/harvard-lil/perma/commit/8558fa3acd6ff65426c48ddb5dc0c5585a923f9a#diff-86c1f99e1e554ec8cf5e888d2c1033ffdced7ca1d91459906e8b37cdd67b711f. It works for admins, but 403s for registrar users. I'll make sure that, going forward, the tests pick that up, as part of the general refactoring of tests in https://github.com/harvard-lil/perma/pull/3621