### PR TITLE
permission fix

### DIFF
--- a/perma_web/perma/tests/test_permissions.py
+++ b/perma_web/perma/tests/test_permissions.py
@@ -114,7 +114,7 @@ def test_permissions(client, admin_user, registrar_user, org_user, link_user_fac
             'urls': [
                 ['user_management_manage_single_organization_user_expiration_date', {'kwargs': {'user_id': org_user.id, 'organization_id': org_user_org.id}}]
             ],
-            'allowed': {admin_user, org_user_registrar_user},
+            'allowed': {admin_user, org_user_registrar_user, org_user},
         },
         {
             'urls': [

--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -1046,7 +1046,7 @@ def manage_single_organization_user_remove(request, user_id):
     return HttpResponseRedirect(reverse('user_management_manage_organization_user'))
 
 
-@user_passes_test_or_403(lambda user: user.is_staff or user.is_registrar_user())
+@user_passes_test_or_403(lambda user: user.is_registrar_user() or user.is_organization_user or user.is_staff)
 def manage_single_organization_user_expiration_date(request, user_id, organization_id):
     """
         Modify the affiliation expiration date of an org user


### PR DESCRIPTION
This PR allows the organization users of the same organization to be able to modify each other's affiliation expiration dates. 