### PR TITLE
Show Manage Subscription and Billing button on canceled subs

### DIFF
--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -133,6 +133,17 @@
                 {% endif %}
                 until {{ subscription.paid_through | date:"F jS, Y" }}.
               </p>
+              {% if use_stripe_payments_app %}
+                <div class="row subscription-buttons">
+                  <div class="col-xs-12 col-md-6">
+                    <form method="post" action="{{ update_url }}">
+                      {% csrf_token %}
+                      <input type="hidden" name="account_type" value={{ customer_type }}>
+                      <button class="btn btn-primary" type="submit">Manage Subscription and Billing</button>
+                    </form>
+                  </div>
+                </div>
+              {% endif %}
             {% else %}
               {% if subscription.status == 'Hold' %}
                 <p class="page-dek">


### PR DESCRIPTION
See LIL-5356

When a subscription reports Canceled, the Usage Plan page dropped the "Manage Subscription and Billing" button, since that button only lived in the current/hold branch of the template. This adds the same portal button to the canceled state.

Pairs with the perma-payments-stripe fix that reports cancellations to perma (LIL-5360).

<img width="2814" height="900" alt="image" src="https://github.com/user-attachments/assets/cc102eb1-7f57-4e5d-9756-ed7e1ce689cf" />
