### PR TITLE
Add a banner for the payments app's downgrade-canceled redirect

### DIFF
--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -237,6 +237,16 @@ def test_payment_success_message_shown_after_redirect(client, user_without_subsc
 
 
 @override_switch('use_stripe_payments_app', active=True)
+def test_downgrade_canceled_message_shown_after_redirect(client, user_without_subscription_or_purchase_history):
+    client.force_login(user_without_subscription_or_purchase_history)
+    response = client.get(reverse('settings_usage_plan') + '?change=canceled', secure=True)
+
+    assert response.status_code == 200
+    assert b'alert-success' in response.content
+    assert b'Your scheduled downgrade has been canceled.' in response.content
+
+
+@override_switch('use_stripe_payments_app', active=True)
 def test_payment_canceled_message_shown_as_info_after_redirect(client, user_without_subscription_or_purchase_history):
     client.force_login(user_without_subscription_or_purchase_history)
     response = client.get(reverse('settings_usage_plan') + '?purchase=canceled', secure=True)

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -154,6 +154,9 @@ def settings_usage_plan(request):
                 'Your subscription change was submitted. Upgrades are billed immediately; '
                 'downgrades take effect at the end of your current billing period.'
             )),
+            ('change', 'canceled'): ('success', (
+                'Your scheduled downgrade has been canceled. Your current plan continues unchanged.'
+            )),
             # Neutral wording: the Stripe portal returns here for any action it
             # allows (payment-method update, invoice view, or cancellation), and
             # the return does not tell us which. "Updated" is honest for all of


### PR DESCRIPTION
The payments app now redirects to `?change=canceled` after canceling a scheduled downgrade. This PR adds the matching banner: "Your scheduled downgrade has been canceled. Your current plan continues unchanged."  Fixes  a small UX gap.

