### PR TITLE
Tweak how links are filtered when listed by the API

### DIFF
--- a/perma_web/api/tests/test_link_authorization.py
+++ b/perma_web/api/tests/test_link_authorization.py
@@ -74,6 +74,9 @@ class LinkAuthorizationMixin():
 
 class LinkAuthorizationTestCase(LinkAuthorizationMixin, ApiResourceTestCase):
 
+    def folder_archives_url(self, folder):
+        return "{0}/folders/{1}/archives".format(self.url_base, folder.pk)
+
     #######
     # GET #
     #######
@@ -98,6 +101,57 @@ class LinkAuthorizationTestCase(LinkAuthorizationMixin, ApiResourceTestCase):
 
     def test_should_reject_logged_out_users_getting_logged_in_detail(self):
         self.rejected_get(self.link_url)
+
+    ##########################
+    # Listing folder archives #
+    ##########################
+
+    def test_should_allow_user_to_list_archives_in_own_folder(self):
+        self.successful_get(self.folder_archives_url(self.regular_user.root_folder),
+                            user=self.regular_user)
+
+    def test_should_allow_org_user_to_list_archives_in_org_shared_folder(self):
+        self.successful_get(self.folder_archives_url(self.link.organization.shared_folder),
+                            user=self.org_user)
+
+    def test_should_allow_related_org_user_to_list_archives_in_org_shared_folder(self):
+        self.successful_get(self.folder_archives_url(self.link.organization.shared_folder),
+                            user=self.related_org_user)
+
+    def test_should_allow_registrar_user_to_list_archives_in_registrar_org_folder(self):
+        self.successful_get(self.folder_archives_url(self.link.organization.shared_folder),
+                            user=self.registrar_user)
+
+    def test_should_allow_admin_to_list_archives_in_any_folder(self):
+        self.successful_get(self.folder_archives_url(self.regular_user.root_folder),
+                            user=self.admin_user)
+
+    def test_should_reject_listing_archives_in_other_users_folder(self):
+        self.rejected_get(self.folder_archives_url(self.org_user.root_folder),
+                          user=self.regular_user,
+                          expected_status_code=403)
+
+    def test_should_reject_listing_archives_in_unrelated_org_folder(self):
+        self.rejected_get(self.folder_archives_url(self.link.organization.shared_folder),
+                          user=self.unrelated_org_user,
+                          expected_status_code=403)
+
+    def test_should_reject_logged_out_user_listing_folder_archives(self):
+        self.rejected_get(self.folder_archives_url(self.regular_user.root_folder))
+
+    def test_should_return_404_for_nonexistent_folder_archives(self):
+        url = "{0}/folders/{1}/archives".format(self.url_base, 99999)
+        self.rejected_get(url, user=self.regular_user, expected_status_code=404)
+
+    def test_folder_archives_only_contains_links_from_that_folder(self):
+        folder = self.regular_user.root_folder
+        data = self.successful_get(self.folder_archives_url(folder), user=self.regular_user)
+        returned_guids = {obj['guid'] for obj in data['objects']}
+        folder_link_guids = set(
+            folder.links.filter(user_deleted=False).values_list('guid', flat=True)
+        )
+        self.assertTrue(returned_guids.issubset(folder_link_guids),
+                        f"Returned links {returned_guids - folder_link_guids} are not in folder {folder.pk}")
 
     ###########
     # Editing #

--- a/perma_web/api/views.py
+++ b/perma_web/api/views.py
@@ -395,12 +395,16 @@ class AuthenticatedLinkListView(BaseView):
         queryset = Link.objects\
             .order_by('-creation_timestamp')\
             .select_related('organization', 'organization__registrar', 'organization__shared_folder', 'capture_job', 'created_by')\
-            .prefetch_related('captures')\
-            .accessible_to(request.user)
+            .prefetch_related('captures')
 
-        # for /folders/:parent_id/archives, limit to links in folder
         if request.parent:
+            # For /folders/:parent_id/archives, limit to links in folder.
+            # The code that sets request.parent guarantees that folder is accessible to this user;
+            # no need for a check here.
             queryset = queryset.filter(folders=request.parent)
+        else:
+            # Otherwise, get all the links accessible to the user
+            queryset = queryset.accessible_to(request.user)
 
         return queryset
 


### PR DESCRIPTION
We recently noticed some odd SQL: queries with a redundant WHERE filter:
```
WHERE (NOT "perma_link"."user_deleted" AND "perma_link_folders"."folder_id" IN (x, y, z) AND T4."folder_id" = x)
```
The above is checking to see if a link is in a set  of folders... and then checking to see if the link is in one particular folder.

That's silly.

This PR tweaks the code, so that we do one or the other:
- filter for links in the one folder, if a folder is specified
- filter for all the links in the accessible set, otherwise

Removing the redundancy will hopefully improve performance somewhat for users who have access to large trees of folders.