### PR TITLE
Show status message on usage plan page after payment redirects

### DIFF
--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -7,6 +7,9 @@
 {% load humanize %}
 {% block title %} | Settings{% endblock %}
 {% block dashboardContent %}
+  {% if payment_status_message %}
+    <div class="alert alert-{{ payment_status_level }} alert-block">{{ payment_status_message }}</div>
+  {% endif %}
   {% for account in accounts %}
     {% with subscription=account.subscription %}
       {% with customer=account.customer %}

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -183,6 +183,32 @@ def test_regular_user_can_see_usage_plan_page(client, link_user):
     assert response.status_code == 200
 
 
+def test_payment_success_message_shown_after_redirect(client, user_without_subscription_or_purchase_history):
+    client.force_login(user_without_subscription_or_purchase_history)
+    response = client.get(reverse('settings_usage_plan') + '?subscription=success', secure=True)
+
+    assert response.status_code == 200
+    assert b'alert-success' in response.content
+    assert b'Your subscription has been created.' in response.content
+
+
+def test_payment_canceled_message_shown_as_info_after_redirect(client, user_without_subscription_or_purchase_history):
+    client.force_login(user_without_subscription_or_purchase_history)
+    response = client.get(reverse('settings_usage_plan') + '?purchase=canceled', secure=True)
+
+    assert response.status_code == 200
+    assert b'alert-info' in response.content
+    assert b'Link purchase checkout was canceled. You were not charged.' in response.content
+
+
+def test_no_payment_message_for_unrecognized_params(client, user_without_subscription_or_purchase_history):
+    client.force_login(user_without_subscription_or_purchase_history)
+    response = client.get(reverse('settings_usage_plan') + '?subscription=bogus&foo=success', secure=True)
+
+    assert response.status_code == 200
+    assert b'alert-block' not in response.content
+
+
 def test_no_purchase_history_section_if_no_one_time_purchases(client, user_without_subscription_or_purchase_history):
     user = user_without_subscription_or_purchase_history
 

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -137,6 +137,26 @@ def settings_tools(request):
 def settings_usage_plan(request):
     accounts = []
     purchase_history = {}
+    # Messages for redirects back from the payments app after Stripe checkout,
+    # e.g. settings/usage-plan/?subscription=success
+    payment_redirect_messages = {
+        ('subscription', 'success'): ('success', 'Your subscription has been created.'),
+        ('subscription', 'canceled'): ('info', 'Subscription checkout was canceled. You were not charged.'),
+        ('purchase', 'success'): ('success', 'Your link purchase succeeded.'),
+        ('purchase', 'canceled'): ('info', 'Link purchase checkout was canceled. You were not charged.'),
+        ('change', 'success'): ('success', (
+            'Your subscription change was submitted. Upgrades may be billed immediately; '
+            'downgrades take effect at the end of the current billing period.'
+        )),
+        ('update', 'success'): ('success', 'Your payment information was updated.'),
+    }
+    payment_status_level = payment_status_message = None
+    for param in ('subscription', 'purchase', 'change', 'update'):
+        match = payment_redirect_messages.get((param, request.GET.get(param)))
+        if match:
+            payment_status_level, payment_status_message = match
+            break
+
     try:
         if request.user.is_registrar_user() and not request.user.registrar.nonpaying:
             accounts.append(request.user.registrar.get_subscription_info(timezone.now()))
@@ -157,8 +177,9 @@ def settings_usage_plan(request):
         'update_url': reverse('settings_subscription_update'),
         'accounts': accounts,
         'purchase_history': purchase_history,
-        'bonus_packages': request.user.get_bonus_packages()
-
+        'bonus_packages': request.user.get_bonus_packages(),
+        'payment_status_level': payment_status_level,
+        'payment_status_message': payment_status_message,
     }
     return render(request, 'settings/settings-usage-plan.html', context)
 


### PR DESCRIPTION
I think without this when you do something like edit a subscription, it just dumps you back on the plans page without confirming what changed -- does that sound right?