### PR TITLE
Disable prorating

### DIFF
--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -14,7 +14,6 @@ from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
 
 from perma.exceptions import InvalidTransmissionException, PermaPaymentsCommunicationException
 from perma.utils import (
-    first_day_of_next_month,
     pp_date_from_post,
     prep_for_perma_payments,
     process_perma_payments_transmission,

--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -18,6 +18,7 @@ from perma.utils import (
     pp_date_from_post,
     prep_for_perma_payments,
     process_perma_payments_transmission,
+    today_next_month,
     today_next_year,
 )
 
@@ -315,13 +316,20 @@ class CustomerModel(models.Model):
         '''
 
         # Calculate when, after today, the customer will/should next be charged.
-        # Calculate what fraction of the current subscription period remains,
-        # to use when determining how much to charge them today.
         if tier['period'] == 'monthly':
-            # monthly subscriptions are paid on the first of the next month
-            next_payment = next_month
-            days_in_month = calendar.monthrange(now.year, now.month)[1]
-            prorated_ratio = Decimal((next_payment - now).days / days_in_month)
+            # montly subscriptions are now paid on the anniversary of their creation.
+            # historically, monthly subscriptions were all paid on the first of the month.
+            if current_subscription:
+                # n.b. these values are nonsensical if the current subscription is not active.
+                # there is no good answer in that case.... so updating a non-active
+                # subscription is forbidden below. continuing to calculate the nonsensical values
+                # for these fields since.... that at least avoids type errors.
+                next_payment = current_subscription['paid_through']
+                days_in_month = calendar.monthrange(now.year, now.month)[1]
+                prorated_ratio = Decimal((next_payment - now).days / days_in_month)
+            else:
+                next_payment = next_month
+                prorated_ratio  = Decimal(1)
         elif tier['period'] == 'annually':
             # annual subscriptions are paid on the anniversary of their creation
             if current_subscription:
@@ -409,7 +417,7 @@ class CustomerModel(models.Model):
 
     def get_subscription_info(self, now):
         timestamp = now.timestamp()
-        next_month = first_day_of_next_month(now)
+        next_month = today_next_month(now)
         next_year = today_next_year(now)
         subscription = self.get_subscription()
 

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -639,7 +639,8 @@ def test_annotate_tier_monthly_active_subscription_upgrade_first_of_month(custom
         'status': 'Current',
         'rate': '0.10',
         'frequency': 'monthly',
-        'link_limit': 0
+        'link_limit': 0,
+        'paid_through': next_month
     }
     for customer in customers:
         tier = {
@@ -663,7 +664,8 @@ def test_annotate_tier_monthly_active_subscription_upgrade_mid_month(customers):
         'status': 'Current',
         'rate': '0.10',
         'frequency': 'monthly',
-        'link_limit': 0
+        'link_limit': 0,
+        'paid_through': next_month
     }
     for customer in customers:
         tier = {
@@ -687,7 +689,8 @@ def test_annotate_tier_monthly_active_subscription_upgrade_last_of_month(custome
         'status': 'Current',
         'rate': '0.10',
         'frequency': 'monthly',
-        'link_limit': 0
+        'link_limit': 0,
+        'paid_through': next_month
     }
     for customer in customers:
         tier = {
@@ -717,7 +720,8 @@ def test_annotate_tier_monthly_active_subscription_downgrade_first_of_month(cust
         'status': 'Current',
         'rate': '9999.10',
         'frequency': 'monthly',
-        'link_limit': 9999
+        'link_limit': 9999,
+        'paid_through': next_month
     }
     for customer in customers:
         tier = {
@@ -741,7 +745,8 @@ def test_annotate_tier_monthly_active_subscription_downgrade_mid_month(customers
         'status': 'Current',
         'rate': '9999.10',
         'frequency': 'monthly',
-        'link_limit': 9999
+        'link_limit': 9999,
+        'paid_through': next_month
     }
     for customer in customers:
         tier = {
@@ -765,7 +770,8 @@ def test_annotate_tier_monthly_active_subscription_downgrade_last_of_month(custo
         'status': 'Current',
         'rate': '9999.10',
         'frequency': 'monthly',
-        'link_limit': 9999
+        'link_limit': 9999,
+        'paid_through': next_month
     }
     for customer in customers:
         tier = {

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -17,7 +17,7 @@ from perma.models import (
     most_active_org_in_time_period,
     subscription_is_active
 )
-from perma.utils import pp_date_from_post, tz_datetime, first_day_of_next_month, today_next_year, years_ago_today
+from perma.utils import pp_date_from_post, tz_datetime, first_day_of_next_month, today_next_month, today_next_year, years_ago_today
 
 from conftest import GENESIS
 import pytest
@@ -527,7 +527,7 @@ def test_annotate_tier_monthly_no_subscription_first_of_month(customers):
 
 def test_annotate_tier_monthly_no_subscription_mid_month(customers):
     now = GENESIS.replace(day=16)
-    next_month = first_day_of_next_month(now)
+    next_month = today_next_month(now)
     next_year = today_next_year(now)
     subscription = None
     for customer in customers:
@@ -539,8 +539,8 @@ def test_annotate_tier_monthly_no_subscription_mid_month(customers):
         customer.annotate_tier(tier, subscription, now, next_month, next_year)
         assert tier['type'] == 'upgrade'
         assert tier['link_limit_effective_timestamp'] == now.timestamp()
-        assert Decimal(tier['todays_charge']) == (customer.base_rate * tier['rate_ratio'] / 31 * 16).quantize(Decimal('.01'))
-        assert tier['recurring_amount'] != tier['todays_charge']
+        assert Decimal(tier['todays_charge']) == (customer.base_rate * tier['rate_ratio']).quantize(Decimal('.01'))
+        assert tier['recurring_amount'] == tier['todays_charge']
         assert tier['next_payment'] == next_month
 
 
@@ -549,7 +549,7 @@ def test_annotate_tier_monthly_no_subscription_last_of_month(is_active, customer
     is_active.return_value = True
 
     now = GENESIS.replace(day=31)
-    next_month = first_day_of_next_month(now)
+    next_month = today_next_month(now)
     next_year = today_next_year(now)
     subscription = None
     for customer in customers:
@@ -561,8 +561,8 @@ def test_annotate_tier_monthly_no_subscription_last_of_month(is_active, customer
         customer.annotate_tier(tier, subscription, now, next_month, next_year)
         assert tier['type'] == 'upgrade'
         assert tier['link_limit_effective_timestamp'] == now.timestamp()
-        assert Decimal(tier['todays_charge']) == (customer.base_rate * tier['rate_ratio'] / 31).quantize(Decimal('.01'))
-        assert tier['recurring_amount'] != tier['todays_charge']
+        assert Decimal(tier['todays_charge']) == (customer.base_rate * tier['rate_ratio']).quantize(Decimal('.01'))
+        assert tier['recurring_amount'] == tier['todays_charge']
         assert tier['next_payment'] == next_month
 
 

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -293,12 +293,14 @@ def get_client_ip(request):
 def tz_datetime(*args, **kwargs):
     return timezone.make_aware(datetime(*args, **kwargs))
 
-
 def first_day_of_next_month(now):
     # use first of month instead of today to avoid issues w/ variable length months
     first_of_month = now.replace(day=1)
     return first_of_month + relativedelta(months=1)
 
+def today_next_month(now):
+    # relativedelta handles leap years: 2/29 -> 2/28
+    return now + relativedelta(months=1)
 
 def today_next_year(now):
     # relativedelta handles leap years: 2/29 -> 2/28


### PR DESCRIPTION
Until now, we have always set new monthly subscriptions to start on the 1st of the month, charging a one-time prorated fee on initial setup for the days remaining in the current month.

We plan to switch that: full price on the day you sign up, and then your next payment in a month, whichever day that falls on.

This PR takes care of the Perma side of that switch: it cannot be deployed until [Perma Payments is adjusted ](https://github.com/harvard-lil/perma-payments/blob/997d5914be26c76be07d594eeccaa2df6a53cd0f/web/perma_payments/models.py#L224C1-L227C68)to handle that change.

I configured my local dev setup to communicate with the Cybersource test tier to click the button in Perma and watch a new monthly subscription get correctly created.

I was charged $10 today on the 13th, correctly.
<img width="1394" height="850" alt="image" src="https://github.com/user-attachments/assets/e5d9e91f-df64-4d65-98eb-595aaa1674b4" />
<img width="1512" height="912" alt="image" src="https://github.com/user-attachments/assets/5f8c0c69-2bac-41ae-88d0-52bfb10d579a" />

A new subscription was created, with a "start" date of June 13th, with a scheduled payment on the correct date.
<img width="1512" height="912" alt="image" src="https://github.com/user-attachments/assets/02032897-8c48-4b0d-b5fa-6fec4c6bd9db" />
<img width="1512" height="912" alt="image" src="https://github.com/user-attachments/assets/a379833d-b243-4e7a-bc97-e39f6b95e401" />

I'll keep the PR in draft mode until the corresponding Perma Payments change has been deployed: https://github.com/harvard-lil/perma-payments/pull/194


