### PR TITLE
Fix links term for monthly subscriptions

### DIFF
--- a/perma_web/perma/admin.py
+++ b/perma_web/perma/admin.py
@@ -581,7 +581,7 @@ class LinkUserAdmin(UserAdmin):
         ('Personal info', {'fields': ('first_name', 'last_name', 'email', 'raw_email', 'notes')}),
         (None, {'fields': ('password',)}),
         ('Permissions', {'fields': ('is_active', 'is_staff', 'is_confirmed', 'registrar', 'groups')}),
-        ('Tier', {'fields': ('nonpaying', 'base_rate', 'cached_subscription_started', 'cached_subscription_status', 'cached_subscription_rate', 'unlimited', 'link_limit', 'link_limit_period', 'in_trial', 'bonus_links')}),
+        ('Tier', {'fields': ('nonpaying', 'base_rate', 'cached_subscription_started', 'cached_subscription_status', 'cached_subscription_rate', 'cached_paid_through', 'unlimited', 'link_limit', 'link_limit_period', 'in_trial', 'bonus_links')}),
         ('Important dates', {'fields': ('last_login', 'date_joined')}),
     )
     add_fieldsets = (
@@ -591,7 +591,7 @@ class LinkUserAdmin(UserAdmin):
         }),
     )
     raw_id_fields = ['registrar']
-    list_display = ('email', 'first_name', 'last_name', 'is_staff', 'is_active', 'is_confirmed', 'in_trial', 'unlimited', 'nonpaying','cached_subscription_status', 'cached_subscription_started', 'cached_subscription_rate', 'base_rate', 'bonus_links', 'date_joined', 'last_login', 'link_count', 'registrar')
+    list_display = ('email', 'first_name', 'last_name', 'is_staff', 'is_active', 'is_confirmed', 'in_trial', 'unlimited', 'nonpaying','cached_subscription_status', 'cached_subscription_started', 'cached_paid_through', 'cached_subscription_rate', 'base_rate', 'bonus_links', 'date_joined', 'last_login', 'link_count', 'registrar')
     search_fields = ('first_name', 'last_name', 'email')
     list_filter = ('is_staff', 'is_active', 'in_trial', 'unlimited', 'nonpaying', 'cached_subscription_status', RegistrarUserFilter, OrgUserFilter, OrgUserForRegistrarFilter)
     ordering = ('-id',)

--- a/perma_web/perma/models/user.py
+++ b/perma_web/perma/models/user.py
@@ -368,20 +368,21 @@ class LinkUser(CustomerModel, AbstractBaseUser, PermissionsMixin):
             else:
                 link_count = personal_links.filter(created_by_id=self.id, organization_id=None).count()
         elif period == 'monthly':
-            # MONTHLY RECURRING: links this calendar month (or, for new customers, links this month from the moment you started paying us)
-            if self.cached_subscription_started and \
-               self.cached_subscription_started.year == today.year and \
-               self.cached_subscription_started.month == today.month:
-                link_count = personal_links.filter(creation_timestamp__range=(self.cached_subscription_started, today), created_by_id=self.id, organization_id=None).count()
+            # MONTHLY RECURRING
+            if self.cached_paid_through:
+                # if you have a paid subscription, calculate via its expiry date
+                link_count = personal_links.filter(creation_timestamp__range=(self.cached_paid_through - relativedelta(months=1), today), created_by_id=self.id, organization_id=None).count()
             else:
+                # else, check the links created this calendar month
                 link_count = personal_links.filter(creation_timestamp__year=today.year, creation_timestamp__month__gte=today.month, created_by_id=self.id, organization_id=None).count()
         elif period == 'annually':
             # ANNUAL RECURRING
-            # if you have a paid subscription, calculate via its expiry date
             if self.cached_paid_through:
+                # if you have a paid subscription, calculate via its expiry date
                 link_count = personal_links.filter(creation_timestamp__range=(self.cached_paid_through - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
-            # else, check the last 365 days
-            link_count = personal_links.filter(creation_timestamp__range=(today - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
+            else:
+                # else, check the last 365 days
+                link_count = personal_links.filter(creation_timestamp__range=(today - relativedelta(years=1), today), created_by_id=self.id, organization_id=None).count()
         else:
             raise NotImplementedError("User's link_limit_period not yet handled.")
         return max(limit - link_count, 0)

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from dateutil.relativedelta import relativedelta
 from decimal import Decimal
 from django.conf import settings
 from django.test import override_settings
@@ -281,7 +282,7 @@ def test_monthly_link_limit_with_midmonth_subscription1(mocked_timezone, user_wi
     mocked_timezone.now.return_value = fifteenth_of_month
 
     u = user_with_links_this_month_before_the_15th
-    u.cached_subscription_started = fifteenth_of_month
+    u.cached_paid_through = fifteenth_of_month + relativedelta(months=1)
     u.save()
 
     assert not u.unlimited
@@ -297,7 +298,7 @@ def test_monthly_link_limit_with_midmonth_subscription2(mocked_timezone, user_wi
     mocked_timezone.now.return_value = fifteenth_of_month
 
     u = user_with_links_this_month_before_the_15th
-    u.cached_subscription_started = fifth_of_month
+    u.cached_paid_through = fifth_of_month + relativedelta(months=1)
     u.save()
 
     assert not u.unlimited


### PR DESCRIPTION
This PR is a followup on https://github.com/harvard-lil/perma/pull/3774

Prior to that PR, we always set new monthly subscriptions to start on the 1st of the month, charging a one-time prorated fee on initial setup for the days remaining in the current month.

We switched that: full price on the day you sign up, and then your next payment in a month, whichever day that falls on.

But, I did not think to adapt the code that checks how many links you have created: it was still checking how many links you have created since the beginning of the month. So, a person's link limit would appear to reset on the 1st of the month, regardless of when their subscription began.

This PR updates that code. If our records show you are paid through a particular date, we count however many links have been created since that date, one month prior. So like, if you are paid through July 15th, we count however many links have been created since June 15th. I included a fallback: if we don't have a `cached_paid_through` date, we'll assume the limit resets on the first of the month, like before. But, that should never happen in practice: we should always have that field available. 

I also added `cached_paid_through` to the Django admin list and detail views, for easier inspection.

<img width="1105" height="643" alt="image" src="https://github.com/user-attachments/assets/908319c0-1b01-44e6-b91b-5a811df1f02f" />
<img width="1105" height="643" alt="image" src="https://github.com/user-attachments/assets/0390fd06-c521-4309-9524-48a66d27e42e" />

