### PR TITLE
add user name to contact and report emails

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -724,7 +724,7 @@ class ReportForm(forms.Form):
             'Copyright Infringement',
             'Other'
         ]],
-        label = 'Reason for Reporting'
+        label = 'Reason for reporting'
     )
     source = forms.CharField(
         label="How did you discover this Perma Link?",

--- a/perma_web/perma/templates/email/admin/contact.txt
+++ b/perma_web/perma/templates/email/admin/contact.txt
@@ -9,6 +9,7 @@ Message from user
 {% endblock%}{% block footer %}
 ----
 Troubleshooting Info:
+
 {% if request.user.is_authenticated %}User name: {{ request.user.first_name }} {{ request.user.last_name }}
 {% endif %}User email: {{ from_address }}
 Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}

--- a/perma_web/perma/templates/email/admin/contact.txt
+++ b/perma_web/perma/templates/email/admin/contact.txt
@@ -9,7 +9,8 @@ Message from user
 {% endblock%}{% block footer %}
 ----
 Troubleshooting Info:
-User email: {{ from_address }}
+{% if request.user.is_authenticated %}User name: {{ request.user.first_name }} {{ request.user.last_name }}
+{% endif %}User email: {{ from_address }}
 Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}
 Affiliations: {{ affiliation_string | default:"(none)" }}
 Referring Page: {{ referer }}

--- a/perma_web/perma/templates/email/admin/contact.txt
+++ b/perma_web/perma/templates/email/admin/contact.txt
@@ -1,20 +1,21 @@
 {% block content %}
-This is a message from the Perma.cc contact form, http://perma.cc/contact
+This is a message from the Perma.cc contact form: {{ request.scheme|add:"://"|add:request.get_host }}{% url 'contact' %}
 
 
 
 Message from user
---------
+-----------------
 {{ message }}
 {% endblock%}{% block footer %}
-----
-Troubleshooting Info:
 
+Troubleshooting info
+--------------------
 {% if request.user.is_authenticated %}User name: {{ request.user.first_name }} {{ request.user.last_name }}
+User admin: {{ request.scheme|add:"://"|add:request.get_host }}{% url 'admin:perma_linkuser_change' request.user.id %}
 {% endif %}User email: {{ from_address }}
-Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}
-Affiliations: {{ affiliation_string | default:"(none)" }}
-Referring Page: {{ referer }}
-User agent: {{ request.META.HTTP_USER_AGENT | default:"(unknown)"}}
+Logged in: {{ request.user.is_authenticated | yesno:"Yes,No" }}
+Affiliations: {{ affiliation_string | default:"None" }}
+Referring page: {{ referer | default:"Unknown" }}
+User agent: {{ request.META.HTTP_USER_AGENT | default:"Unknown" }}
 {% endblock footer %}
 

--- a/perma_web/perma/templates/email/admin/report.txt
+++ b/perma_web/perma/templates/email/admin/report.txt
@@ -14,7 +14,8 @@ How did you discover this Perma Link?
 {% endblock%}{% block footer %}
 ----
 Troubleshooting Info:
-User email: {{ from_address }}
+{% if request.user.is_authenticated %}User name: {{ request.user.first_name }} {{ request.user.last_name }}
+{% endif %}User email: {{ from_address }}
 Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}
 Affiliations: {{ affiliation_string | default:"(none)" }}
 Referring Page: {{ referer }}

--- a/perma_web/perma/templates/email/admin/report.txt
+++ b/perma_web/perma/templates/email/admin/report.txt
@@ -14,6 +14,7 @@ How did you discover this Perma Link?
 {% endblock%}{% block footer %}
 ----
 Troubleshooting Info:
+
 {% if request.user.is_authenticated %}User name: {{ request.user.first_name }} {{ request.user.last_name }}
 {% endif %}User email: {{ from_address }}
 Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}

--- a/perma_web/perma/templates/email/admin/report.txt
+++ b/perma_web/perma/templates/email/admin/report.txt
@@ -4,7 +4,7 @@ A user has reported that {{ guid }} contains inappropriate material.
 {{ request.scheme|add:"://"|add:request.get_host }}{% url 'admin:perma_link_changelist' %}?guid={{ guid | urlencode }}
 
 
-Reason for Reporting
+Reason for reporting
 --------------------
 {{ reason }}
 
@@ -12,14 +12,15 @@ How did you discover this Perma Link?
 -------------------------------------
 {{ source}}
 {% endblock%}{% block footer %}
-----
-Troubleshooting Info:
 
+Troubleshooting info
+--------------------
 {% if request.user.is_authenticated %}User name: {{ request.user.first_name }} {{ request.user.last_name }}
+User admin: {{ request.scheme|add:"://"|add:request.get_host }}{% url 'admin:perma_linkuser_change' request.user.id %}
 {% endif %}User email: {{ from_address }}
-Logged in: {{ request.user.is_authenticated | yesno:"true,false" }}
-Affiliations: {{ affiliation_string | default:"(none)" }}
-Referring Page: {{ referer }}
-User agent: {{ request.META.HTTP_USER_AGENT | default:"(unknown)"}}
+Logged in: {{ request.user.is_authenticated | yesno:"Yes,No" }}
+Affiliations: {{ affiliation_string | default:"None" }}
+Referring page: {{ referer | default:"None" }}
+User agent: {{ request.META.HTTP_USER_AGENT | default:"Unknown" }}
 {% endblock footer %}
 

--- a/perma_web/perma/tests/test_views_contact.py
+++ b/perma_web/perma/tests/test_views_contact.py
@@ -237,9 +237,9 @@ def test_contact_standard_submit_required(client, email_details):
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert email_details["message_text"] in message.body
-    assert "Referring Page: " + email_details["referring_page"] in message.body
-    assert "Affiliations: (none)" in message.body
-    assert "Logged in: false" in message.body
+    assert "Referring page: " + email_details["referring_page"] in message.body
+    assert "Affiliations: None" in message.body
+    assert "Logged in: No" in message.body
     assert message.subject.startswith(email_details["subject_prefix"] + email_details["custom_subject"])
     assert message.from_email == email_details["our_address"]
     assert message.recipients() == [email_details["our_address"]]
@@ -279,9 +279,9 @@ def test_contact_standard_submit_no_optional(client, email_details):
     len(mail.outbox) == 1
     message = mail.outbox[0]
     assert email_details["message_text"] in message.body
-    assert "Referring Page: " in message.body
-    assert "Affiliations: (none)" in message.body
-    assert "Logged in: false" in message.body
+    assert "Referring page: " in message.body
+    assert "Affiliations: None" in message.body
+    assert "Logged in: No" in message.body
     assert message.subject.startswith(email_details["subject_prefix"] + 'New message from Perma contact form')
     assert message.from_email, email_details["our_address"]
     assert message.recipients() == [email_details["our_address"]]
@@ -328,7 +328,8 @@ def test_contact_org_user_submit(client, multi_registrar_org_user, email_details
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert email_details["message_text"] in message.body
-    assert "Logged in: true" in message.body
+    assert f"https://testserver{reverse('admin:perma_linkuser_change', args=(multi_registrar_org_user.id,))}" in message.body
+    assert "Logged in: Yes" in message.body
     assert message.from_email == email_details["our_address"]
     assert message.to == [user.email for user in registrar_users]
     assert message.cc == [email_details["our_address"], email_details["from_email"]]
@@ -352,7 +353,7 @@ def test_contact_org_user_affiliation_string(client, multi_registrar_org_user, e
     message = mail.outbox[0]
     for org in multi_registrar_org_user.organizations.all():
         assert f"{org.name} ({org.registrar.name})" in message.body
-    assert "Logged in: true" in message.body
+    assert "Logged in: Yes" in message.body
 
 
 @override_settings(REQUIRE_JS_FORM_SUBMISSIONS=False)
@@ -370,7 +371,7 @@ def test_contact_reg_user_affiliation_string(client, registrar_user, email_detai
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert f"Affiliations: {registrar_user.registrar.name} (Registrar)" in message.body
-    assert "Logged in: true" in message.body
+    assert "Logged in: Yes" in message.body
 
 
 @override_settings(REQUIRE_JS_FORM_SUBMISSIONS=False)
@@ -390,7 +391,7 @@ def test_contact_sponsored_user_affiliation_string(client, sponsored_user, email
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert f"Affiliations: {registrar.name}" in message.body
-    assert "Logged in: true" in message.body
+    assert "Logged in: Yes" in message.body
 
 
 #
@@ -473,7 +474,7 @@ def test_report_post_with_basic_fields(client):
     assert 'Somewhere online' in message.body
     assert 'me@me.com' in message.body
     assert 'some-string-that-could-be-a-guid' in message.body
-    assert "Logged in: false" in message.body
+    assert "Logged in: No" in message.body
 
 
 @override_settings(REQUIRE_JS_FORM_SUBMISSIONS=False)

--- a/perma_web/perma/tests/test_views_contact.py
+++ b/perma_web/perma/tests/test_views_contact.py
@@ -240,6 +240,8 @@ def test_contact_standard_submit_required(client, email_details):
     assert "Referring page: " + email_details["referring_page"] in message.body
     assert "Affiliations: None" in message.body
     assert "Logged in: No" in message.body
+    assert "User name:" not in message.body
+    assert "User admin:" not in message.body
     assert message.subject.startswith(email_details["subject_prefix"] + email_details["custom_subject"])
     assert message.from_email == email_details["our_address"]
     assert message.recipients() == [email_details["our_address"]]
@@ -282,6 +284,8 @@ def test_contact_standard_submit_no_optional(client, email_details):
     assert "Referring page: " in message.body
     assert "Affiliations: None" in message.body
     assert "Logged in: No" in message.body
+    assert "User name:" not in message.body
+    assert "User admin:" not in message.body
     assert message.subject.startswith(email_details["subject_prefix"] + 'New message from Perma contact form')
     assert message.from_email, email_details["our_address"]
     assert message.recipients() == [email_details["our_address"]]
@@ -328,6 +332,7 @@ def test_contact_org_user_submit(client, multi_registrar_org_user, email_details
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert email_details["message_text"] in message.body
+    assert f"User name: {multi_registrar_org_user.first_name} {multi_registrar_org_user.last_name}" in message.body
     assert f"https://testserver{reverse('admin:perma_linkuser_change', args=(multi_registrar_org_user.id,))}" in message.body
     assert "Logged in: Yes" in message.body
     assert message.from_email == email_details["our_address"]
@@ -353,6 +358,8 @@ def test_contact_org_user_affiliation_string(client, multi_registrar_org_user, e
     message = mail.outbox[0]
     for org in multi_registrar_org_user.organizations.all():
         assert f"{org.name} ({org.registrar.name})" in message.body
+    assert "User name:" in message.body
+    assert "User admin:" in message.body
     assert "Logged in: Yes" in message.body
 
 
@@ -371,6 +378,8 @@ def test_contact_reg_user_affiliation_string(client, registrar_user, email_detai
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert f"Affiliations: {registrar_user.registrar.name} (Registrar)" in message.body
+    assert f"User name: {registrar_user.first_name} {registrar_user.last_name}" in message.body
+    assert f"https://testserver{reverse('admin:perma_linkuser_change', args=(registrar_user.id,))}" in message.body
     assert "Logged in: Yes" in message.body
 
 
@@ -391,6 +400,8 @@ def test_contact_sponsored_user_affiliation_string(client, sponsored_user, email
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
     assert f"Affiliations: {registrar.name}" in message.body
+    assert f"User name: {sponsored_user.first_name} {sponsored_user.last_name}" in message.body
+    assert f"https://testserver{reverse('admin:perma_linkuser_change', args=(sponsored_user.id,))}" in message.body
     assert "Logged in: Yes" in message.body
 
 
@@ -475,6 +486,8 @@ def test_report_post_with_basic_fields(client):
     assert 'me@me.com' in message.body
     assert 'some-string-that-could-be-a-guid' in message.body
     assert "Logged in: No" in message.body
+    assert "User name:" not in message.body
+    assert "User admin:" not in message.body
 
 
 @override_settings(REQUIRE_JS_FORM_SUBMISSIONS=False)


### PR DESCRIPTION
This PR 

- adds the authenticated user's first and last names, and admin user change URL to the troubleshooting info section of the contact and report form emails
- makes a few minor style/copy changes in the same views