### PR TITLE
Prevent long court name from erroring out during sign up

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -344,7 +344,11 @@ class CreateUserFormWithCourt(UserForm):
     add court to the create user form
     """
 
-    requested_account_note = forms.CharField(required=True)
+    requested_account_note = forms.CharField(
+        required=True,
+        # Explicitly add this max length to the form, so that it enforced by the HTML
+        max_length=LinkUser.requested_account_note.field.max_length
+    )
 
     class Meta:
         model = LinkUser

--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -346,7 +346,7 @@ class CreateUserFormWithCourt(UserForm):
 
     requested_account_note = forms.CharField(
         required=True,
-        # Explicitly add this max length to the form, so that it enforced by the HTML
+        # Explicitly add this max length to the form, so that it is enforced by the HTML
         max_length=LinkUser.requested_account_note.field.max_length
     )
 

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1692,15 +1692,6 @@ class UserManagementViewsTestCase(PermaTestCase):
 
         # NOT LOGGED IN
 
-        # Existing user's email address, no court info
-        # (currently succeeds, should probably fail; see issue 1746)
-        self.submit_form('sign_up_courts',
-                          data = { 'address': self.randomize_capitalization(existing_user['email'])},
-                          success_url = reverse('court_request_response'))
-        expected_emails_sent += 1
-        self.assertEqual(len(mail.outbox), expected_emails_sent)
-        self.check_court_email(mail.outbox[expected_emails_sent - 1], existing_user['email'])
-
         # Existing user's email address + court info
         self.submit_form('sign_up_courts',
                           data = { 'address': self.randomize_capitalization(existing_user['email']),
@@ -1789,6 +1780,13 @@ class UserManagementViewsTestCase(PermaTestCase):
                           user = 'test_user@example.com',
                           error_keys = ['email', 'requested_account_note'])
         self.assertEqual(len(mail.outbox), 0)
+
+        # Existing user's email address, no court info
+        self.submit_form('sign_up_courts',
+                          data = { 'address': self.randomize_capitalization('test_user@example.com')},
+                          error_keys = ['requested_account_note'])
+        self.assertEqual(len(mail.outbox), 0)
+
 
 
     ### Firms ###

--- a/perma_web/perma/views/user_sign_up.py
+++ b/perma_web/perma/views/user_sign_up.py
@@ -138,14 +138,21 @@ def sign_up_courts(request):
             target_user = None
 
         if target_user:
-            requested_account_note = request.POST.get('requested_account_note', None)
-            target_user.requested_account_type = 'court'
-            target_user.requested_account_note = requested_account_note
-            target_user.save()
-            email_court_request(request, target_user)
-            return HttpResponseRedirect(reverse('court_request_response'))
+            # Validate the entire form
+            form.is_valid()
+            # Remove the email validation error (since we know the user exists)
+            form.errors.pop('email', None)
+            # Check if there are any remaining errors (like requested_account_note being too long)
+            if not form.errors:
+                # No errors - proceed
+                requested_account_note = request.POST.get('requested_account_note', None)
+                target_user.requested_account_type = 'court'
+                target_user.requested_account_note = requested_account_note
+                target_user.save()
+                email_court_request(request, target_user)
+                return HttpResponseRedirect(reverse('court_request_response'))
 
-        if form.is_valid():
+        elif form.is_valid():
             new_user = form.save(commit=False)
             new_user.requested_account_type = 'court'
             create_account = request.POST.get('create_account', None)


### PR DESCRIPTION
See LIL-3723.

These signup forms are (and ever have been) so quirky: you can fill them out with any email address, and there is special logic for, if you happen to use the email address of an existing user. We have long talked about completely re-envisioning this flow.

But, in the meantime, we were seeing an occasional bug: if a user filled out the form with the email of an existing user, and supplied a court name > 45, we tried to save the overly long value to the DB and got an error. (Form validation took care of it otherwise, if a new email address was used.)

This PR takes care of that in two ways. 

First, it tweaks the logic in `[user_sign_up.py](https://github.com/harvard-lil/perma/compare/develop...rebeccacremona:prevent-long-name?expand=1#diff-d97eadd77df375d1af215119a37863572f3205e05eedf8c8fe186f6f9aaf4f90)` to validate the form, but ignore the error that complains there is already a user with that email (we know). That is sufficient to get a validation error to the user:
<img width="2842" height="1974" alt="image" src="https://github.com/user-attachments/assets/77c3febf-de1e-472c-bd85-85dba5bc6555" />

But, I also explicitly added a max_length to the char field definition. That results in the form being rendered with `<input type="text" name="requested_account_note" maxlength="45" required="" id="id_requested_account_note">`, so, the user's browser will enforce the limit.