### PR TITLE
Don't show prorating text, when not prorated.

### DIFF
--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -33,10 +33,12 @@
                         </span>
                         <br>
                         ${{ tier.required_fields.recurring_amount | intcomma }}/month
-                        <br>
-                        <br>
-                        ${{ tier.required_fields.amount | intcomma }}
-                        this month (prorated)
+                        {% if tier.required_fields.recurring_amount != tier.required_fields.amount %}
+                          <br>
+                          <br>
+                          ${{ tier.required_fields.amount | intcomma }}
+                          this month (prorated)
+                        {% endif %}
                       </button>
                     {% elif tier.period == 'annually' %}
                       <button>


### PR DESCRIPTION
I somehow failed to commit a change intended to ship with https://github.com/harvard-lil/perma/pull/3774/changes: I didn't commit my changes to the template file, so you see 
<img width="1880" height="832" alt="image" src="https://github.com/user-attachments/assets/f6115539-fbe9-4715-acc8-2d17e6e70872" />

instead of 

<img width="940" height="416" alt="image" src="https://github.com/user-attachments/assets/5cc4e7d4-5104-4fa2-8154-1db06bf687d9" />

Whoops!

This PR fixes that oversight.