### PR TITLE
add registrar name to csv export

### DIFF
--- a/perma_web/perma/models/base.py
+++ b/perma_web/perma/models/base.py
@@ -5,7 +5,6 @@ import logging
 import waffle
 
 import requests
-import waffle
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction

--- a/perma_web/perma/tests/test_views_user_management.py
+++ b/perma_web/perma/tests/test_views_user_management.py
@@ -405,10 +405,11 @@ class UserManagementViewsTestCase(PermaTestCase):
 
     def test_sponsored_user_export_user_list(self):
         expected_results = [
-            ('another_inactive_sponsored_user@example.com', 'inactive'),
-            ('another_sponsored_user@example.com', 'active'),
-            ('inactive_sponsored_user@example.com', 'inactive'),
-            ('test_sponsored_user@example.com', 'active'),
+            ('another_inactive_sponsored_user@example.com', 'Another Library', 'inactive'),
+            ('another_sponsored_user@example.com', 'Another Library', 'active'),
+            ('another_sponsored_user@example.com', 'A Third Library', 'active'),
+            ('inactive_sponsored_user@example.com', 'Test Library', 'inactive'),
+            ('test_sponsored_user@example.com', 'Test Library', 'active'),
         ]
 
         # Get CSV export output
@@ -423,8 +424,9 @@ class UserManagementViewsTestCase(PermaTestCase):
         csv_file = StringIO(csv_response.content.decode('utf8'))
         reader = csv.DictReader(csv_file)
         for index, record in enumerate(reader):
-            expected_email, expected_sponsorship_status = expected_results[index]
+            expected_email, expected_sponsoring_registrar, expected_sponsorship_status = expected_results[index]
             self.assertEqual(record['email'], expected_email)
+            self.assertEqual(record['sponsoring_registrar'], expected_sponsoring_registrar)
             self.assertEqual(record['sponsorship_status'], expected_sponsorship_status)
         self.assertEqual(index + 1, len(expected_results))
 
@@ -439,8 +441,9 @@ class UserManagementViewsTestCase(PermaTestCase):
         # Validate JSON output against expected results
         reader = json.loads(json_response.content)
         for index, record in enumerate(reader):
-            expected_email, expected_sponsorship_status = expected_results[index]
+            expected_email, expected_sponsoring_registrar, expected_sponsorship_status = expected_results[index]
             self.assertEqual(record['email'], expected_email)
+            self.assertEqual(record['sponsoring_registrar'], expected_sponsoring_registrar)
             self.assertEqual(record['sponsorship_status'], expected_sponsorship_status)
         self.assertEqual(index + 1, len(expected_results))
 

--- a/perma_web/perma/views/user_management/views.py
+++ b/perma_web/perma/views/user_management/views.py
@@ -331,12 +331,14 @@ def manage_sponsored_user_export_user_list(request: HttpRequest) -> HttpResponse
         'last_name',
         'date_joined',
         'last_login',
+        'sponsoring_registrar',
         'sponsorship_status',
         'sponsorship_created_at',
         'sponsorship_expires_at'
     ]
     records = list_sponsored_users(request, export=True)
     users = records.annotate(
+        sponsoring_registrar=F('sponsorships__registrar__name'),
         sponsorship_status=F('sponsorships__status'),
         sponsorship_created_at=F('sponsorships__created_at'),
         sponsorship_expires_at=F('sponsorships__expires_at'),


### PR DESCRIPTION
This PR adds the sponsoring registrar's name to the `manage/sponsored-users` CSV export. 