### PR TITLE
Show links remaining in billing period

### DIFF
--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -341,12 +341,8 @@
       {% if use_stripe_payments_app %}
         <hr>
         <h3 class="body-ch">Additional Links</h3>
-        {# Not a dl-horizontal: its term column is a fixed 160px and clips #}
-        {# "Additional Links Remaining" to an ellipsis. #}
         <p class="page-dek">Additional Links Remaining: {{ request.user.bonus_links|default:0 }} Links</p>
         {% if billing_portal_url %}
-          {# Posts straight to the payments app, like the purchase buttons above, #}
-          {# so receipts are one click away rather than two. #}
           <div class="row subscription-buttons">
             <div class="col-xs-12 col-md-6">
               <form method="post" action="{{ billing_portal_url }}">

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -307,6 +307,12 @@
                   {% endif %}
                 </div>
               {% endif %}
+              {% if use_stripe_payments_app and subscription and customer_type == 'Individual' and subscription.frequency == 'monthly' %}
+                <hr>
+                <h3 class="body-ch">Remaining Links</h3>
+                {% widthratio links_remaining.0 1 -1 as negative_links_remaining %}
+                <p class="page-dek">You have created {{ customer.link_limit | add:negative_links_remaining}} of {{ customer.link_limit }} links this billing period.</p>
+              {% endif %}
             {% endwith %}
           {% endwith %}
         {% endwith %}

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -190,6 +190,7 @@ def settings_usage_plan(request):
         'cancel_confirm_url': reverse('settings_subscription_cancel'),
         'update_url': reverse('settings_subscription_update'),
         'accounts': accounts,
+        'links_remaining': request.user.get_links_remaining(),
         'purchase_history': purchase_history,
         'bonus_packages': request.user.get_bonus_packages(),
         'display_cybersource_freeze_message': waffle.switch_is_active('display_cybersource_freeze_message'),


### PR DESCRIPTION
See LIL-5474.

Once Stripe is enabled, on the Usage Plan page, show individual monthly subscribers how many of their links they have created this billing period.

<img width="2880" height="1864" alt="image" src="https://github.com/user-attachments/assets/c2f26b47-f8f2-40ad-823a-b524227942ed" />

<img width="2880" height="1864" alt="image" src="https://github.com/user-attachments/assets/b8c1658c-e492-441e-b809-109d24b5facf" />

I didn't write a test, didn't seem worth it for something so tiny.