### PR TITLE
Catch `ImproperlyConfigured`

### DIFF
--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -5,6 +5,7 @@ import logging
 
 import requests
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction
 from django.db.models import Count
 from django.utils import timezone
@@ -194,7 +195,7 @@ class CustomerModel(models.Model):
                 }
             )
             assert r.ok, r.status_code
-        except (requests.RequestException, AssertionError) as e:
+        except (requests.RequestException, AssertionError, ImproperlyConfigured) as e:
             msg = f"Communication with Perma-Payments failed: {e}"
             if settings.PERMA_PAYMENTS_IN_MAINTENANCE:
                 logger.info(msg)
@@ -239,7 +240,7 @@ class CustomerModel(models.Model):
                 }
             )
             assert r.ok, r.status_code
-        except (requests.RequestException, AssertionError) as e:
+        except (requests.RequestException, AssertionError, ImproperlyConfigured) as e:
             msg = f"Communication with Perma-Payments failed: {e}"
             if settings.PERMA_PAYMENTS_IN_MAINTENANCE:
                 logger.info(msg)
@@ -497,7 +498,7 @@ class CustomerModel(models.Model):
                             }
                         )
                         assert r.ok, r.status_code
-                    except (requests.RequestException, AssertionError) as e:
+                    except (requests.RequestException, AssertionError, ImproperlyConfigured) as e:
                         msg = f"Communication with Perma-Payments failed: {str(e)}"
                         if settings.PERMA_PAYMENTS_IN_MAINTENANCE:
                             logger.info(msg)


### PR DESCRIPTION
To date, when Perma has encountered any difficulty interacting with Perma Payments, it has fallen back to cached stored values, and logged an error.

https://github.com/harvard-lil/perma/pull/3794 added a new failure mechanism: `ImproperlyConfigured` is raised if we try to talk to Stripe before the app is configured for it. 

This PR follows up with consistent error-handling: Perma users won't see 500s, but the error logs will be flooded with notifications that we engineers have made an error.