### PR TITLE
Update Kyle's contact info

### DIFF
--- a/perma_web/perma/templates/copyright_policy.html
+++ b/perma_web/perma/templates/copyright_policy.html
@@ -26,12 +26,12 @@
       <p class="body-text">Perma.cc’s designated agent for notice for claims of copyright infringement is Kyle K. Courtney, who can be reached as follows:</p>
 
       <ul>
-        <li>By mail: 1 Harvard Yard, Widener G-20, Cambridge, MA 02138</li>
-        <li>By phone: 617 495-1494</li>
-        <li>By email: kyle_courtney(@)harvard.edu</li>
+        <li>By mail: John Adams Courthouse, One Pemberton Square, Suite 4100, Boston, MA 02108</li>
+        <li>By phone: 617 226-1500</li>
+        <li>By email: kcourtney(@)socialaw.com</li>
       </ul>
 
-      <p class="body-text">Note: the above contact information is provided exclusively for notifying Perma.cc that your copyrighted material may have been infringed. All other inquiries, (e.g., requests for technical assistance or customer service, reports of email abuse, and piracy reports), will not receive a response through this process and should be directed to the appropriate entity via email or by phone</p>
+      <p class="body-text">Note: the above contact information is provided exclusively for notifying Perma.cc that your copyrighted material may have been infringed. All other inquiries, (e.g., requests for technical assistance or customer service, reports of email abuse, and piracy reports), will not receive a response through this process and should be directed to the appropriate entity via email or by phone.</p>
 
       <p class="body-text">This Copyright Policy was last updated September 23, 2013</p>
     </div><!--span-->


### PR DESCRIPTION
Edit to https://perma.cc/copyright-policy to update Kyle Courtney's contact information since his move to the Social Law Library.