### PR TITLE
test new image push to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Perma.cc helps authors and journals create permanent archived citations in their
 
 ## Installation
 
-If you're installing Perma.cc, see [the installation doc](https://github.com/harvard-lil/perma/blob/develop/install.md)
+If you're installing Perma.cc, see [the installation doc](https://github.com/harvard-lil/perma/blob/develop/install.md).
 
 ## Developing in Perma.cc
 


### PR DESCRIPTION
This image referenced in the latest develop build doesn't exist in the Harbor registry, and is causing PR [3769](https://github.com/harvard-lil/perma/pull/3769) to fail during the build action. This PR makes a tiny change to the readme so I can see whether it can be reproduced or if it was a blip of some kind. 

