### PR TITLE
Adjust downgrade-canceled banner wording per QA

### DIFF
--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -155,7 +155,7 @@ def settings_usage_plan(request):
                 'downgrades take effect at the end of your current billing period.'
             )),
             ('change', 'canceled'): ('success', (
-                'Your scheduled downgrade has been canceled. Your current plan continues unchanged.'
+                'Your scheduled downgrade has been canceled. Your current plan will continue unchanged.'
             )),
             # Neutral wording: the Stripe portal returns here for any action it
             # allows (payment-method update, invoice view, or cancellation), and


### PR DESCRIPTION
Tiny suggested change in copy (follow-up to #3814)

"Your current plan continues unchanged" is now "Your current plan will continue unchanged."