### PR TITLE
Send the registrar org name to Perma Payments

### DIFF
--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import logging
 
 import requests
+import waffle
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction
@@ -188,6 +189,23 @@ class CustomerModel(models.Model):
     @cached_property
     def customer_type(self):
         return CUSTOMER_TYPE_MAP[type(self).__name__]
+
+    def payments_customer_name(self):
+        """
+        The name to send to the payments service, so Stripe invoices and
+        receipts show it under "Bill to" instead of an internal customer
+        description (LIL-5399).
+
+        Registrars only: an organization name is not personal data, while an
+        individual's name is, and the payments service deliberately holds no
+        individual PII. Individuals supply a name themselves at Stripe Checkout.
+        Sent only on the Stripe path; the Cybersource payload is unchanged.
+        """
+        if not waffle.switch_is_active('use_stripe_payments_app'):
+            return None
+        if self.customer_type != 'Registrar':
+            return None
+        return (getattr(self, 'name', '') or '').strip() or None
 
     @sensitive_variables()
     def get_purchase_history(self):
@@ -438,6 +456,7 @@ class CustomerModel(models.Model):
         next_month = today_next_month(now)
         next_year = today_next_year(now)
         subscription = self.get_subscription()
+        customer_name = self.payments_customer_name()
 
         tiers = []
         if subscription and subscription.get('pending_change'):
@@ -478,6 +497,8 @@ class CustomerModel(models.Model):
                     'link_limit': tier['link_limit'],
                     'link_limit_effective_timestamp': tier['link_limit_effective_timestamp']
                 }
+                if customer_name:
+                    required_fields['customer_name'] = customer_name
                 tiers.append({
                     'type': tier['type'],
                     'period': tier['period'],
@@ -533,6 +554,7 @@ class CustomerModel(models.Model):
 
     def get_bonus_packages(self):
         bonus_packages = []
+        customer_name = self.payments_customer_name()
         for package in settings.BONUS_PACKAGES:
             required_fields = {
                 'timestamp': datetime.utcnow().timestamp(),
@@ -541,6 +563,8 @@ class CustomerModel(models.Model):
                 'amount': package['price'],
                 'link_quantity': package['link_quantity']
             }
+            if customer_name:
+                required_fields['customer_name'] = customer_name
             bonus_packages.append({
                 'amount': required_fields['amount'],
                 'link_quantity': required_fields['link_quantity'],

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -22,6 +22,7 @@ from perma.utils import pp_date_from_post, tz_datetime, first_day_of_next_month,
 
 from conftest import GENESIS
 import pytest
+from waffle.testutils import override_switch
 
 
 #
@@ -479,6 +480,31 @@ def test_user_link_creation_disallowed_if_subscription_active_and_under_limit(ge
 
 #
 # Link limit / subscription related tests for registrars
+#
+
+#
+# The name sent to Perma Payments for Stripe's "Bill to" (LIL-5399)
+#
+
+@override_switch('use_stripe_payments_app', active=True)
+def test_payments_customer_name_is_the_registrar_org_name(paying_registrar):
+    assert paying_registrar.payments_customer_name() == paying_registrar.name
+
+
+@override_switch('use_stripe_payments_app', active=True)
+def test_payments_customer_name_is_none_for_individuals(paying_user):
+    # An individual's name is personal data; they supply one themselves at
+    # Stripe Checkout instead, so perma never sends it.
+    assert paying_user.payments_customer_name() is None
+
+
+@override_switch('use_stripe_payments_app', active=False)
+def test_payments_customer_name_is_none_on_the_cybersource_path(paying_registrar):
+    assert paying_registrar.payments_customer_name() is None
+
+
+#
+# Link limit / subscription related tests for registrars (continued)
 #
 
 @patch('perma.models.Registrar.get_subscription', autospec=True)


### PR DESCRIPTION
(LIL-5399)

Stripe invoices and receipts showed an internal description ("Perma.cc Registrar 47") under "Bill to" instead of the customer's name. The payments side now sets the Stripe customer's name, but it needs perma to send one. This is that half.

Registrars only: an organization name isn't personal data, while an individual's is, and the payments service deliberately holds no individual PII (individuals type a name themselves at Stripe Checkout). Only sent when the `use_stripe_payments_app` switch is on, so the Cybersource payload is unchanged.

Pairs with perma-payments PR. Until that one merges, this just adds an unused field.