### PR TITLE
update form labels and fields

### DIFF
--- a/perma_web/perma/forms.py
+++ b/perma_web/perma/forms.py
@@ -170,13 +170,13 @@ class ApproveRegistrarForm(ModelForm):
 
 
 class FirmUsageForm(Form):
-    estimated_number_of_accounts = forms.ChoiceField(
+    estimated_number_of_seats = forms.ChoiceField(
         choices=[(option, option) for option in ['1 - 10', '10 - 50', '50 - 100', '100+']],
-        label='Number of individual accounts',
+        label='Number of seats',
     )
     estimated_perma_links_per_month = forms.ChoiceField(
-        choices=[(option, option) for option in ['< 10', '10 - 50', '50 - 100', '100+']],
-        label='Number of Perma Links created each month (per user)',
+        choices=[(option, option) for option in ['< 100', '101 - 500', '500+']],
+        label='Number of new Perma Links created each month (across all users)',
     )
 
 ### ORGANIZATION FORMS ###

--- a/perma_web/perma/templates/email/admin/firm_request.txt
+++ b/perma_web/perma/templates/email/admin/firm_request.txt
@@ -4,8 +4,8 @@ Registrar name: {{ registrar.name }}
 Registrar email: {{ registrar.email }}
 Registrar website: {{ registrar.website }}
 
-Estimated number of individual accounts: {{ usage_form.cleaned_data.estimated_number_of_accounts }}
-Estimated number of Perma Links created each month (per user): {{ usage_form.cleaned_data.estimated_perma_links_per_month }}
+Estimated number of seats: {{ usage_form.cleaned_data.estimated_number_of_seats }}
+Estimated number of new Perma Links created each month (across all users): {{ usage_form.cleaned_data.estimated_perma_links_per_month }}
 
 User name: {{ user_name }}
 User email: {{ user_email }}

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -1800,8 +1800,8 @@ class UserManagementViewsTestCase(PermaTestCase):
 
     def create_firm_usage_form(self):
         return {
-            'estimated_number_of_accounts': '10 - 50',
-            'estimated_perma_links_per_month': '100+',
+            'estimated_number_of_seats': '10 - 50',
+            'estimated_perma_links_per_month': '101 - 500',
         }
 
     def create_firm_user_form(self):
@@ -1938,7 +1938,7 @@ class UserManagementViewsTestCase(PermaTestCase):
         error_keys = [
             'email',
             'website',
-            'estimated_number_of_accounts',
+            'estimated_number_of_seats',
             'estimated_perma_links_per_month',
             'name',
             'registrar_user_candidate',


### PR DESCRIPTION
This PR updates the labels and the field options on the `sign-up/orgs` estimated usage information form. 