### PR TITLE
Add expiration date field to sponsored user and org user exports

### DIFF
--- a/perma_web/perma/views/user_management.py
+++ b/perma_web/perma/views/user_management.py
@@ -322,11 +322,13 @@ def manage_sponsored_user_export_user_list(request: HttpRequest) -> HttpResponse
         'last_login',
         'sponsorship_status',
         'sponsorship_created_at',
+        'sponsorship_expires_at'
     ]
     records = list_sponsored_users(request, export=True)
     users = records.annotate(
         sponsorship_status=F('sponsorships__status'),
         sponsorship_created_at=F('sponsorships__created_at'),
+        sponsorship_expires_at=F('sponsorships__expires_at'),
     ).values(*field_names)
     filename = 'perma-sponsored-users'
 
@@ -384,9 +386,13 @@ def manage_organization_user_export_user_list(request: HttpRequest):
         'date_joined',
         'last_login',
         'organization_name',
+        'affiliation_expires_at',
     ]
     records = list_users_in_group(request, 'organization_user', export=True)
-    org_users = records.annotate(organization_name=F('organizations__name')).values(*field_names)
+    org_users = records.annotate(
+        organization_name=F('organizations__name'),
+        affiliation_expires_at=F('userorganizationaffiliation__expires_at'),
+    ).values(*field_names)
     filename = 'perma-organization-users'
 
     # Export records in appropriate format based on `format` URL parameter


### PR DESCRIPTION
See LIL-4437.

Users with sufficient credentials can download a spreadsheet of metadata about the users affiliated with the groups they administer: org users, and/or sponsored users, depending on their particular permissions.

This PR adds a column to those spreadsheets, reporting when the users' affiliations expire (which is a "newer" Perma feature, in the scheme of things: all affiliations were originally permanent).

The column is called "affiliation_expires_at" for org users, and "sponsorship_expires_at" for sponsored users. The new column appears in both CSV and JSON export formats.

<img width="1124" height="240" alt="image" src="https://github.com/user-attachments/assets/0f2c54f3-96ea-4719-9ba1-fc19554088de" />
<img width="1308" height="172" alt="image" src="https://github.com/user-attachments/assets/f47873a1-5438-40ca-8700-433b55ca4a25" />
<img width="3216" height="1976" alt="image" src="https://github.com/user-attachments/assets/b3c960b3-3e4b-4190-82df-a63c1efe2f44" />

I didn't think it was worth updating the tests to check for the presence of that column. If you think I should, I am happy to readdress 🙂 
