### PR TITLE
Add survey email

### DIFF
--- a/perma_web/perma/email.py
+++ b/perma_web/perma/email.py
@@ -156,6 +156,7 @@ def registrar_users(registrars=None):
                 "first_name": user.first_name,
                 "last_name": user.last_name,
                 "email": user.email,
+                "raw_email": user.raw_email,
             })
     return users
 

--- a/perma_web/perma/templates/email/special.txt
+++ b/perma_web/perma/templates/email/special.txt
@@ -1,25 +1,25 @@
-TITLE: Perma.cc: notes for law school registrars
+TITLE: Perma.cc Institutional Partner Survey
 
-Hi Perma Colleagues!
+Below is a message from the Perma.cc team at HLSL. If your library is currently a Registrar for Perma, we ask that you participate in this brief, 10-minute survey to inform Perma’s future participation models and potential platform improvements.
 
-I'm Brett Johnson from the Perma.cc team at Harvard Law Library.
+—
 
-I hope you've had a wonderful start to your September. I know this is a very busy time for you all as you introduce students to the services your library offers. To that end I wanted to reach out with some resources that may help you assist journal members and others at your school using Perma.cc.
+Dear Perma.cc Institutional Partners,
 
-* Creating Perma.cc orgs and adding org users:
-  https://docs.google.com/document/d/1ZNheAxvY24HBvRbxsDBJAgK7Q_syHYOplTNKQ47PQZA/edit
+Thank you for the part you’ve played in the Perma.cc network, connecting your patrons with Perma.cc’s services. In addition to being built and maintained by a unit of the Harvard Law School Library, Perma’s connection with the academic library system has been a core part of its structure since the beginning. We are writing today to ask you to participate in this brief, 10-minute survey to inform Perma’s future participation and sustainability models as well as potential platform improvements.
 
-* Handling graduating and departing users:
-  https://blogs.harvard.edu/perma/2019/03/07/academic-libraries-on-perma-how-to-handle-departing-or-graduating-users/
+Perma.cc Institutional Partner Survey
+https://harvard.az1.qualtrics.com/jfe/form/SV_doL6I7r9OFx7bDM
 
-* How to use a Perma.cc link in a citation:
-  https://guides.library.harvard.edu/c.php?g=537635&p=3756915
+Due to the ongoing needs of a project like Perma.cc (see below) we are considering new approaches to funding. You are being asked to participate in the survey because as director of a Perma Registrar or the local Perma admin for a library your insights will greatly inform our conversations about Perma’s ongoing sustainability and governance.
 
-* How bad is link rot? A collection of studies:
-  https://blogs.harvard.edu/perma/2019/02/14/so-how-bad-a-problem-is-link-rot/
+The stability of libraries and archives is front of mind for all of us, including from a financial point of view. We acknowledge up front that any adjustments made to our funding structure need to prioritize accessibility of Perma to the academic community – including by having provisions for institutions where funding is particularly scarce.
 
-As you communicate with your journals about using Perma, please feel free to reach out to us at info@perma.cc with any questions that come up - and follow us on Twitter @permacc !
+Since our launch in 2013, the Perma Team has been striving to keep pace with changes in web technologies, such as changing browser protocols, increasingly sophisticated and disruptive advertising tactics, and locked-down social media platforms. There will surely be future innovations in the digital and web space that will need to be incorporated into Perma.cc, and keeping pace with these changes requires us to fund the staffing for these necessary and other user-identified improvements. We would love your input in determining the best way forward for ensuring Perma’s ongoing success.
 
-Thanks for reading - and happy Fall semester from me and the rest of the Perma.cc Team!
+We are committed to Perma.cc being accessible, especially in the academic context. In a moment where there is a great deal of uncertainty in academia, ensuring our collective ability to preserve the web is vital. In the survey, please share any thoughts you have about how we may best approach the sustainability of this tool as a community.
 
-P.S. - Interested in some swag (stickers, bookmarks, etc.) to help promote Perma.cc at your school? Reply to this email with your name and shipping address and we'll get a pack out to you!
+Take the survey via Qualtrics: https://harvard.az1.qualtrics.com/jfe/form/SV_doL6I7r9OFx7bDM
+
+All the best,
+The Perma.cc Team at Harvard Law School Library

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -213,7 +213,7 @@ def ping_registrar_users(ctx, limit_to="", limit_by_tag="", exclude="", exclude_
         context = {}
         context.update(user)
         context["year"] = year
-        succeeded = send_user_email(user['email'],
+        succeeded = send_user_email(user['raw_email'],
                                     template,
                                      context)
         if succeeded:

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -209,7 +209,7 @@ def ping_registrar_users(ctx, limit_to="", limit_by_tag="", exclude="", exclude_
     logger.info("Begin emailing registrar users.")
     send_count = 0
     failed_list = []
-    for user in users:
+    for user in tqdm(users):
         context = {}
         context.update(user)
         context["year"] = year

--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -177,7 +177,7 @@ def ping_registrar_users(ctx, limit_to="", limit_by_tag="", exclude="", exclude_
        Sends an email to our current registrar users. See templates/email/registrar_user_ping.txt
 
        Arguments should be strings, with multiple values separated by semi-colons
-       e.g. invoke ping-registrar-users --limit-to "14;27;30" --exclude-by-tag "opted_out" --email "special"
+       e.g. invoke dev.ping-registrar-users --limit-to "14;27;30" --exclude-by-tag "opted_out" --email "special"
 
        Limit filters are applied before exclude filters.
     '''


### PR DESCRIPTION
See LIL-4459

This PR updates templates/email/special.txt to a new, one-time email, to be sent out shortly.

Additional tweaks:
- it fixes this code to send to the newish `user.raw_email` (original capitalization) instead of the `user.email` (down-cased)
- it adds TQDM, so that the person invoking the task will see a progress bar as it proceeds instead of having to wait until the task is complete for any output
- it updates the docstring with the correct `invoke` invocation

A sample email and headers:
```
-------------------------------------------------------------------------------
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: 8bit
Subject: Perma.cc Institutional Partner Survey
From: webmaster@localhost
To: test_registrar_user@example.com
Date: Mon, 03 Nov 2025 18:40:04 -0000
Message-ID: <176219520402.17.11393205331663203102@4a86482901b8>

Below is a message from the Perma.cc team at HLSL. If your library is currently a Registrar for Perma, we ask that you participate in this brief, 10-minute survey to inform Perma’s future participation models and potential platform improvements.

—

Dear Perma.cc Institutional Partners,

Thank you for the part you’ve played in the Perma.cc network, connecting your patrons with Perma.cc’s services. In addition to being built and maintained by a unit of the Harvard Law School Library, Perma’s connection with the academic library system has been a core part of its structure since the beginning. We are writing today to ask you to participate in this brief, 10-minute survey to inform Perma’s future participation and sustainability models as well as potential platform improvements.

Perma.cc Institutional Partner Survey
https://harvard.az1.qualtrics.com/jfe/form/SV_doL6I7r9OFx7bDM

Due to the ongoing needs of a project like Perma.cc (see below) we are considering new approaches to funding. You are being asked to participate in the survey because as director of a Perma Registrar or the local Perma admin for a library your insights will greatly inform our conversations about Perma’s ongoing sustainability and governance.

The stability of libraries and archives is front of mind for all of us, including from a financial point of view. We acknowledge up front that any adjustments made to our funding structure need to prioritize accessibility of Perma to the academic community – including by having provisions for institutions where funding is particularly scarce.

Since our launch in 2013, the Perma Team has been striving to keep pace with changes in web technologies, such as changing browser protocols, increasingly sophisticated and disruptive advertising tactics, and locked-down social media platforms. There will surely be future innovations in the digital and web space that will need to be incorporated into Perma.cc, and keeping pace with these changes requires us to fund the staffing for these necessary and other user-identified improvements. We would love your input in determining the best way forward for ensuring Perma’s ongoing success.

We are committed to Perma.cc being accessible, especially in the academic context. In a moment where there is a great deal of uncertainty in academia, ensuring our collective ability to preserve the web is vital. In the survey, please share any thoughts you have about how we may best approach the sustainability of this tool as a community.

Take the survey via Qualtrics: https://harvard.az1.qualtrics.com/jfe/form/SV_doL6I7r9OFx7bDM

All the best,
The Perma.cc Team at Harvard Law School Library
```