### PR TITLE
Allow self-serve cancellation through Stripe page

### DIFF
--- a/perma_web/perma/templates/settings/settings-subscription-update.html
+++ b/perma_web/perma/templates/settings/settings-subscription-update.html
@@ -12,6 +12,10 @@
       {% endif %}
     </h2>
 
+    {% if customer_type == 'Registrar' %}
+      <p class="page-dek">Please contact <a href="mailto:info@perma.cc">info@perma.cc</a> to make changes to your current subscription.</p>
+    {% endif %}
+
     {% if account.can_change_tiers %}
       <h3 class="body-bh">Change Plan</h3>
 
@@ -86,11 +90,12 @@
       {% endif %}
     {% endif %}
 
-    <h3 class="body-bh">Update Credit Card Information</h3>
+    <h3 class="body-bh">Manage Payment and Billing</h3>
+    <p class="page-dek">Update payment information, view invoices and receipts, or cancel your subscription via Stripe's secure customer portal.</p>
     <form method="post" action="{{ update_url }}">
       <input type="hidden" name="encrypted_data" value={{ update_encrypted_data }}>
       <button class="btn btn-primary" type="submit">
-        Update Credit Card Information
+        Manage Payment and Billing
       </button>
     </form>
 

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -93,7 +93,7 @@
                   Your subscription is <span class="blue-text">on hold</span> due to a problem with your credit card.
                 </p>
                 <p class="page-dek">
-                  You can update payment information by clicking the "Modify Subscription" button below. If you need
+                  You can update payment information by clicking the "Manage Subscription and Billing" button below. If you need
                   assistance or believe this message is in error, please <a href="{% url 'contact' %}?subject=Subscription%20On%20Hold">contact us</a>.
                 </p>
               {% else %}
@@ -218,14 +218,7 @@
                     <form method="post" action="{{ update_url }}">
                       {% csrf_token %}
                       <input type="hidden" name="account_type" value={{ customer_type }}>
-                      <button class="btn btn-primary" type="submit">Modify Subscription</button>
-                    </form>
-                  </div>
-                  <div class="col-xs-12 col-md-6">
-                    <form method="post" action="{{ cancel_confirm_url }}">
-                      {% csrf_token %}
-                      <input type="hidden" name="account_type" value={{ customer_type }}>
-                      <button class="btn cancel" type="submit">Cancel Subscription</button>
+                      <button class="btn btn-primary" type="submit">Manage Subscription and Billing</button>
                     </form>
                   </div>
                 </div>

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -234,10 +234,10 @@ def test_update_button_cancel_button_and_subscription_info_present_if_standing_s
 
     assert b'Rate' in response.content
     assert b'Paid Through' in response.content
-    assert b'Modify Subscription' in response.content
-    assert b'Cancel Subscription' in response.content
+    assert b'Manage Subscription and Billing' in response.content
+    assert b'Cancel Subscription' not in response.content
     assert b'Your subscription is <span class="blue-text">current</span>' in response.content
-    assert response.content.count(b'<input type="hidden" name="account_type"') == 2
+    assert response.content.count(b'<input type="hidden" name="account_type"') == 1
 
 
 def test_help_present_if_subscription_on_hold(client, user_with_on_hold_subscription):
@@ -338,7 +338,7 @@ def test_update_page_if_standing_subscription(model_prepped, view_prepped, clien
     # Should be able to up/downgrade to all monthly individual tiers, except the current tier
     available_tiers = len([tier for tier in settings.TIERS['Individual'] if tier['period'] == 'monthly']) - 1
 
-    assert b'Update Credit Card Information' in response.content
+    assert b'Manage Payment and Billing' in response.content
     assert response.content.count(b'<input type="hidden" name="encrypted_data"') == 1
     assert b'Change Plan' in response.content
     assert b'Cancel Scheduled Downgrade' not in response.content
@@ -361,7 +361,7 @@ def test_update_page_if_downgrade_scheduled(model_prepped, view_prepped, client,
         data={'account_type':'Individual'}
     )
 
-    assert b'Update Credit Card Information' in response.content
+    assert b'Manage Payment and Billing' in response.content
     assert b'Cancel Scheduled Downgrade' in response.content
     assert response.content.count(b'<input type="hidden" name="encrypted_data"') == 2
     assert b'<input required type="radio" name="encrypted_data"' not in response.content
@@ -381,7 +381,7 @@ def test_update_page_if_subscription_on_hold(prepped, client, user_with_on_hold_
         data={'account_type':'Individual'}
     )
 
-    assert b'Update Credit Card Information' in response.content
+    assert b'Manage Payment and Billing' in response.content
     assert response.content.count(b'<input type="hidden" name="encrypted_data"') == 1
     assert response.content.count(prepped.return_value) == 1
     assert b'Change Plan' not in response.content
@@ -399,7 +399,7 @@ def test_update_page_if_cancellation_requested(prepped, client, user_with_reques
         data={'account_type':'Individual'}
     )
 
-    assert b'Update Credit Card Information' in response.content
+    assert b'Manage Payment and Billing' in response.content
     assert response.content.count(b'<input type="hidden" name="encrypted_data"') == 1
     assert response.content.count(prepped.return_value) == 1
     assert b'Change Plan' not in response.content
@@ -479,9 +479,9 @@ def test_paying_registrar_user_sees_subscriptions_independently(prepped, client,
 
     assert b'Rate' in response.content
     assert b'Paid Through' in response.content
-    assert b'Modify Subscription' in response.content
-    assert response.content.count(b'<input type="hidden" name="account_type"') == 2
-    assert b'Cancel Subscription' in response.content
+    assert b'Manage Subscription and Billing' in response.content
+    assert response.content.count(b'<input type="hidden" name="account_type"') == 1
+    assert b'Cancel Subscription' not in response.content
 
 
 @patch('perma.views.user_settings.prep_for_perma_payments', autospec=True)
@@ -549,6 +549,8 @@ def test_paying_registrar_user_institutional_update_form(client, registrar_user_
 
     assert user.registrar.name.encode() in response.content
     assert b'Personal' not in response.content
+    assert b'Please contact' in response.content
+    assert b'info@perma.cc' in response.content
 
 
 #


### PR DESCRIPTION
Per [LIL-5354: Funnel all payment and billing operations Stripe-side rather than Perma-side in Usage Plan page](https://linear.app/harvard-lil/issue/LIL-5354/funnel-all-payment-and-billing-operations-stripe-side-rather-than) --

**Usage Plan page**
- Removed the "Cancel Subscription" button and its form entirely.
- Renamed the blue "Modify Subscription" button to **"Manage Subscription and Billing"**.
- Updated the on-hold help text that referenced the old button name to match.

**Subscription update page** (`settings-subscription-update.html`):
- Renamed the "Update Credit Card Information" heading and button to **"Manage Payment and Billing"**.
- Added the descriptive line under the heading: *"Update payment information, view invoices and receipts, or cancel your subscription via Stripe's secure customer portal."*
- For registrars only, added under the "Modify ___'s Subscription" heading: *"Please contact info@perma.cc to make changes to your current subscription."*

Update tests to match.