### PR TITLE
Spell "cancelled" on the usage-plan cancellation message (LIL-5356)

### DIFF
--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -123,7 +123,7 @@
               {% endif %}
             {% elif subscription.status == 'Canceled' %}
               <p class="page-dek">
-                Your paid subscription has been <span class="blue-text">canceled</span>. You will not be charged
+                Your paid subscription has been <span class="blue-text">cancelled</span>. You will not be charged
                 again.
               </p>
               <p class="page-dek">


### PR DESCRIPTION
switch the cancellation message to the British "cancelled" spelling.