### PR TITLE
Alter public api route

### DIFF
--- a/perma_web/api/urls.py
+++ b/perma_web/api/urls.py
@@ -13,7 +13,6 @@ root_view = APIRootView.as_view(api_root_dict={
     'folders': 'folders',
     'capture_jobs': 'capture_jobs',
     'archives': 'archives',
-    'public_archives': 'public_archives',
     'organizations': 'organizations',
     'user': 'user',
 })

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -317,8 +317,6 @@ class LinkFilter(django_filters.rest_framework.FilterSet):
 class PublicLinkListView(BaseView):
     permission_classes = ()  # no login required
     serializer_class = LinkSerializer
-    filterset_class = LinkFilter
-    search_fields = ('guid', 'submitted_url', 'submitted_title')  # fields that can be searched with q= query string
 
     def get(self, request, format=None):
         """ List public links. """
@@ -335,7 +333,7 @@ class PublicLinkListView(BaseView):
 class AuthenticatedLinkListView(BaseView):
     serializer_class = AuthenticatedLinkSerializer
     filterset_class = LinkFilter
-    search_fields = PublicLinkListView.search_fields + ('notes',)  # private links can also be searched by notes field
+    search_fields = ('guid', 'submitted_url', 'submitted_title', 'notes',)  # fields that can be searched with q= query string
 
     @staticmethod
     def get_folder_from_request(request):


### PR DESCRIPTION
This PR removes the `public_archives` route from the list of available routes:
<img width="1380" height="632" alt="image" src="https://github.com/user-attachments/assets/fa308e9c-25f1-44ad-afd5-b43c6c51e626" />

It is still available, it just isn't advertised via that mechanism, which may reduce the number of crawlers that hit it.

This also drops support for filtering or searching within the list of public archives; that has grown too expensive to support, over time.