### PR TITLE
add daily link counts endpoint

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -361,3 +361,10 @@ class LinkBatchSerializer(BaseSerializer):
 
 class DetailedLinkBatchSerializer(LinkBatchSerializer):
     target_folder = FolderSerializer(read_only=True)
+
+
+### DAILY LINK COUNTS ###
+
+class InternalDailyLinkCountsQuerySerializer(serializers.Serializer):
+    lookback_period = serializers.IntegerField(default=30, min_value=1, max_value=365, required=False)
+

--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -75,6 +75,9 @@ urlpatterns = [
         # /user
         re_path(r'^user/?$', views.LinkUserView.as_view(), name='user'),
 
+        # /internal/daily_link_counts
+        re_path(r'^internal/daily_link_counts/?$', views.InternalDailyLinkCountsView.as_view(), name='internal_daily_link_counts'),
+
         # / ('/v1/' only, not '/v1')
         re_path(r'^$', root_view)
     ])),

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -361,7 +361,10 @@ class InternalDailyLinkCountsView(APIView):
             .annotate(count=Count('guid'))
             .order_by('day')
         )
-        data = [{row['day'].isoformat(): row['count']} for row in rows]
+        data = {
+            "lookback_period": lookback_period, 
+            "counts": [{row['day'].isoformat(): row['count']} for row in rows]
+        }
         return Response(data)
 
 

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -1,10 +1,13 @@
 from collections import OrderedDict
 import csv
+from datetime import timedelta
 import django_filters
 import os.path
 from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
 from django.db import transaction
-from django.db.models import Prefetch, F
+from django.db.models import Count, Prefetch, F
+from django.db.models.functions import TruncDate
+from django.utils import timezone
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied, ValidationError
@@ -22,7 +25,8 @@ from .utils import TastypiePagination, LongTastypiePagination, LimitedTastypiePa
     raise_invalid_capture_job, dispatch_multiple_requests, reverse_api_view_relative, \
     url_is_invalid_unicode, get_download_file_format
 from .serializers import FolderSerializer, CaptureJobSerializer, LinkSerializer, AuthenticatedLinkSerializer, \
-    LinkUserSerializer, OrganizationSerializer, LinkBatchSerializer, DetailedLinkBatchSerializer
+    LinkUserSerializer, OrganizationSerializer, LinkBatchSerializer, DetailedLinkBatchSerializer, \
+    InternalDailyLinkCountsQuerySerializer
 from django.conf import settings
 from django.urls import reverse
 
@@ -328,6 +332,37 @@ class PublicLinkListView(BaseView):
             .select_related('capture_job')\
             .prefetch_related('captures').discoverable()
         return self.simple_list(request, queryset, paginator_class=LimitedTastypiePagination)
+
+
+# /internal/daily_link_counts
+class InternalDailyLinkCountsView(APIView):
+    """
+    Returns the number of public archives created per day over a lookback window.
+    Accepts query param lookback_period - number of days to look back (default 30, max 365).
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, format=None):
+        serializer = InternalDailyLinkCountsQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        lookback_period = serializer.validated_data['lookback_period']
+        today = timezone.now().date()
+        start_date = today - timedelta(days=lookback_period)
+        end_date = today - timedelta(days=1)
+
+        rows = (
+            Link.objects.discoverable()
+            .filter(
+                creation_timestamp__date__gte=start_date,
+                creation_timestamp__date__lte=end_date,
+            )
+            .annotate(day=TruncDate('creation_timestamp'))
+            .values('day')
+            .annotate(count=Count('guid'))
+            .order_by('day')
+        )
+        data = [{row['day'].isoformat(): row['count']} for row in rows]
+        return Response(data)
 
 
 # /archives


### PR DESCRIPTION
This new endpoint (/v1/internal/daily_link_counts/?lookback_period=int) returns the daily link counts for a given period in the following response format. The reason behind the creation of this is to prevent the status app from calling the archives endpoint repeatedly by paginating through multiple pages, looking for link creation dates. 

```
{
    "lookback_period": 30,
    "counts": [
        {
            "2026-03-14": 10
        },
        {
            "2026-03-16": 3
        }
    ]
}
```