### PR TITLE
Workaround for immutable dict error

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -298,7 +298,7 @@ class AuthenticatedLinkSerializer(LinkSerializer):
                             if content_length > settings.MAX_ARCHIVE_FILE_SIZE:
                                 errors['url'] = f"Target page is too large (max size {settings.MAX_ARCHIVE_FILE_SIZE / 1024 / 1024}MB)."
                         if validation_status_code := response_data.get("status_code"):
-                            self.context['request'].data["validation_status_code"] = validation_status_code
+                            self.validation_status_code = validation_status_code
                     except ScoopAPIException:
                         logger.exception("Scoop validation attempt failed.")
                         errors['url'] = "We encountered a network error: please try again."

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -535,7 +535,7 @@ class AuthenticatedLinkListView(BaseView):
                 # kick off capture tasks -- no need for guid since it'll work through the queue
                 capture_job.status = 'pending'
                 capture_job.link = link
-                if validation_status_code := serializer.context['request'].data.get("validation_status_code"):
+                if validation_status_code := getattr(serializer, 'validation_status_code', None):
                     capture_job.validation_status_code = validation_status_code
                 capture_job.save(update_fields=['status', 'link', 'validation_status_code'])
                 if not os.path.exists(settings.DEPLOYMENT_SENTINEL):


### PR DESCRIPTION
It's the weirdest thing. https://github.com/harvard-lil/perma/blob/develop/perma_web/api/serializers.py#L301 is throwing with:
> Exception Type: AttributeError at /v1/archives/
> Exception Value: This QueryDict instance is immutable

... but only for one particular api user (whom we have not heard from), under unknown circumstances I cannot seem to recreate, no matter what I try. Beats me. I would really like to know the root cause, but ????

This PR hopefully works around the issue, by setting `validation_status_code` directly on the serializer, instead of trying to inject it into the request data. That is a cleaner strategy anyway: I should have done that in the first place.