### PR TITLE
Reword subscription change message

### DIFF
--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -150,8 +150,8 @@ def settings_usage_plan(request):
             ('purchase', 'success'): ('success', 'Your link purchase succeeded.'),
             ('purchase', 'canceled'): ('info', 'Link purchase checkout was canceled. You were not charged.'),
             ('change', 'success'): ('success', (
-                'Your subscription change was submitted. Upgrades may be billed immediately; '
-                'downgrades take effect at the end of the current billing period.'
+                'Your subscription change was submitted. Upgrades are billed immediately; '
+                'downgrades take effect at the end of your current billing period.'
             )),
             ('update', 'success'): ('success', 'Your payment information was updated.'),
         }


### PR DESCRIPTION
See LIL-5421.

Updates the "subscription change submitted" message on the Usage Plan page so that:

- "Upgrades may be billed immediately" becomes "Upgrades are billed immediately" 

- "the current billing period" becomes "your current billing period."

<img width="1860" height="348" alt="image" src="https://github.com/user-attachments/assets/f78a21d3-2f6f-4afa-bfb5-5b8ebd6b910a" />
