### PR TITLE
Add capture_queue_health invoke task for use by salt

### DIFF
--- a/perma_web/tasks/dev.py
+++ b/perma_web/tasks/dev.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from invoke import task
 import json
 import os
@@ -10,9 +10,10 @@ from tqdm import tqdm
 
 from django.conf import settings
 from django.http import HttpRequest
+from django.utils import timezone
 
 from perma.email import send_user_email, send_self_email, registrar_users, registrar_users_plus_stats
-from perma.models import Link, LinkUser, Registrar
+from perma.models import Link, LinkUser, Registrar, CaptureJob
 
 import logging
 logger = logging.getLogger(__name__)
@@ -91,6 +92,58 @@ def count_links_without_cached_playback_status(ctx):
     """
     count = Link.objects.permanent().filter(cached_can_play_back__isnull=True).count()
     print(count)
+
+
+@task
+def capture_queue_health(ctx, quiet=False, window=50, max_uncompleted=25, stuck_minutes=20, max_stuck=25):
+    """
+    Report on whether captures are completing, flagging two conditions:
+
+      1. Of the most recently created {window} links, how many still have a
+         capture (other than a user upload) in the 'pending' state. This is the
+         original status.perma.cc/monitor heuristic -- a snapshot of whether
+         recent captures are succeeding right now -- and fires when more than
+         {max_uncompleted} of them are unfinished. This can happen the moment 50
+         links are submitted, even in a healthy queue.
+      2. How many CaptureJobs are old enough to have finished but are still
+         pending/in_progress: fires when
+         more than {max_stuck} jobs have been unfinished for over
+         {stuck_minutes} minutes.
+
+    Report if *either* condition is exceeded.
+    With --quiet (for cron/alerting) print nothing unless something is wrong;
+    otherwise print both numbers for a human.
+    """
+    # 1. Recent-window pending snapshot (original /monitor heuristic).
+    recent_link_ids = list(
+        Link.objects.order_by('-creation_timestamp')
+        .values_list('pk', flat=True)[:window]
+    )
+    uncompleted = Link.objects.filter(
+        pk__in=recent_link_ids,
+        captures__status='pending',
+        captures__user_upload=False,
+    ).distinct().count()
+
+    # 2. Stuck jobs: too old to still be unfinished. Age comes from
+    # Link.creation_timestamp (write-once); CaptureJob.creation_timestamp is
+    # auto_now and so tracks last save, not submission.
+    cutoff = timezone.now() - timedelta(minutes=stuck_minutes)
+    stuck = CaptureJob.objects.filter(
+        status__in=['pending', 'in_progress'],
+        link__creation_timestamp__lt=cutoff,
+    ).count()
+
+    problems = []
+    if uncompleted > max_uncompleted:
+        problems.append(f"{uncompleted} uncompleted captures in the most recent {window}")
+    if stuck > max_stuck:
+        problems.append(f"{stuck} captures unfinished for over {stuck_minutes} minutes")
+
+    if problems:
+        print("; ".join(problems))
+    elif not quiet:
+        print(f"OK: {uncompleted} uncompleted in last {window}, {stuck} unfinished over {stuck_minutes} min")
 
 
 @task


### PR DESCRIPTION
This adds an `invoke dev.capture-queue-health` command that checks if more than 25 of the last 50 capture jobs are uncompleted, or if 25 jobs have been stuck for more than 20 minutes. This is primarily for use by an automatic salt check, so with --quiet it only prints if one of those conditions applies. You can also run it manually without --quiet to see the counts.

* The first check is approximately the same as what status.perma.cc/monitor used to decide to print "PROBLEM_PENDING". It's a little more correct because that check was limited to info available through the public API endpoint.
* The second check might be a way to have fewer false positives: it won't trigger if 50 links happen to be dropped into the queue and processed right when this checks, only if jobs are sticking around longer than we want. This check wasn't possible with the /monitor approach. I'm not sure what the right values are for `max_stuck` and `stuck_minutes` though, so it's a fallback mode for now.

This is first of a 3-part PR series. Once it ships, we can update the salt crontab to use it, and then update status.perma.cc to drop the old route.