### PR TITLE
fix wrong purchase date bug

### DIFF
--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -302,7 +302,7 @@
         <dl class="dl-horizontal">
           {% for purchase in purchase_history.purchases %}
             <dt>
-              {{ purchase.date | date:"F n, Y" }}:
+              {{ purchase.date | date:"F j, Y" }}:
             </dt>
             <dd>
               {{ purchase.reference_number }}


### PR DESCRIPTION
This PR fixes the bug that was displaying the purchase date of the personal links incorrectly. The fix is to replace the month of the year parameter with the day of the month parameter. 