### PR TITLE
Fix/guard null link limit effective timestamp

### DIFF
--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -284,7 +284,12 @@ class CustomerModel(models.Model):
         self.cached_paid_through = pp_date_from_post(post_data['subscription']['paid_through'])
 
         pending_change = None
-        if subscription_change_effective <= timezone.now():
+        # Perma Payments should always supply an effective timestamp, but the
+        # field is nullable there, so a missing value would raise on the
+        # comparison below (None <= datetime). Treat a missing timestamp as
+        # already applied: show the returned tier as current with no pending
+        # change, rather than 500 the usage-plan page.
+        if subscription_change_effective is None or subscription_change_effective <= timezone.now():
             self.link_limit_period = post_data['subscription']['frequency']
             self.cached_subscription_rate = Decimal(post_data['subscription']['rate'])
             if post_data['subscription']['link_limit'] == 'unlimited':

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -129,7 +129,7 @@
               <div class="row">
                 {% if subscription.pending_change %}
                   <div class="col-xs-12">
-                    <h3 class="body-ch">Through {{ subscription.paid_through | date:"F jS, Y" }}</h3>
+                    <h3 class="body-ch">Current plan (through {{ subscription.paid_through | date:"F jS, Y" }})</h3>
                     <dl class="dl-horizontal">
                       {% if subscription.frequency == 'monthly' %}
                         <dt>
@@ -162,7 +162,7 @@
                         </dd>
                       {% endif %}
                     </dl>
-                    <h3 class="body-ch">Beginning {{ subscription.pending_change.effective | date:"F jS, Y" }}</h3>
+                    <h3 class="body-ch">Scheduled change (effective {{ subscription.pending_change.effective | date:"F jS, Y" }})</h3>
                     <dl class="dl-horizontal">
                       {% if subscription.frequency == 'monthly' %}
                         <dt>

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -201,6 +201,22 @@ def test_get_subscription_happy_path_with_pending_change(post, process, paying_u
         assert credited.call_count == 0
 
 
+@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.base.requests.post', autospec=True)
+def test_get_subscription_null_effective_timestamp_treated_as_applied(post, process, paying_user, spoof_pp_response_subscription):
+    # A null link_limit_effective_timestamp (e.g. a legacy Perma Payments row)
+    # must not crash the usage-plan read on the None <= now comparison; it is
+    # treated as already applied, with no pending change.
+    post.return_value.status_code = 200
+    customer = paying_user
+    response = spoof_pp_response_subscription(customer)
+    response['subscription']['link_limit_effective_timestamp'] = None
+    process.return_value = response
+    subscription = customer.get_subscription()
+    assert subscription['pending_change'] is None
+    assert subscription['status'] == response['subscription']['status']
+
+
 #
 # Link limits and bonus links
 #


### PR DESCRIPTION
Two small perma-side changes for the "scheduled downgrade isn't shown in perma" bug, paired with the perma-payments-stripe change that now reports the pending change.

- Template: the pending-downgrade section showed "Through <date>" and "Beginning <date>" with the same date (a Stripe downgrade takes effect at period end, which is also paid-through). Reworded to "Current plan (through <date>)" and "Scheduled change (effective <date>)" so it reads sensibly.
- Guard: `get_subscription` no longer does `None <= now`. If perma-payments ever sends a null effective timestamp, it's treated as already applied instead of 500-ing the usage-plan page. This is just a safety net, since the payments side should always supply it.