### PR TITLE
Admin stats page efficiency

### DIFF
--- a/perma_web/perma/templates/admin-stats.html
+++ b/perma_web/perma/templates/admin-stats.html
@@ -19,6 +19,9 @@
 
       <div class="tab-pane active" id="celery_data">
         <h3 class="body-ah">Celery queues</h3>
+        <button type="button" id="toggle-queues-auto-refresh">Start Auto-Refresh (every 2s)</button>
+        <br>
+        <hr>
         <div id="celery_queues">Loading...</div>
 
         <h3 class="body-ah">Celery task data</h3>

--- a/perma_web/static/js/admin-stats.js
+++ b/perma_web/static/js/admin-stats.js
@@ -17,21 +17,61 @@ function fillSection(name, callback){
   });
 }
 
-fillSection("capture_errors");
-fillSection("celery_queues");
-fillSection("celery");
-fillSection("rate_limits");
-fillSection("job_queue");
-fillSection("days");
-fillSection("random");
-fillSection("emails");
+// Start an auto-refresh timer that only fetches while the data is actually
+// being looked at: skip when the browser tab is hidden, or when the section's
+// sub-tab is not the visible one. The interval keeps running so the refresh
+// resumes automatically when the section becomes visible again.
+function autoRefresh(fn, ms, sectionId){
+  return setInterval(function(){
+    if (document.hidden) return;
+    if (!sectionVisible(sectionId)) return;
+    fn();
+  }, ms);
+}
 
-// Refresh the celery queue job counts automatically
-setInterval(function(){ fillSection("celery_queues")}, 2000);
+function sectionVisible(sectionId){
+  let pane = document.getElementById(sectionId).closest('.tab-pane');
+  return Boolean(pane && pane.classList.contains('active'));
+}
 
-// Start refreshing the list of celery works and the jobs they are processing on button press
+// Each tab's sections are loaded lazily, the first time the tab is opened
+// (see the bottom of this file), rather than all at once on page load.
+const tabSections = {
+  '#celery_data': ['celery_queues', 'celery'],
+  '#rate-limits-pane': ['rate_limits'],
+  '#capture-job-pane': ['job_queue'],
+  '#capture-error-pane': ['capture_errors'],
+  '#days-pane': ['days'],
+  '#random-pane': ['random'],
+  '#emails-pane': ['emails'],
+};
+const loadedTabs = new Set();
+function loadTab(hash){
+  if (loadedTabs.has(hash) || !tabSections[hash]) return;
+  loadedTabs.add(hash);
+  tabSections[hash].forEach(name => fillSection(name));
+}
+
+// Refresh the celery queue job counts on button press.
+// Loaded once on page load above; auto-refresh is opt-in to avoid constant polling.
+function refresh_celery_queues(){
+  return autoRefresh(function(){ fillSection("celery_queues")}, 2000, "celery_queues");
+}
+let celery_queues_refresh = null;
+document.getElementById('toggle-queues-auto-refresh').addEventListener('click', (e) => {
+  if (celery_queues_refresh){
+    clearInterval(celery_queues_refresh);
+    celery_queues_refresh = null;
+    e.target.innerText = 'Start Auto-Refresh (every 2s)';
+  } else {
+    celery_queues_refresh = refresh_celery_queues();
+    e.target.innerText = 'Stop Auto-Refresh';
+  }
+})
+
+// Start refreshing the list of celery workers and the jobs they are processing on button press
 function refresh_celery_jobs(){
-  return setInterval(function(){ fillSection("celery")}, 2000);
+  return autoRefresh(function(){ fillSection("celery")}, 2000, "celery");
 }
 let celery_tasks_refresh = null;
 document.getElementById('toggle-tasks-auto-refresh').addEventListener('click', (e) => {
@@ -56,7 +96,7 @@ function refresh_rate_limits(){
   });
 }
 function auto_refresh_rate_limits(){
-  return setInterval(function(){ refresh_rate_limits()}, 15000);
+  return autoRefresh(function(){ refresh_rate_limits()}, 15000, "rate_limits");
 }
 document.getElementById('refresh-rate-limits').addEventListener('click', (e) => {
   refresh_rate_limits()
@@ -77,7 +117,7 @@ document.getElementById('auto-refresh-rate-limits').addEventListener('click', (e
 
 // Start refreshing the list of capture jobs on button press
 function refresh_capture_jobs(){
-  return setInterval(function(){ fillSection("job_queue")}, 2000);
+  return autoRefresh(function(){ fillSection("job_queue")}, 2000, "job_queue");
 }
 let capture_jobs_refresh = null;
 document.getElementById('toggle-capture-jobs-auto-refresh').addEventListener('click', (e) => {
@@ -103,7 +143,7 @@ function refresh_capture_errors(){
   });
 }
 function auto_refresh_capture_errors(){
-  return setInterval(function(){ refresh_capture_errors()}, 15000);
+  return autoRefresh(function(){ refresh_capture_errors()}, 15000, "capture_errors");
 }
 document.getElementById('refresh-capture-errors').addEventListener('click', (e) => {
   refresh_capture_errors()
@@ -123,6 +163,12 @@ document.getElementById('auto-refresh-capture-errors').addEventListener('click',
 
 
 
+// Load a tab's sections when it is opened.
+document.querySelector('.nav-tabs').addEventListener('click', (e) => {
+  window.location.hash = e.target.hash;
+  loadTab(e.target.hash);
+})
+
 // Select the tab specified in the hash, if present on page load
 if (window.location.hash) {
     let tabNav = document.querySelector(`a[href="${window.location.hash}"]`);
@@ -130,6 +176,6 @@ if (window.location.hash) {
       tabNav.click();
     }
 }
-document.querySelector('.nav-tabs').addEventListener('click', (e) => {
-  window.location.hash = e.target.hash;
-})
+
+// Load the initially-visible tab's sections (the hash tab if valid, else the default).
+loadTab(tabSections[window.location.hash] ? window.location.hash : '#celery_data');


### PR DESCRIPTION
The admin stats page polls /manage/stats/celery_queues every 2 seconds, which adds up to a real amount of traffic in the logs. For efficiency:

- Add start/stop buttons for celery queues to match the other stats sub-tabs
- Lazy load sub-tabs, so no data is loaded for unused tabs
- Disable polling when document is not visible to user (document.hidden)
- Disable polling when sub-tab not selected (so if you click the start button and switch sub-tabs, that tab doesn't poll until you switch back)

This way it not only doesn't start automatically, but if you do start and then move away, it and other sub-tabs don't keep pointlessly going in the background.

This PR is AI coded and not tested by me. In my defense: I discussed this with Becky and it sounds like this contribution is useful; it's a low risk staff-only page, easy to apply (if you have Perma up and running locally) and check if it works. Feel free to take it over, or if it's wrong in some complicated way, reject without looking too hard.