### PR TITLE
Replace the Purchase History list with a Stripe billing portal button

### DIFF
--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -5,7 +5,6 @@ import logging
 import waffle
 
 import requests
-import waffle
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -341,14 +341,9 @@
       {% if use_stripe_payments_app %}
         <hr>
         <h3 class="body-ch">Additional Links</h3>
-        <dl class="dl-horizontal">
-          <dt>
-            Additional Links Remaining
-          </dt>
-          <dd>
-            {{ request.user.bonus_links|default:0 }} Links
-          </dd>
-        </dl>
+        {# Not a dl-horizontal: its term column is a fixed 160px and clips #}
+        {# "Additional Links Remaining" to an ellipsis. #}
+        <p class="page-dek">Additional Links Remaining: {{ request.user.bonus_links|default:0 }} Links</p>
         {% if billing_portal_url %}
           {# Posts straight to the payments app, like the purchase buttons above, #}
           {# so receipts are one click away rather than two. #}

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -338,7 +338,30 @@
       {% else %}
         <p class="page-dek">New purchases are temporarily unavailable. If you are working on a time-sensitive project and need to make a one-time purchase of additional links, please <a href="{% url 'contact' %}?subject=Time%20Sensitive%20New%20Project%20Inquiry">contact us</a> so we can assist you directly.</p>
       {% endif %}
-      {% if purchase_history.purchases %}
+      {% if use_stripe_payments_app %}
+        <hr>
+        <h3 class="body-ch">Additional Links</h3>
+        <dl class="dl-horizontal">
+          <dt>
+            Additional Links Remaining
+          </dt>
+          <dd>
+            {{ request.user.bonus_links|default:0 }} Links
+          </dd>
+        </dl>
+        {% if billing_portal_url %}
+          {# Posts straight to the payments app, like the purchase buttons above, #}
+          {# so receipts are one click away rather than two. #}
+          <div class="row subscription-buttons">
+            <div class="col-xs-12 col-md-6">
+              <form method="post" action="{{ billing_portal_url }}">
+                <input type="hidden" name="encrypted_data" value="{{ billing_encrypted_data }}">
+                <button class="btn btn-primary" type="submit">Billing and Purchase History</button>
+              </form>
+            </div>
+          </div>
+        {% endif %}
+      {% elif purchase_history.purchases %}
         <hr>
         <h3 class="body-ch">Purchase History</h3>
         <dl class="dl-horizontal">

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.test import override_settings
 
 from perma.exceptions import PermaPaymentsCommunicationException
+from perma.models import LinkUser
 
 from conftest import submit_form
 from unittest.mock import patch, sentinel
@@ -337,6 +338,43 @@ def test_stripe_mode_shows_subscribe_and_purchase_forms(prepped, client, user_wi
     assert b'Get More Personal Links' in response.content
     assert response.content.count(b'<form class="purchase-form') == bonus_package_count
     assert response.content.count(b'<form class="upgrade-form') == individual_tier_count
+
+
+@override_switch('use_stripe_payments_app', active=True)
+@override_settings(STRIPE_PAYMENTS_APP_EXTERNAL_URL=STRIPE_APP_URL)
+def test_stripe_mode_replaces_purchase_history_with_portal_button(client, user_without_subscription_or_purchase_history):
+    user = user_without_subscription_or_purchase_history
+    user.bonus_links = 7
+    user.save()
+
+    client.force_login(user)
+    response = client.get(reverse('settings_usage_plan'), secure=True)
+
+    assert response.status_code == 200
+    assert b'Additional Links Remaining' in response.content
+    assert b'7 Links' in response.content
+    assert b'Billing and Purchase History' in response.content
+    assert b'Purchase History</h3>' not in response.content
+    assert f'{STRIPE_APP_URL}/billing/' in form_actions(response.content)
+    # Every form on the page posts somewhere: a missing billing_portal_url must
+    # never render as a form that posts back to the usage plan page itself.
+    forms = BeautifulSoup(response.content, 'html.parser').find_all('form')
+    assert forms and all(form.get('action') for form in forms)
+    # The list is gone from the page, so fetching it would be a wasted round
+    # trip. Bonus links are still credited, off the /subscription/ payload.
+    LinkUser.get_purchase_history.assert_not_called()
+
+
+@override_switch('use_stripe_payments_app', active=False)
+def test_cybersource_mode_keeps_purchase_history_list(client, user_without_subscription_with_purchase_history):
+    client.force_login(user_without_subscription_with_purchase_history)
+    response = client.get(reverse('settings_usage_plan'), secure=True)
+
+    assert b'Purchase History' in response.content
+    assert b'13 Links' in response.content
+    assert b'January 1, 1970' in response.content
+    assert b'Additional Links Remaining' not in response.content
+    assert b'Billing and Purchase History' not in response.content
 
 
 @patch('perma.views.user_settings.prep_for_perma_payments', autospec=True)

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.test import override_settings
 
 from perma.exceptions import PermaPaymentsCommunicationException
-from perma.models import LinkUser
 
 from conftest import submit_form
 from unittest.mock import patch, sentinel
@@ -342,28 +341,26 @@ def test_stripe_mode_shows_subscribe_and_purchase_forms(prepped, client, user_wi
 
 @override_switch('use_stripe_payments_app', active=True)
 @override_settings(STRIPE_PAYMENTS_APP_EXTERNAL_URL=STRIPE_APP_URL)
-def test_stripe_mode_replaces_purchase_history_with_portal_button(client, user_without_subscription_or_purchase_history):
-    user = user_without_subscription_or_purchase_history
-    user.bonus_links = 7
-    user.save()
+def test_stripe_mode_replaces_purchase_history_with_portal_button(client, mocker, link_user, no_purchase_history):
+    mocker.patch('perma.models.LinkUser.get_subscription', autospec=True, return_value=None)
+    get_purchase_history = mocker.patch(
+        'perma.models.LinkUser.get_purchase_history', autospec=True, return_value=no_purchase_history
+    )
+    link_user.bonus_links = 7
+    link_user.save()
 
-    client.force_login(user)
+    client.force_login(link_user)
     response = client.get(reverse('settings_usage_plan'), secure=True)
 
     assert response.status_code == 200
-    # One line, whole and unsplit. A dl-horizontal was tried first and its
-    # 160px term column clipped the label to "Additional Links Rem...".
     assert b'Additional Links Remaining: 7 Links' in response.content
     assert b'Billing and Purchase History' in response.content
     assert b'Purchase History</h3>' not in response.content
     assert f'{STRIPE_APP_URL}/billing/' in form_actions(response.content)
-    # Every form on the page posts somewhere: a missing billing_portal_url must
-    # never render as a form that posts back to the usage plan page itself.
-    forms = BeautifulSoup(response.content, 'html.parser').find_all('form')
-    assert forms and all(form.get('action') for form in forms)
-    # The list is gone from the page, so fetching it would be a wasted round
-    # trip. Bonus links are still credited, off the /subscription/ payload.
-    LinkUser.get_purchase_history.assert_not_called()
+    # Under Stripe the list is not rendered, so the page must not pay for the
+    # round trip that fetches it. Bonus links are still credited, off the
+    # /subscription/ payload.
+    get_purchase_history.assert_not_called()
 
 
 @override_switch('use_stripe_payments_app', active=False)

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -351,8 +351,9 @@ def test_stripe_mode_replaces_purchase_history_with_portal_button(client, user_w
     response = client.get(reverse('settings_usage_plan'), secure=True)
 
     assert response.status_code == 200
-    assert b'Additional Links Remaining' in response.content
-    assert b'7 Links' in response.content
+    # One line, whole and unsplit. A dl-horizontal was tried first and its
+    # 160px term column clipped the label to "Additional Links Rem...".
+    assert b'Additional Links Remaining: 7 Links' in response.content
     assert b'Billing and Purchase History' in response.content
     assert b'Purchase History</h3>' not in response.content
     assert f'{STRIPE_APP_URL}/billing/' in form_actions(response.content)

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -421,6 +421,10 @@ def get_payments_app_url(route):
             urls['subscription_status'] = f"{settings.STRIPE_PAYMENTS_APP_INTERNAL_URL}/subscription/"
             urls['update'] = f"{settings.STRIPE_PAYMENTS_APP_EXTERNAL_URL}/update/"
             urls['change'] = f"{settings.STRIPE_PAYMENTS_APP_EXTERNAL_URL}/change/"
+            # Stripe-only: the customer portal has no Cybersource equivalent,
+            # so there is deliberately no entry for this route in the base
+            # dict. Callers must ask for it only when the switch is on.
+            urls['billing'] = f"{settings.STRIPE_PAYMENTS_APP_EXTERNAL_URL}/billing/"
         else:
             # Fail loud rather than silently falling back to Cybersource: if the
             # switch is on, we must never route a "Stripe" transaction to

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -143,7 +143,8 @@ def settings_usage_plan(request):
     # app issues these redirects, so we only surface the messages when it is in
     # use; on Cybersource these params never appear and are ignored.
     payment_status_level = payment_status_message = None
-    if waffle.switch_is_active('use_stripe_payments_app'):
+    use_stripe = waffle.switch_is_active('use_stripe_payments_app')
+    if use_stripe:
         payment_redirect_messages = {
             ('subscription', 'success'): ('success', 'Your subscription has been created.'),
             ('subscription', 'canceled'): ('info', 'Subscription checkout was canceled. You were not charged.'),
@@ -169,7 +170,13 @@ def settings_usage_plan(request):
             accounts.append(request.user.registrar.get_subscription_info(timezone.now()))
         if not request.user.nonpaying:
             accounts.append(request.user.get_subscription_info(timezone.now()))
-            purchase_history = request.user.get_purchase_history()
+            if not use_stripe:
+                # Under Stripe the purchase list is not rendered (history lives
+                # in the customer portal), so fetching it would be a round trip
+                # per page load for data we throw away. Bonus-link crediting is
+                # unaffected: that happens in get_subscription_info() above, off
+                # the /subscription/ payload, not this one.
+                purchase_history = request.user.get_purchase_history()
     except PermaPaymentsCommunicationException:
         context = {
             'this_page': 'settings_usage_plan',
@@ -187,10 +194,22 @@ def settings_usage_plan(request):
         'bonus_packages': request.user.get_bonus_packages(),
         'display_cybersource_freeze_message': waffle.switch_is_active('display_cybersource_freeze_message'),
         'allow_cybersource_transactions': waffle.switch_is_active('allow_cybersource_transactions'),
-        'use_stripe_payments_app': waffle.switch_is_active('use_stripe_payments_app'),
+        'use_stripe_payments_app': use_stripe,
         'payment_status_level': payment_status_level,
         'payment_status_message': payment_status_message,
     }
+
+    # The "Billing and Purchase History" button posts straight to the payments
+    # app, like the bonus package buttons do. Stripe only: Cybersource has no
+    # customer portal to send anyone to. This section is about personal links,
+    # so the customer is always the LinkUser, never their registrar.
+    if use_stripe and not request.user.nonpaying:
+        context['billing_portal_url'] = get_payments_app_url('billing')
+        context['billing_encrypted_data'] = prep_for_perma_payments({
+            'customer_pk': request.user.pk,
+            'customer_type': 'Individual',
+            'timestamp': timezone.now().timestamp(),
+        }).decode('utf-8')
 
     grandfathered = not waffle.switch_is_active('allow_cybersource_transactions') and (
         request.user.grandfathered or (


### PR DESCRIPTION
Implements LIL-5357.

The "Purchase History" section is removed entirely and replaced with an "Additional Links" section containing one line, "Additional Links Remaining: N Links", and a blue "Billing and Purchase History" button into the Stripe portal. All history, including Cybersource-era purchases, is handled by contacting us directly.

The per-page-load call to `get_purchase_history()` is dropped under Stripe. The list is no longer rendered, so fetching it was a wasted HTTP round trip, and summing it under-reported for anyone who bought via Cybersource. Bonus-link crediting is unaffected, that runs off the /subscription/ payload in `credit_for_purchased_links()`, not this one.

The form posts directly to the payments app, the same pattern the existing bonus package buttons use, so there's no new Perma view or URL and it's one click to the portal instead of the current two-step.

Depends on the /billing/ endpoint in perma-payments.

<img width="1280" height="1440" alt="image" src="https://github.com/user-attachments/assets/6a6b8327-dda7-4a34-8a34-dd008590ff20" />
