### PR TITLE
Prevent duplicate CI runs

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,6 +1,12 @@
 name: Lints
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - prod
+      - stage
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - prod
+      - stage
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Before:

* When someone pushes up changes to an open PR, it triggers 4 jobs:
  + lints (due to branch push)
  + lints (due to open PR)
  + tests (due to branch push)
  + tests (due to open PR)
* This is pointless and duplicative; it can also cause CI bottlenecks

After:

* When someone pushes up changes to an open PR, whether from a branch or a fork, it triggers 2 jobs:
  + lints (due to open PR)
  + tests (due to open PR)
* Pushes to branches not associated with a PR will not trigger CI
* To be safe, any push to `develop`, `prod`, or `stage` still triggers a CI run