### PR TITLE
Use intended form label

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -103,13 +103,15 @@ class LibraryRegistrarForm(ModelForm):
 
 class FirmRegistrarForm(ModelForm):
     # Ensure firm name doesn't throw a DataError when we write it to LinkUser.requested_account_note
-    name = forms.CharField(max_length=LinkUser.requested_account_note.field.max_length)
+    name = forms.CharField(
+        max_length=LinkUser.requested_account_note.field.max_length,
+        label='Organization name'
+    )
 
     class Meta:
         model = Registrar
         fields = ['name', 'email', 'website']
         labels = {
-            'name': 'Organization name',
             'email': 'Organization email',
             'website': 'Organization website',
         }


### PR DESCRIPTION
See LIL-3778.

The `name` field was supposed to be labeled "Organization name", but that code wasn't working as intended: it turns out, you can only override the label for model fields using that syntax, not set the label for extra fields. So, this PR defines the label inline, when defining the field, instead.

Before:
<img width="622" height="926" alt="image" src="https://github.com/user-attachments/assets/5f6e0578-fbf3-46cb-809a-92f38162a8dd" />

After:
<img width="842" height="950" alt="image" src="https://github.com/user-attachments/assets/3b0cafc4-0f3a-435b-a0ec-073d4d55cbbc" />
