### PR TITLE
Treat the URL scheme as case-insensitive when supplying a missing one

### DIFF
--- a/perma_web/api/serializers.py
+++ b/perma_web/api/serializers.py
@@ -236,7 +236,9 @@ class AuthenticatedLinkSerializer(LinkSerializer):
     def validate_url(self, url):
         # Clean up the user submitted url
         url = url.strip()
-        if url and url[:4] != 'http':
+        # Schemes are case-insensitive, and a host that merely starts with
+        # "http" (httpbin.org) still needs one.
+        if url and not url.lower().startswith(('http://', 'https://')):
             url = 'http://' + url
         return url
 

--- a/perma_web/api/tests/test_link_resource.py
+++ b/perma_web/api/tests/test_link_resource.py
@@ -434,6 +434,18 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
                              user=self.org_user)
 
 
+    def test_should_capture_url_with_uppercase_scheme(self):
+        submitted_url = "HTTP://" + self.server_url.split("//")[1] + "/test.html"
+        obj = self.successful_post(self.list_url,
+                                   data={'url': submitted_url},
+                                   user=self.org_user)
+
+        link = Link.objects.get(guid=obj['guid'])
+        self.assertEqual(link.submitted_url, submitted_url)
+        self.assertEqual(link.capture_job.status, 'completed')
+        self.assertEqual(link.primary_capture.status, 'success')
+
+
     def test_should_not_use_bonus_link_if_regular_limit_is_available(self):
         # give our user a bonus link
         user = self.org_user
@@ -640,6 +652,27 @@ class LinkResourceTransactionTestCase(LinkResourceTestMixin, ApiResourceTransact
             self.assertEqual(link.submitted_url, 'http://asdf.asdf')
             self.assertRecordsInArchive(link, upload=True)
             self.assertEqual(link.primary_capture.user_upload, True)
+
+    def test_should_add_http_to_url_beginning_with_http(self):
+        with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.jpg'), 'rb') as test_file:
+            obj = self.successful_post(self.list_url,
+                                       format='multipart',
+                                       data=dict(self.post_data.copy(), url='httpasdf.asdf', file=test_file),
+                                       user=self.org_user)
+
+            link = Link.objects.get(guid=obj['guid'])
+            self.assertEqual(link.submitted_url, 'http://httpasdf.asdf')
+
+    def test_should_preserve_uppercase_https_scheme(self):
+        with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.jpg'), 'rb') as test_file:
+            obj = self.successful_post(self.list_url,
+                                       format='multipart',
+                                       data=dict(self.post_data.copy(), url='HTTPS://asdf.asdf', file=test_file),
+                                       user=self.org_user)
+
+            link = Link.objects.get(guid=obj['guid'])
+            self.assertEqual(link.submitted_url, 'HTTPS://asdf.asdf')
+            self.assertEqual(link.ascii_safe_url, 'https://asdf.asdf/')
 
     def test_should_reject_invalid_file(self):
         with open(os.path.join(TEST_ASSETS_DIR, 'target_capture_files', 'test.html'), 'rb') as test_file:


### PR DESCRIPTION
This PR proposes treating the URL scheme as case-insensitive when Perma supplies a missing one, so a link typed as `HTTP://example.com` is captured instead of rejected (Fixes #2373). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/234. You can sign in with your GitHub ID to claim ownership of the project.

## What's broken

`AuthenticatedLinkSerializer.validate_url` decides whether a submitted URL already has a scheme with `url[:4] != 'http'`. That comparison is case-sensitive, so a phone that capitalizes the first letter produces `Http://example.com`, which is treated as scheme-less and rewritten to `http://Http://example.com` — the netloc becomes `Http:` and validation rejects it. The same test is wrong in the other direction for a bare host that merely starts with "http" (`httpbin.org`): it looks like it already carries a scheme, so nothing is prepended and it fails validation with no scheme at all.

Reproduced on `develop` at 45c00a2, in the repo's own shell (`docker compose exec web ./manage.py shell`), running each input through `validate_url` and then the `URLValidator` check that `LinkSerializer.validate` performs:

```
submitted by user            stored as                            verdict
--------------------------------------------------------------------------------------
'http://example.com'         'http://example.com'                 accepted
'HTTP://example.com'         'http://HTTP://example.com'          REJECTED (Enter a valid URL.)
'Http://example.com'         'http://Http://example.com'          REJECTED (Enter a valid URL.)
'HTTPS://example.com'        'http://HTTPS://example.com'         REJECTED (Enter a valid URL.)
'example.com'                'http://example.com'                 accepted
'httpbin.org'                'httpbin.org'                        REJECTED (Enter a valid URL.)
```

This is the `/v1/archives/` path, so it covers the public API, the "Create a Perma Link" box (`CreateLink.vue` POSTs the raw input to `/archives/`), and the bookmarklet's `?url=` hand-off — which is where a mobile keyboard's capitalization tends to arrive.

## The change

One line: test the scheme case-insensitively, and require the `://` so a host beginning with "http" still gets one.

```python
if url and not url.lower().startswith(('http://', 'https://')):
    url = 'http://' + url
```

The submitted URL is still stored as the user typed it, exactly as host casing already is. `Link.ascii_safe_url` continues to hand a normalized `http://example.com/` to validation and to Scoop, and `surt.surt()` already lowercases, so `submitted_url_surt` — and with it the memento and duplicate lookups — is unchanged for these inputs. `httpexamplecom` is still rejected: it now picks up a scheme first and fails on the missing TLD, so `test_should_reject_malformed_url1` still holds.

## Verification

Three tests in `api/tests/test_link_resource.py`, alongside your existing `test_should_add_http_to_url` and `test_should_create_archive_from_jpg_file_with_nonloading_url`: an end-to-end capture of an uppercase-scheme URL, the bare-host-starting-with-http case, and preservation of an uppercase `HTTPS://` scheme with its normalized `ascii_safe_url`.

They fail on the unmodified tree and pass with the change:

```
# with the serializers.py change stashed
$ pytest api/tests/test_link_resource.py -k "uppercase_scheme or beginning_with_http or uppercase_https"
3 failed

# with the change applied
3 passed
```

Full package before and after, on the same containers (`db`, `perma-redis`, `web`, `minio`, `scoop-rest-api`, per the tests workflow):

```
$ pytest api/tests
175 passed          # develop at 45c00a2
178 passed          # this branch, the 3 new tests included
```

Nothing that passed before fails now, and `flake8` is clean.

## How this was managed

This work was tracked as [Handle case sensitivity in URLS](https://eastagiletracker.com/projects/234/stories/109603) on a board imported from this repository's issues, pull requests and milestones — 3673 stories in all — which is also where the history below comes from: https://eastagiletracker.com/projects/234

![board](https://raw.githubusercontent.com/eastagiletracker/perma/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
