### PR TITLE
add payment system upgrade banner

### DIFF
--- a/perma_web/perma/models/user.py
+++ b/perma_web/perma/models/user.py
@@ -409,6 +409,19 @@ class LinkUser(CustomerModel, AbstractBaseUser, PermissionsMixin):
         """
         return not self.nonpaying or (self.is_registrar_user() and not self.registrar.nonpaying)
 
+    ### banner visibility ###
+    
+    def should_see_payment_system_upgrade_banner(self):
+        """
+            Should the user see the temporary "Payment System Upgrade Period" banner?
+            Shown to paid registrar users and paid individual users whose subscription status is 'Current' or 'Hold'.
+        """
+        subscription_statuses = ['Current', 'Hold']
+        if self.is_registrar_user() and not self.registrar.nonpaying:
+            return self.registrar.cached_subscription_status in subscription_statuses
+        if self.is_individual() and not self.nonpaying:
+            return self.cached_subscription_status in subscription_statuses
+        return False
 
     ### merging accounts ###
 

--- a/perma_web/perma/templates/base-responsive.html
+++ b/perma_web/perma/templates/base-responsive.html
@@ -38,6 +38,7 @@
   </head>
   <body class="{% block bodyFlags %}{% endblock bodyFlags %}">
     {% block modals %}{% endblock modals %}
+    {% block top_banner %}{% endblock top_banner %}
     <div id="after-modals">
       <a href="#main-skip-target" class="skip-link">Skip to main content</a>
       <a href="#footer-skip-target" class="skip-link">Skip to footer</a>

--- a/perma_web/perma/templates/includes/top_banner.html
+++ b/perma_web/perma/templates/includes/top_banner.html
@@ -1,0 +1,4 @@
+<div class="top-banner">
+  <p class="top-banner-title">Payment System Upgrade Period: July 31st, 2026 through August 7th, 2026.</p>
+  <p>Payment, billing, and cancellation services may be limited during this time. We apologize for any inconvenience and appreciate your patience as we improve the payment experience. Reach out to <a href="mailto:{{ DEFAULT_FROM_EMAIL }}" target="_blank">{{ DEFAULT_FROM_EMAIL }}</a> if you have any questions. </p>
+</div>

--- a/perma_web/perma/templates/includes/top_banner.html
+++ b/perma_web/perma/templates/includes/top_banner.html
@@ -1,4 +1,4 @@
 <div class="top-banner">
-  <p class="top-banner-title">Payment System Upgrade Period: July 31st, 2026 through August 7th, 2026.</p>
-  <p>Payment, billing, and cancellation services may be limited during this time. We apologize for any inconvenience and appreciate your patience as we improve the payment experience. Reach out to <a href="mailto:{{ DEFAULT_FROM_EMAIL }}" target="_blank">{{ DEFAULT_FROM_EMAIL }}</a> if you have any questions. </p>
+  <p class="top-banner-title">Payment System Upgrade Period: July 27th, 2026 through July 31st, 2026.</p>
+  <p>Payment, billing, and cancellation services may be limited during this time. We apologize for any inconvenience and appreciate your patience as we improve the payment experience. <a href="{% if request.user.is_registrar_user %}https://mailchi.mp/perma.cc/permacc-scheduled-payment-system-upgrade-july-27-july-31{% else %}https://mailchi.mp/perma.cc/permacc-scheduled-payment-system-upgrade-july-27-july-5860029{% endif %}" target="_blank">View more details</a>, and reach out to <a href="mailto:{{ DEFAULT_FROM_EMAIL }}" target="_blank">{{ DEFAULT_FROM_EMAIL }}</a> if you have any questions.</p>
 </div>

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -1,4 +1,9 @@
 {% extends "settings-layout.html" %}
+{% block top_banner %}
+  {% if request.user.is_authenticated and request.user.should_see_payment_system_upgrade_banner %}
+    {% include "includes/top_banner.html" %}
+  {% endif %}
+{% endblock top_banner %}
 {% load humanize %}
 {% block title %} | Settings{% endblock %}
 {% block dashboardContent %}

--- a/perma_web/perma/templates/user_management/create-link.html
+++ b/perma_web/perma/templates/user_management/create-link.html
@@ -9,9 +9,15 @@
   {% render_bundle 'dashboard' 'css' %}
 {% endblock %}
 
+{% block top_banner %}
+  {% if request.user.is_authenticated and request.user.should_see_payment_system_upgrade_banner %}
+    {% include "includes/top_banner.html" %}
+  {% endif %}
+{% endblock top_banner %}
+
 {% block mainContent %}
 
- <!-- vue app -->
+<!-- vue app -->
 <div id="vue-app"></div>
 
 {% endblock %}

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -1617,3 +1617,38 @@ def test_move_subfolder_with_bonus_links_to_org_folder(complex_user_with_bonus_l
     # the link should no longer be a bonus link
     bonus_link.refresh_from_db()
     assert not bonus_link.bonus_link
+
+
+#
+# should_see_payment_system_upgrade_banner
+#
+
+SUBSCRIPTION_STATUSES = [
+    ('Current', True),
+    ('Hold', True),
+    ('Canceled', False),
+    ('Cancellation Requested', False),
+    (None, False),
+]
+
+@pytest.mark.parametrize("status,expected", SUBSCRIPTION_STATUSES)
+def test_paid_individual_sees_banner_for_current_and_hold(paying_user_factory, status, expected):
+    user = paying_user_factory(cached_subscription_status=status)
+    assert user.should_see_payment_system_upgrade_banner() is expected
+
+def test_nonpaying_individual_does_not_see_banner(nonpaying_user_factory):
+    user = nonpaying_user_factory(cached_subscription_status='Current')
+    assert user.should_see_payment_system_upgrade_banner() is False
+
+@pytest.mark.parametrize("status,expected", SUBSCRIPTION_STATUSES)
+def test_paid_registrar_user_sees_banner_for_current_and_hold(paying_registrar_user_factory, status, expected):
+    user = paying_registrar_user_factory()
+    user.registrar.cached_subscription_status = status
+    user.registrar.save()
+    assert user.should_see_payment_system_upgrade_banner() is expected
+
+def test_registrar_user_from_nonpaying_registrar_does_not_see_banner(registrar_user_factory):
+    user = registrar_user_factory()
+    user.registrar.cached_subscription_status = 'Current'
+    user.registrar.save()
+    assert user.should_see_payment_system_upgrade_banner() is False

--- a/perma_web/static/css/_vars-global.scss
+++ b/perma_web/static/css/_vars-global.scss
@@ -50,6 +50,8 @@ $color-orange: #DD671A;
 $color-green: #77AE3A;
 $color-khaki: #F6F8F1;
 
+$color-banner-background: #bcd3f9;
+
 $color-black: #222;
 $color-trans-black: rgba(0,0,0,.95);
 $color-trans-darkgray: rgba(0,0,0,.5);
@@ -92,6 +94,7 @@ $size-xlarge: 40px;
 $size-large: 24px;
 $size-xbody: 1.222222rem;
 $size-body: 17px;
+$size-medium: 14px;
 $size-small: 12px;
 
 /////////////////////////

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -6138,3 +6138,21 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
   50% { transform: scale(1.2); }
   100% { transform: scale(1); }
 }
+
+/* Banner styles */
+.top-banner {
+  background-color: $color-banner-background;
+  padding: 10px 15px;
+  text-align: center;
+  font-family: $font-hed;
+
+  p {
+    max-width: inherit;
+    font-size: $size-medium;
+  }
+
+  .top-banner-title {
+    font-weight: 700;
+    font-size: $size-body;
+  }
+}

--- a/perma_web/static/css/style-responsive.scss
+++ b/perma_web/static/css/style-responsive.scss
@@ -6142,7 +6142,7 @@ Example: calc(4rem / 16) is equal to 4px or 0.25rem */
 /* Banner styles */
 .top-banner {
   background-color: $color-banner-background;
-  padding: 10px 15px;
+  padding: 12px;
   text-align: center;
   font-family: $font-hed;
 


### PR DESCRIPTION
This PR adds a banner to the dashboard and usage-plan page announcing the payment system upgrade. 

Copy/dates to be updated before merging.

<img width="1725" height="860" alt="image" src="https://github.com/user-attachments/assets/b16d4c00-58f4-4165-9e29-bd314c17a43e" />