### PR TITLE
remove blog and twitter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Perma.cc helps authors and journals create permanent archived citations in their
 ## Connect with Perma.cc
 
 - Use Perma.cc at [Perma.cc](https://perma.cc)
-- Twitter [@permacc](https://twitter.com/permacc)
 - Email us at [info@perma.cc](mailto:info@perma.cc)
 
 ## Installation

--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -93,8 +93,6 @@
                     <li class="footer-nav-item"><a href="{{ base_url }}{% url 'docs' %}">Guide</a></li>
                     <li class="footer-nav-item"><a href="{{ base_url }}{% url 'dev_docs' %}">Developers</a></li>
                     <li class="footer-nav-item"><a href="{{ base_url }}{% url 'contact' %}">Contact</a></li>
-                    <li class="footer-nav-item"><a href="https://blogs.law.harvard.edu/perma/">Blog</a></li>
-                    <li class="footer-nav-item"><a href="https://twitter.com/permacc">Twitter</a></li>
                     <li class="footer-nav-item"><a href="https://github.com/harvard-lil/perma">GitHub</a></li>
                     <li class="footer-nav-item"><a href="https://status.perma.cc/">Status</a></li>
                   </ul>

--- a/perma_web/perma/templates/includes/upper_right_menu.html
+++ b/perma_web/perma/templates/includes/upper_right_menu.html
@@ -78,7 +78,6 @@
     {% else %}
       <li><a href="{{ base_url }}{% url 'about' %}" class="navbar-link">About Perma.cc</a></li>
       <li><a href="{{ base_url }}{% url 'docs' %}" class="navbar-link">Guide</a></li>
-      <li><a href="https://blogs.law.harvard.edu/perma/" class="navbar-link">Blog</a></li>
       <li><a href="{{ base_url }}{% url 'sign_up' %}" class="btn _nav{% if this_page == 'sign_up' %} this-page{% endif %}">Sign up</a></li>
       <li><a href="{{ base_url }}{% url 'user_management_limited_login' %}" class="navbar-link _login">Log in</a></li>
     {% endif %}


### PR DESCRIPTION
This PR removes the Twitter and blog links from the footer and the blog link from the anonymous user view header. 