### PR TITLE
Use neutral wording for the portal-return banner

### DIFF
--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -153,7 +153,11 @@ def settings_usage_plan(request):
                 'Your subscription change was submitted. Upgrades may be billed immediately; '
                 'downgrades take effect at the end of the current billing period.'
             )),
-            ('update', 'success'): ('success', 'Your payment information was updated.'),
+            # Neutral wording: the Stripe portal returns here for any action it
+            # allows (payment-method update, invoice view, or cancellation), and
+            # the return does not tell us which. "Updated" is honest for all of
+            # them; the accurate canceled state, if any, shows below this banner.
+            ('update', 'success'): ('success', 'Your subscription settings have been updated.'),
         }
         for param in ('subscription', 'purchase', 'change', 'update'):
             match = payment_redirect_messages.get((param, request.GET.get(param)))


### PR DESCRIPTION
See LIL-5415.

A cancel done in the Stripe portal returned to the Usage Plan page showing "Your payment information was updated," because the portal sends every action (card update,  invoice view, cancel) back to the same URL and doesn't tell us which one happened.

Since we can't tell them apart, this changes the banner to neutral wording: "Your subscription settings have been updated." That's honest for all three portal actions, and the accurate cancellation notice already shows below it (from the LIL-5360 fix). 

<img width="1796" height="288" alt="image" src="https://github.com/user-attachments/assets/ff366694-20d8-408f-a539-8b8d568cd36f" />
