### PR TITLE
Disable the public list route again, temporarily.

### DIFF
--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -77,8 +77,8 @@ class LinkAuthorizationTestCase(LinkAuthorizationMixin, ApiResourceTestCase):
     # GET #
     #######
 
-    def test_should_allow_logged_out_users_to_get_list(self):
-        self.successful_get(self.public_list_url)
+    # def test_should_allow_logged_out_users_to_get_list(self):
+    #     self.successful_get(self.public_list_url)
 
     def test_should_allow_logged_in_users_to_get_logged_in_list(self):
         self.successful_get(self.list_url, user=self.regular_user)

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -152,8 +152,8 @@ class LinkResourceTestCase(LinkResourceTestMixin, ApiResourceTestCase):
     # GET #
     #######
 
-    def test_get_list_json(self):
-        self.successful_get(self.public_list_url, count=13)
+    # def test_get_list_json(self):
+    #     self.successful_get(self.public_list_url, count=13)
 
     def test_private_download_unauthenticated(self):
         self.rejected_get(self.logged_in_private_link_download_url, expected_status_code=401)

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -323,11 +323,13 @@ class PublicLinkListView(BaseView):
     def get(self, request, format=None):
         """ List public links. """
 
-        queryset = Link.objects\
-            .order_by('-creation_timestamp')\
-            .select_related('capture_job')\
-            .prefetch_related('captures').discoverable()
-        return self.simple_list(request, queryset, paginator_class=LimitedTastypiePagination)
+        return HttpResponse('This route is temporarily unavailable', status=503)
+
+        # queryset = Link.objects\
+        #     .order_by('-creation_timestamp')\
+        #     .select_related('capture_job')\
+        #     .prefetch_related('captures').discoverable()
+        # return self.simple_list(request, queryset, paginator_class=LimitedTastypiePagination)
 
 
 # /archives

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -18,7 +18,7 @@ from perma.utils import stream_archive_if_permissible
 from perma.celery_tasks import run_next_capture
 from perma.models import Folder, CaptureJob, Link, Capture, Organization, LinkBatch
 
-from .utils import TastypiePagination, LimitedTastypiePagination, load_parent, raise_general_validation_error, \
+from .utils import TastypiePagination, load_parent, raise_general_validation_error, \
     raise_invalid_capture_job, dispatch_multiple_requests, reverse_api_view_relative, \
     url_is_invalid_unicode, get_download_file_format
 from .serializers import FolderSerializer, CaptureJobSerializer, LinkSerializer, AuthenticatedLinkSerializer, \


### PR DESCRIPTION
This is here in case we need to revert, after deploying my latest.