### PR TITLE
Refactor customer's "usage plan" page and customer models

### DIFF
--- a/perma_web/perma/models/__init__.py
+++ b/perma_web/perma/models/__init__.py
@@ -1,18 +1,10 @@
 """
-Django models for the perma app, implemented in submodules (base.py, link.py, etc.).
+Django models for the perma app.
 
 Application code can keep using imports such as 'from perma.models import Link'.
 Two callables (get_default_archive_formats, get_empty_datetime_range) are also added here
 because older migrations resolve them on perma.models (migrations 0005 and 0046).
 """
-
-from .base import ( # noqa: F401
-    ACTIVE_SUBSCRIPTION_STATUSES,
-    FIELDS_REQUIRED_FROM_PERMA_PAYMENTS,
-    link_count_in_time_period,
-    most_active_org_in_time_period,
-    subscription_is_active
-)
 from .folder import Folder # noqa: F401
 from .internet_archive import ( # noqa: F401
     InternetArchiveFile,
@@ -37,4 +29,3 @@ from .user import( # noqa: F401
     LinkUserManager,
     UserOrganizationAffiliation
 )
-

--- a/perma_web/perma/models/customer.py
+++ b/perma_web/perma/models/customer.py
@@ -283,6 +283,7 @@ class CustomerModel(models.Model):
             pending_change = {
                 'rate': post_data['subscription']['rate'],
                 'link_limit': post_data['subscription']['link_limit'],
+                'frequency': post_data['subscription']['frequency'],
                 'effective': subscription_change_effective
             }
         self.save(update_fields=['in_trial', 'cached_subscription_started', 'cached_subscription_status', 'cached_paid_through', 'cached_subscription_rate', 'unlimited', 'link_limit', 'link_limit_period'])

--- a/perma_web/perma/models/customer.py
+++ b/perma_web/perma/models/customer.py
@@ -1,17 +1,14 @@
 import calendar
 from datetime import datetime
 from decimal import Decimal
-import logging
-
-import requests
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction
-from django.db.models import Count
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.views.decorators.debug import sensitive_variables
-from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
+import requests
+import logging
 
 from perma.exceptions import InvalidTransmissionException, PermaPaymentsCommunicationException
 from perma.utils import (
@@ -23,6 +20,7 @@ from perma.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 ### CONSTANTS
 ACTIVE_SUBSCRIPTION_STATUSES = ['Current', 'Cancellation Requested']
@@ -47,38 +45,6 @@ CUSTOMER_TYPE_MAP = {
     'Registrar': 'Registrar'
 }
 
-
-### HELPERS ###
-
-# functions
-def link_count_in_time_period(links, start_time=None, end_time=None):
-    if start_time and end_time and (start_time > end_time):
-        raise ValueError("specified end time is earlier than specified start time")
-    elif start_time and end_time and (start_time == end_time):
-        links = links.filter(creation_timestamp=start_time)
-    else:
-        if start_time:
-            links = links.filter(creation_timestamp__gte=start_time)
-        if end_time:
-            links = links.filter(creation_timestamp__lte=end_time)
-    return links.count()
-
-def most_active_org_in_time_period(organizations, start_time=None, end_time=None):
-    if start_time and end_time and (start_time > end_time):
-        raise ValueError("specified end time is earlier than specified start time")
-    # unlike 'link_count_in_time_period', no special behavior required
-    # if start_time = end_time here. the end result is the same
-    else:
-        if start_time:
-            organizations = organizations.filter(links__creation_timestamp__gte=start_time)
-        if end_time:
-            organizations = organizations.filter(links__creation_timestamp__lte=end_time)
-        return organizations\
-            .annotate(num_links=Count('links'))\
-            .exclude(num_links=0)\
-            .order_by('-num_links')\
-            .first()
-
 def subscription_is_active(subscription):
     return subscription and (
         subscription['status'] in ACTIVE_SUBSCRIPTION_STATUSES or (
@@ -91,43 +57,6 @@ def subscription_is_active(subscription):
 def subscription_has_problem(subscription):
     return subscription and subscription['status'] in PROBLEM_SUBSCRIPTION_STATUSES
 
-
-# classes
-
-class DeletableManager(models.Manager):
-    """
-        Manager that excludes results where user_deleted=True by default.
-    """
-    def get_queryset(self):
-        # exclude deleted entries by default
-        return super(DeletableManager, self).get_queryset().filter(user_deleted=False)
-
-    def all_with_deleted(self):
-        return super(DeletableManager, self).get_queryset()
-
-
-class DeletableModel(models.Model):
-    """
-        Abstract base class that lets a model track deletion.
-    """
-    user_deleted = models.BooleanField(default=False, verbose_name="Deleted by user")
-    user_deleted_timestamp = models.DateTimeField(null=True, blank=True)
-
-    class Meta:
-        abstract = True
-
-    def safe_delete(self):
-        self.user_deleted = True
-        self.user_deleted_timestamp = timezone.now()
-
-
-# django-taggit assumes the model being tagged has an integer primary key.
-# per http://django-taggit.readthedocs.io/en/latest/custom_tagging.html,
-# tag "through" this class if your model has a string as primary key.
-# tags = TaggableManager(through=GenericStringTaggedItem)
-# (copied straight from their docs)
-class GenericStringTaggedItem(CommonGenericTaggedItemBase, TaggedItemBase):
-    object_id = models.CharField(max_length=50, db_index=True)
 
 
 class CustomerModel(models.Model):
@@ -617,4 +546,3 @@ class CustomerModel(models.Model):
         Must be implemented by children
         """
         raise NotImplementedError
-

--- a/perma_web/perma/models/link.py
+++ b/perma_web/perma/models/link.py
@@ -26,10 +26,10 @@ from taggit.managers import TaggableManager
 
 from perma.utils import preserve_perma_wacz
 
-from .base import DeletableManager, DeletableModel, GenericStringTaggedItem
 from .folder import Folder
 from .organization import Organization
 from .user import LinkUser
+from .utils import DeletableManager, DeletableModel, GenericStringTaggedItem
 
 logger = logging.getLogger(__name__)
 

--- a/perma_web/perma/models/organization.py
+++ b/perma_web/perma/models/organization.py
@@ -6,9 +6,9 @@ from simple_history.models import HistoricalRecords
 
 from perma.utils import tz_datetime
 
-from .base import DeletableManager, DeletableModel, link_count_in_time_period
 from .folder import Folder
 from .registrar import Registrar
+from .utils import DeletableManager, DeletableModel, link_count_in_time_period
 
 
 class OrganizationQuerySet(QuerySet):

--- a/perma_web/perma/models/registrar.py
+++ b/perma_web/perma/models/registrar.py
@@ -11,7 +11,8 @@ from taggit.managers import TaggableManager
 
 from perma.utils import tz_datetime
 
-from .base import CustomerModel, link_count_in_time_period, most_active_org_in_time_period
+from .customer import CustomerModel
+from .utils import link_count_in_time_period, most_active_org_in_time_period
 
 
 class RegistrarQuerySet(QuerySet):

--- a/perma_web/perma/models/user.py
+++ b/perma_web/perma/models/user.py
@@ -412,6 +412,9 @@ class LinkUser(CustomerModel, AbstractBaseUser, PermissionsMixin):
         """
         return not self.nonpaying or (self.is_registrar_user() and not self.registrar.nonpaying)
 
+    def can_purchase_bonus_links(self):
+        return not self.nonpaying and not self.unlimited
+
     def should_see_grandfathered_banner(self):
         """
             Should the user see the "Payment System Upgrade" banner for grandfathered-in users?

--- a/perma_web/perma/models/user.py
+++ b/perma_web/perma/models/user.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 import simple_history
 
-from .base import CustomerModel
+from .customer import CustomerModel
 from .folder import Folder
 from .organization import Organization
 from .registrar import Registrar, Sponsorship

--- a/perma_web/perma/models/utils.py
+++ b/perma_web/perma/models/utils.py
@@ -2,9 +2,7 @@ from django.db import models
 from django.db.models import Count
 from django.utils import timezone
 from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
-import logging
 
-logger = logging.getLogger(__name__)
 
 ### HELPERS ###
 

--- a/perma_web/perma/models/utils.py
+++ b/perma_web/perma/models/utils.py
@@ -1,0 +1,80 @@
+from django.db import models
+from django.db.models import Count
+from django.utils import timezone
+from taggit.models import CommonGenericTaggedItemBase, TaggedItemBase
+import logging
+
+logger = logging.getLogger(__name__)
+
+### HELPERS ###
+
+# functions
+def link_count_in_time_period(links, start_time=None, end_time=None):
+    if start_time and end_time and (start_time > end_time):
+        raise ValueError("specified end time is earlier than specified start time")
+    elif start_time and end_time and (start_time == end_time):
+        links = links.filter(creation_timestamp=start_time)
+    else:
+        if start_time:
+            links = links.filter(creation_timestamp__gte=start_time)
+        if end_time:
+            links = links.filter(creation_timestamp__lte=end_time)
+    return links.count()
+
+def most_active_org_in_time_period(organizations, start_time=None, end_time=None):
+    if start_time and end_time and (start_time > end_time):
+        raise ValueError("specified end time is earlier than specified start time")
+    # unlike 'link_count_in_time_period', no special behavior required
+    # if start_time = end_time here. the end result is the same
+    else:
+        if start_time:
+            organizations = organizations.filter(links__creation_timestamp__gte=start_time)
+        if end_time:
+            organizations = organizations.filter(links__creation_timestamp__lte=end_time)
+        return organizations\
+            .annotate(num_links=Count('links'))\
+            .exclude(num_links=0)\
+            .order_by('-num_links')\
+            .first()
+
+
+# classes
+
+# django-taggit assumes the model being tagged has an integer primary key.
+# per http://django-taggit.readthedocs.io/en/latest/custom_tagging.html,
+# tag "through" this class if your model has a string as primary key.
+# tags = TaggableManager(through=GenericStringTaggedItem)
+# (copied straight from their docs)
+class GenericStringTaggedItem(CommonGenericTaggedItemBase, TaggedItemBase):
+    object_id = models.CharField(max_length=50, db_index=True)
+
+
+class DeletableManager(models.Manager):
+    """
+        Manager that excludes results where user_deleted=True by default.
+    """
+    def get_queryset(self):
+        # exclude deleted entries by default
+        return super(DeletableManager, self).get_queryset().filter(user_deleted=False)
+
+    def all_with_deleted(self):
+        return super(DeletableManager, self).get_queryset()
+
+
+class DeletableModel(models.Model):
+    """
+        Abstract base class that lets a model track deletion.
+    """
+    user_deleted = models.BooleanField(default=False, verbose_name="Deleted by user")
+    user_deleted_timestamp = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        abstract = True
+
+    def safe_delete(self):
+        self.user_deleted = True
+        self.user_deleted_timestamp = timezone.now()
+
+
+
+

--- a/perma_web/perma/templates/includes/bonus-links-purchase.html
+++ b/perma_web/perma/templates/includes/bonus-links-purchase.html
@@ -1,0 +1,37 @@
+<h2 class="body-ah">Get More Personal Links</h2>
+<p class="page-dek">A one-time purchase, for people with or without subscriptions.</p>
+<p class="fine-print">
+  Have a subscription? These extra links carry over. You can make them whenever you want, and you can still make them if you cancel your subscription.
+</p>
+
+<div class="row">
+  {% for package in bonus_packages %}
+    <form class="purchase-form col-xs-12 col-md-3"
+          method="post"
+          action="{{ purchase_url }}">
+      <button>
+        <span>{{ package.link_quantity }} additional Links</span>
+        <br>
+        ${{ package.amount }}
+        <br>
+        <br>
+        ${{ package.unit_cost | floatformat:2 }}/link
+      </button>
+      <input type="hidden" name="encrypted_data" value={{ package.encrypted_data }}>
+    </form>
+  {% endfor %}
+</div>
+
+<hr>
+
+<h3 class="body-ch">Additional Links</h3>
+<p class="page-dek">Additional Links Remaining: {{ request.user.bonus_links|default:0 }} Links</p>
+
+<div class="row subscription-buttons">
+  <div class="col-xs-12 col-md-6">
+    <form method="post" action="{{ billing_portal_url }}">
+      <input type="hidden" name="encrypted_data" value="{{ billing_encrypted_data }}">
+      <button class="btn btn-primary" type="submit">Billing and Purchase History</button>
+    </form>
+  </div>
+</div>

--- a/perma_web/perma/templates/includes/subscription-canceled.html
+++ b/perma_web/perma/templates/includes/subscription-canceled.html
@@ -1,0 +1,11 @@
+<p class="page-dek">
+  Your paid subscription has been <span class="blue-text">cancelled</span>. You will not be charged
+  again.
+</p>
+<p class="page-dek">
+  You will continue to be able to create Perma Links
+  {% if customer_type == 'Registrar' %}
+    for {{ customer.name }}
+  {% endif %}
+  until {{ subscription.paid_through | date:"F jS, Y" }}.
+</p>

--- a/perma_web/perma/templates/includes/subscription-current-pending-change.html
+++ b/perma_web/perma/templates/includes/subscription-current-pending-change.html
@@ -6,12 +6,12 @@
   <div class="col-xs-12">
     <h3 class="body-ch">Current plan (through {{ subscription.paid_through | date:"F jS, Y" }})</h3>
     <dl class="dl-horizontal">
-      {% include 'includes/subscription-definition.html' with sub=subscription paid_though=False paid=True %}
+      {% include 'includes/subscription-definition.html' with sub=subscription paid_through=False paid=True %}
     </dl>
 
     <h3 class="body-ch">Scheduled change (effective {{ subscription.pending_change.effective | date:"F jS, Y" }})</h3>
     <dl class="dl-horizontal">
-      {% include 'includes/subscription-definition.html' with sub=subscription.pending_change paid_though=False paid=False %}
+      {% include 'includes/subscription-definition.html' with sub=subscription.pending_change paid_through=False paid=False %}
     </dl>
   </div>
 </div>

--- a/perma_web/perma/templates/includes/subscription-current-pending-change.html
+++ b/perma_web/perma/templates/includes/subscription-current-pending-change.html
@@ -1,0 +1,17 @@
+<p class="page-dek">
+  Your subscription is <span class="blue-text">{{ subscription.status | lower }}</span>.
+</p>
+
+<div class="row">
+  <div class="col-xs-12">
+    <h3 class="body-ch">Current plan (through {{ subscription.paid_through | date:"F jS, Y" }})</h3>
+    <dl class="dl-horizontal">
+      {% include 'includes/subscription-definition.html' with sub=subscription paid_though=False paid=True %}
+    </dl>
+
+    <h3 class="body-ch">Scheduled change (effective {{ subscription.pending_change.effective | date:"F jS, Y" }})</h3>
+    <dl class="dl-horizontal">
+      {% include 'includes/subscription-definition.html' with sub=subscription.pending_change paid_though=False paid=False %}
+    </dl>
+  </div>
+</div>

--- a/perma_web/perma/templates/includes/subscription-current.html
+++ b/perma_web/perma/templates/includes/subscription-current.html
@@ -1,0 +1,11 @@
+<p class="page-dek">
+  Your subscription is <span class="blue-text">{{ subscription.status | lower }}</span>.
+</p>
+
+<div class="row">
+  <div class="col-xs-12">
+    <dl class="dl-horizontal">
+      {% include 'includes/subscription-definition.html' with sub=subscription paid_through=True paid=False %}
+    </dl>
+  </div>
+</div>

--- a/perma_web/perma/templates/includes/subscription-definition.html
+++ b/perma_web/perma/templates/includes/subscription-definition.html
@@ -1,0 +1,47 @@
+{% load humanize %}
+
+{% if sub.frequency == 'monthly' %}
+  <dt>
+    Rate:
+  </dt>
+  <dd>
+    ${{ sub.rate | intcomma }}/month{% if paid %} (paid){% endif %}
+  </dd>
+{% elif sub.frequency == 'annually' %}
+  <dt>
+    Rate:
+  </dt>
+  <dd>
+    ${{ sub.rate | intcomma }}/year{% if paid %} (paid){% endif %}
+  </dd>
+{% endif %}
+
+{% if paid_through %}
+  <dt>
+    Paid Through:
+  </dt>
+  <dd>
+    {{ subscription.paid_through | date:"F jS, Y" }}
+  </dd>
+{% endif %}
+
+{% if customer_type == 'Registrar'%}
+  {% if customer.local_subscription_description %}
+    <dt>Usage plan:</dt>
+    <dd>{{ customer.local_subscription_description }}</dd>
+  {% endif %}
+{% elif sub.link_limit == 'unlimited' %}
+  <dt>
+    Links:
+  </dt>
+  <dd>
+    unlimited
+  </dd>
+{% else %}
+  <dt>
+    Included Links:
+  </dt>
+  <dd>
+    {{ sub.link_limit }}
+  </dd>
+{% endif %}

--- a/perma_web/perma/templates/includes/subscription-definition.html
+++ b/perma_web/perma/templates/includes/subscription-definition.html
@@ -21,7 +21,7 @@
     Paid Through:
   </dt>
   <dd>
-    {{ subscription.paid_through | date:"F jS, Y" }}
+    {{ sub.paid_through | date:"F jS, Y" }}
   </dd>
 {% endif %}
 

--- a/perma_web/perma/templates/includes/subscription-details.html
+++ b/perma_web/perma/templates/includes/subscription-details.html
@@ -1,0 +1,28 @@
+<p class="page-dek">Subscription Reference: {{ subscription.reference_number }}</p>
+
+{% if subscription.status == 'Canceled' %}
+  {% include 'includes/subscription-canceled.html' %}
+{% elif subscription.status == 'Hold' %}
+  {% include 'includes/subscription-hold.html' %}
+{% elif subscription.pending_change %}
+  {% include 'includes/subscription-current-pending-change.html' %}
+{% else %}
+  {% include 'includes/subscription-current.html' %}
+{% endif %}
+
+<div class="row subscription-buttons">
+  <div class="col-xs-12 col-md-6">
+    <form method="post" action="{{ update_url }}">
+      {% csrf_token %}
+      <input type="hidden" name="account_type" value={{ customer_type }}>
+      <button class="btn btn-primary" type="submit">Manage Subscription and Billing</button>
+    </form>
+  </div>
+</div>
+
+{% if customer_type == 'Individual' and not customer.unlimited %}
+  <hr>
+  <h3 class="body-ch">Remaining Links</h3>
+  {% widthratio links_remaining.0 1 -1 as negative_links_remaining %}
+  <p class="page-dek">You have created {{ customer.link_limit | add:negative_links_remaining }} of {{ customer.link_limit }} links this billing period.</p>
+{% endif %}

--- a/perma_web/perma/templates/includes/subscription-hold.html
+++ b/perma_web/perma/templates/includes/subscription-hold.html
@@ -9,7 +9,7 @@
 <div class="row">
   <div class="col-xs-12">
     <dl class="dl-horizontal">
-      {% include 'includes/subscription-definition.html' with sub=subscription paid_though=True paid=False %}
+      {% include 'includes/subscription-definition.html' with sub=subscription paid_through=True paid=False %}
     </dl>
   </div>
 </div>

--- a/perma_web/perma/templates/includes/subscription-hold.html
+++ b/perma_web/perma/templates/includes/subscription-hold.html
@@ -1,0 +1,15 @@
+<p class="page-dek">
+  Your subscription is <span class="blue-text">on hold</span> due to a problem with your credit card.
+</p>
+<p class="page-dek">
+  You can update payment information by clicking the "Manage Subscription and Billing" button below. If you need
+  assistance or believe this message is in error, please <a href="{% url 'contact' %}?subject=Subscription%20On%20Hold">contact us</a>.
+</p>
+
+<div class="row">
+  <div class="col-xs-12">
+    <dl class="dl-horizontal">
+      {% include 'includes/subscription-definition.html' with sub=subscription paid_though=True paid=False %}
+    </dl>
+  </div>
+</div>

--- a/perma_web/perma/templates/includes/subscription-purchase.html
+++ b/perma_web/perma/templates/includes/subscription-purchase.html
@@ -1,0 +1,62 @@
+{% load humanize %}
+
+{% if customer_type == 'Registrar' %}
+  <p class="page-dek">Purchase a subscription for {{ customer.name }}</p>
+  {% if customer.local_subscription_description %}
+    <p class="fine-print">Usage plan: {{ customer.local_subscription_description}}</p>
+  {% endif %}
+{% else %}
+  <p class="page-dek">Purchase a personal subscription</p>
+{% endif %}
+
+<div class="row">
+  {% for tier in account.tiers %}
+    {% if tier.type == 'upgrade' or tier.type == 'downgrade' %}
+      {% if tier.period == 'monthly' and customer.offer_monthly or tier.period == 'annually' and customer.offer_annual %}
+        <form class="upgrade-form col-xs-12 col-md-3" method="post" action="{{ subscribe_url }}">
+          {% if tier.period == 'monthly' %}
+            {% if customer_type == 'Registrar' %}
+              <button>
+              <span>Monthly plan
+              </span>
+              <br>
+              ${{ tier.required_fields.recurring_amount | intcomma }}/month
+              </button>
+            {% else %}
+              <button>
+                <span>
+                  {{ tier.limit }} Links {% if tier.limit != "unlimited" %}per month{% endif %}
+                </span>
+                <br>
+                ${{ tier.required_fields.recurring_amount | intcomma }}/month
+                {% if tier.required_fields.recurring_amount != tier.required_fields.amount %}
+                  <br>
+                  <br>
+                  ${{ tier.required_fields.amount | intcomma }}
+                  this month (prorated)
+                {% endif %}
+              </button>
+            {% endif %}
+          {% elif tier.period == 'annually' %}
+            {% if customer_type == 'Registrar' %}
+              <button>
+                <span>Annual plan</span>
+                <br>
+                ${{ tier.required_fields.recurring_amount | intcomma }}/year
+              </button>
+            {% else %}
+              <button>
+                <span>
+                  {{ tier.limit }} Links {% if tier.limit != "unlimited" %}per year{% endif %}
+                </span>
+                <br>
+                ${{ tier.required_fields.amount | intcomma }}/year
+              </button>
+            {% endif %}
+          {% endif %}
+          <input type="hidden" name="encrypted_data" value={{ tier.encrypted_data }}>
+        </form>
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+</div>

--- a/perma_web/perma/templates/includes/top_banner_grandfathered.html
+++ b/perma_web/perma/templates/includes/top_banner_grandfathered.html
@@ -1,4 +1,0 @@
-<div class="top-banner">
-  <p class="top-banner-title">Payment System Upgrade In Progress</p>
-  <p>Payment, billing, and cancellation services may be limited during this time. We apologize for any inconvenience and appreciate your patience as we improve the payment experience. We will be in touch with more details soon. Reach out to <a href="mailto:info@perma.cc?subject=payment%20system%20upgrade">info@perma.cc</a> if you have any questions.</p>
-</div>

--- a/perma_web/perma/templates/settings/settings-usage-plan-grandfathered.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan-grandfathered.html
@@ -1,6 +1,9 @@
 {% extends "settings-layout.html" %}
 {% block top_banner %}
-    {% include "includes/top_banner_grandfathered.html" %}
+  <div class="top-banner">
+    <p class="top-banner-title">Payment System Upgrade In Progress</p>
+    <p>Payment, billing, and cancellation services may be limited during this time. We apologize for any inconvenience and appreciate your patience as we improve the payment experience. We will be in touch with more details soon. Reach out to <a href="mailto:info@perma.cc?subject=payment%20system%20upgrade">info@perma.cc</a> if you have any questions.</p>
+  </div>
 {% endblock top_banner %}
 {% load humanize %}
 {% block title %} | Settings{% endblock %}

--- a/perma_web/perma/templates/settings/settings-usage-plan.html
+++ b/perma_web/perma/templates/settings/settings-usage-plan.html
@@ -1,5 +1,4 @@
 {% extends "settings-layout.html" %}
-{% load humanize %}
 {% block title %} | Settings{% endblock %}
 {% block dashboardContent %}
 
@@ -11,289 +10,26 @@
     {% with subscription=account.subscription %}
       {% with customer=account.customer %}
         {% with customer_type=customer.customer_type %}
+
           {% if customer_type == 'Registrar' %}
             <h2 class="body-ah">Registrar Subscription &mdash; {{ customer.name }}</h2>
           {% else %}
             <h2 class="body-ah">Personal Subscription</h2>
           {% endif %}
-          {% if subscription %}
-            <p class="page-dek">Subscription Reference: {{ subscription.reference_number }}</p>
-          {% endif %}
-          {% if not subscription %}
-              {% if customer_type == 'Registrar' %}
-                <p class="page-dek">Purchase a subscription for {{ customer.name }}</p>
-                {% if customer.local_subscription_description %}
-                  <p class="fine-print">Usage plan: {{ customer.local_subscription_description}}</p>
-                {% endif %}
-              {% else %}
-                <p class="page-dek">Purchase a personal subscription</p>
-              {% endif %}
-              <div class="row">
-                {% for tier in account.tiers %}
-                  {% if tier.type == 'upgrade' or tier.type == 'downgrade' %}
-                    {% if tier.period == 'monthly' and customer.offer_monthly or tier.period == 'annually' and customer.offer_annual %}
-                    <form class="upgrade-form col-xs-12 col-md-3"
-                          method="post"
-                          action="{{ subscribe_url }}">
-                      {% if tier.period == 'monthly' %}
-                        {% if customer_type == 'Registrar' %}
-                        <button>
-                          <span>Monthly plan
-                          </span>
-                          <br>
-                          ${{ tier.required_fields.recurring_amount | intcomma }}/month
-                        </button>
-                        {% else %}
-                        <button>
-                          <span>{{ tier.limit }} Links
-                            {% if tier.limit != "unlimited" %}per month{% endif %}
-                          </span>
-                          <br>
-                          ${{ tier.required_fields.recurring_amount | intcomma }}/month
-                          {% if tier.required_fields.recurring_amount != tier.required_fields.amount %}
-                            <br>
-                            <br>
-                            ${{ tier.required_fields.amount | intcomma }}
-                            this month (prorated)
-                          {% endif %}
-                        </button>
-                        {% endif %}
-                      {% elif tier.period == 'annually' %}
-                        {% if customer_type == 'Registrar' %}
-                        <button>
-                          <span>Annual plan
-                          </span>
-                          <br>
-                          ${{ tier.required_fields.recurring_amount | intcomma }}/year
-                        </button>
-                        {% else %}
-                        <button>
-                          <span>{{ tier.limit }} Links
-                            {% if tier.limit != "unlimited" %}per year{% endif %}
-                          </span>
-                          <br>
-                          ${{ tier.required_fields.amount | intcomma }}/year
-                        </button>
-                        {% endif %}
-                      {% endif %}
-                      <input type="hidden" name="encrypted_data" value={{ tier.encrypted_data }}>
-                    </form>
-                    {% endif %}
-                  {% endif %}
-                {% endfor %}
-              </div>
-            {% elif subscription.status == 'Canceled' %}
-              <p class="page-dek">
-                Your paid subscription has been <span class="blue-text">cancelled</span>. You will not be charged
-                again.
-              </p>
-              <p class="page-dek">
-                You will continue to be able to create Perma Links
-                {% if customer_type == 'Registrar' %}
-                  for {{ customer.name }}
-                {% endif %}
-                until {{ subscription.paid_through | date:"F jS, Y" }}.
-              </p>
-              <div class="row subscription-buttons">
-                <div class="col-xs-12 col-md-6">
-                  <form method="post" action="{{ update_url }}">
-                    {% csrf_token %}
-                    <input type="hidden" name="account_type" value={{ customer_type }}>
-                    <button class="btn btn-primary" type="submit">Manage Subscription and Billing</button>
-                  </form>
-                </div>
-              </div>
-            {% else %}
-              {% if subscription.status == 'Hold' %}
-                <p class="page-dek">
-                  Your subscription is <span class="blue-text">on hold</span> due to a problem with your credit card.
-                </p>
-                <p class="page-dek">
-                  You can update payment information by clicking the "Manage Subscription and Billing" button below. If you need
-                  assistance or believe this message is in error, please <a href="{% url 'contact' %}?subject=Subscription%20On%20Hold">contact us</a>.
-                </p>
-              {% else %}
-                <p class="page-dek">
-                  Your subscription is <span class="blue-text">{{ subscription.status | lower }}</span>.
-                </p>
-              {% endif %}
-              <div class="row">
-                {% if subscription.pending_change %}
-                  <div class="col-xs-12">
-                    <h3 class="body-ch">Current plan (through {{ subscription.paid_through | date:"F jS, Y" }})</h3>
-                    <dl class="dl-horizontal">
-                      {% if subscription.frequency == 'monthly' %}
-                        <dt>
-                          Rate:
-                        </dt>
-                        <dd>
-                          ${{ subscription.rate | intcomma }}/month (paid)
-                        </dd>
-                      {% elif subscription.frequency == 'annually' %}
-                        <dt>
-                          Rate:
-                        </dt>
-                        <dd>
-                          ${{ subscription.rate | intcomma }}/year (paid)
-                        </dd>
-                      {% endif %}
-                      {% if customer_type == 'Registrar'%}
-                        {% if customer.local_subscription_description %}
-                          <dt>Usage plan:</dt>
-                          <dd>{{ customer.local_subscription_description }}</dd>
-                        {% endif %}
-                      {% elif customer.unlimited %}
-                        <dt>
-                          Links:
-                        </dt>
-                        <dd>
-                          unlimited
-                        </dd>
-                      {% else %}
-                        <dt>
-                          Included Links:
-                        </dt>
-                        <dd>
-                          {{ customer.link_limit }}
-                        </dd>
-                      {% endif %}
-                    </dl>
-                    <h3 class="body-ch">Scheduled change (effective {{ subscription.pending_change.effective | date:"F jS, Y" }})</h3>
-                    <dl class="dl-horizontal">
-                      {% if subscription.frequency == 'monthly' %}
-                        <dt>
-                          Rate:
-                        </dt>
-                        <dd>
-                          ${{ subscription.pending_change.rate | intcomma }}/month
-                        </dd>
-                      {% elif subscription.frequency == 'annually' %}
-                        <dt>
-                          Rate:
-                        </dt>
-                        <dd>
-                          ${{ subscription.pending_change.rate | intcomma }}/year
-                        </dd>
-                      {% endif %}
-                      {% if subscription.pending_change.link_limit == 'unlimited' %}
-                        <dt>
-                          Links:
-                        </dt>
-                        <dd>
-                          unlimited
-                        </dd>
-                      {% else %}
-                        <dt>
-                          Included Links:
-                        </dt>
-                        <dd>
-                          {{ subscription.pending_change.link_limit }}
-                        </dd>
-                      {% endif %}
-                    </dl>
-                  </div>
-                {% else %}
-                  <div class="col-xs-12">
-                    <dl class="dl-horizontal">
-                      {% if subscription.frequency == 'monthly' %}
-                        <dt>
-                          Rate:
-                        </dt>
-                        <dd>
-                          ${{ subscription.rate | intcomma }}/month
-                        </dd>
-                      {% elif subscription.frequency == 'annually' %}
-                        <dt>
-                          Rate:
-                        </dt>
-                        <dd>
-                          ${{ subscription.rate | intcomma }}/year
-                        </dd>
-                      {% endif %}
-                      <dt>
-                        Paid Through:
-                      </dt>
-                      <dd>
-                        {{ subscription.paid_through | date:"F jS, Y" }}
-                      </dd>
-                      {% if customer_type == 'Registrar'%}
-                        {% if customer.local_subscription_description %}
-                          <dt>Usage plan:</dt>
-                          <dd>{{ customer.local_subscription_description }}</dd>
-                        {% endif %}
-                      {% elif customer.unlimited %}
-                        <dt>
-                          Links:
-                        </dt>
-                        <dd>
-                          unlimited
-                        </dd>
-                      {% else %}
-                        <dt>
-                          Included Links:
-                        </dt>
-                        <dd>
-                          {{ customer.link_limit }}
-                        </dd>
-                      {% endif %}
-                    </dl>
-                  </div>
-                {% endif %}
-                  <div class="row subscription-buttons">
-                    <div class="col-xs-12 col-md-6">
-                      <form method="post" action="{{ update_url }}">
-                        {% csrf_token %}
-                        <input type="hidden" name="account_type" value={{ customer_type }}>
-                        <button class="btn btn-primary" type="submit">Manage Subscription and Billing</button>
-                      </form>
-                    </div>
-                  </div>
-              {% endif %}
-              {% if subscription and customer_type == 'Individual' and subscription.frequency == 'monthly' %}
-                <hr>
-                <h3 class="body-ch">Remaining Links</h3>
-                {% widthratio links_remaining.0 1 -1 as negative_links_remaining %}
-                <p class="page-dek">You have created {{ customer.link_limit | add:negative_links_remaining}} of {{ customer.link_limit }} links this billing period.</p>
-              {% endif %}
-            {% endwith %}
-          {% endwith %}
-        {% endwith %}
-      {% endfor %}
-      <h2 class="body-ah">Get More Personal Links</h2>
-        <p class="page-dek">A one-time purchase, for people with or without subscriptions.</p>
-        <p class="fine-print">
-          Have a subscription? These extra links carry over. You can make them whenever you want, and you
-          can still make them if you cancel your subscription.
-        </p>
-        <div class="row">
-          {% for package in bonus_packages %}
-            <form class="purchase-form col-xs-12 col-md-3"
-                  method="post"
-                  action="{{ purchase_url }}">
-              <button>
-                <span>{{ package.link_quantity }} additional Links</span>
-                <br>
-                ${{ package.amount }}
-                <br>
-                <br>
-                ${{ package.unit_cost | floatformat:2 }}/link
-              </button>
-              <input type="hidden" name="encrypted_data" value={{ package.encrypted_data }}>
-            </form>
-          {% endfor %}
-        </div>
-        <hr>
-        <h3 class="body-ch">Additional Links</h3>
-        <p class="page-dek">Additional Links Remaining: {{ request.user.bonus_links|default:0 }} Links</p>
-        {% if billing_portal_url %}
-          <div class="row subscription-buttons">
-            <div class="col-xs-12 col-md-6">
-              <form method="post" action="{{ billing_portal_url }}">
-                <input type="hidden" name="encrypted_data" value="{{ billing_encrypted_data }}">
-                <button class="btn btn-primary" type="submit">Billing and Purchase History</button>
-              </form>
-            </div>
-          </div>
-        {% endif %}
 
-    {% endblock %}
+          {% if not subscription %}
+            {% include 'includes/subscription-purchase.html' %}
+          {% else %}
+            {% include 'includes/subscription-details.html' %}
+          {% endif %}
+
+        {% endwith %}
+      {% endwith %}
+    {% endwith %}
+  {% endfor %}
+
+  {% if request.user.can_purchase_bonus_links %}
+    {% include 'includes/bonus-links-purchase.html' %}
+  {% endif %}
+
+{% endblock %}

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -233,6 +233,7 @@ def test_get_subscription_happy_path_with_pending_change(post, process, paying_u
             'pending_change': {
                 'rate': response['subscription']['rate'],
                 'link_limit': response['subscription']['link_limit'],
+                'frequency': response['subscription']['frequency'],
                 'effective': pp_date_from_post(response['subscription']['link_limit_effective_timestamp'])
             }
         }

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -8,16 +8,11 @@ from django.utils import timezone
 from unittest.mock import patch, sentinel
 
 from perma.exceptions import PermaPaymentsCommunicationException, InvalidTransmissionException
-import perma.models
 from perma.models import (
-    ACTIVE_SUBSCRIPTION_STATUSES,
-    FIELDS_REQUIRED_FROM_PERMA_PAYMENTS,
-    Link, Organization, Registrar, Folder,
-    Sponsorship,
-    link_count_in_time_period,
-    most_active_org_in_time_period,
-    subscription_is_active
+    Link, Organization, Registrar, Folder, Sponsorship,
 )
+from perma.models.customer import ACTIVE_SUBSCRIPTION_STATUSES, FIELDS_REQUIRED_FROM_PERMA_PAYMENTS, subscription_is_active
+from perma.models.utils import link_count_in_time_period, most_active_org_in_time_period
 from perma.utils import pp_date_from_post, tz_datetime, first_day_of_next_month, today_next_month, today_next_year, years_ago_today
 
 from conftest import GENESIS
@@ -29,7 +24,7 @@ from waffle.testutils import override_switch
 # Related to Perma Payments
 #
 
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_none_and_no_network_call_if_nonpaying(post, noncustomers):
     # also verify that their value of in_trial is unchanged by the call
     for noncustomer in noncustomers:
@@ -40,7 +35,7 @@ def test_get_subscription_none_and_no_network_call_if_nonpaying(post, noncustome
         assert post.call_count == 0
 
 
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_raises_on_non_200(post, customers):
     post.return_value.ok = False
     for customer in customers:
@@ -50,8 +45,8 @@ def test_get_subscription_raises_on_non_200(post, customers):
         post.reset_mock()
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_verifies_transmission_valid(post, process, customers):
     post.return_value.status_code = 200
     post.return_value.json.return_value = sentinel.json
@@ -66,8 +61,8 @@ def test_get_subscription_verifies_transmission_valid(post, process, customers):
         process.reset_mock()
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_raises_if_unexpected_customer_pk(post, process, customers, spoof_pp_response_wrong_pk):
     post.return_value.status_code = 200
     for customer in customers:
@@ -78,8 +73,8 @@ def test_get_subscription_raises_if_unexpected_customer_pk(post, process, custom
         post.reset_mock()
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_raises_if_unexpected_registrar_type(post, process, customers, spoof_pp_response_wrong_type):
     post.return_value.status_code = 200
     for customer in customers:
@@ -90,8 +85,8 @@ def test_get_subscription_raises_if_unexpected_registrar_type(post, process, cus
         post.reset_mock()
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_no_subscription(post, process, customers, spoof_pp_response_no_subscription):
     post.return_value.status_code = 200
     for customer in customers:
@@ -110,8 +105,8 @@ def test_get_subscription_no_subscription(post, process, customers, spoof_pp_res
             post.reset_mock()
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_no_subscription_purchased_bonus(post, process, customers, spoof_pp_response_no_subscription_two_purchases):
     post.return_value.status_code = 200
     for customer in customers:
@@ -125,8 +120,8 @@ def test_get_subscription_no_subscription_purchased_bonus(post, process, custome
             post.reset_mock()
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_happy_path_sets_customer_trial_period_to_false(post, process, paying_registrar, paying_user, spoof_pp_response_subscription):
     post.return_value.status_code = 200
     for customer in [paying_registrar, paying_user]:
@@ -147,8 +142,8 @@ def test_get_subscription_happy_path_sets_customer_trial_period_to_false(post, p
         assert customer.cached_subscription_started
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_happy_path_no_change_pending(post, process, paying_registrar, paying_user, spoof_pp_response_subscription):
     post.return_value.status_code = 200
     for customer in [paying_registrar, paying_user]:
@@ -173,7 +168,7 @@ def test_get_subscription_happy_path_no_change_pending(post, process, paying_reg
 
 
 @override_switch('allow_cybersource_transactions', active=False)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_grandfathered_uses_cached_values(post, grandfathered_paying_user):
     subscription = grandfathered_paying_user.get_subscription()
 
@@ -190,8 +185,8 @@ def test_get_subscription_grandfathered_uses_cached_values(post, grandfathered_p
 
 
 @override_switch('allow_cybersource_transactions', active=False)
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_expired_grandfathered_unsets_flag_and_calls_perma_payments(
     post, process, expired_grandfathered_paying_user, spoof_pp_response_subscription,
 ):
@@ -217,8 +212,8 @@ def test_get_subscription_expired_grandfathered_unsets_flag_and_calls_perma_paym
     }
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_happy_path_with_pending_change(post, process, paying_user, spoof_pp_response_subscription_with_pending_change):
     post.return_value.status_code = 200
     customer = paying_user
@@ -247,8 +242,8 @@ def test_get_subscription_happy_path_with_pending_change(post, process, paying_u
         assert credited.call_count == 0
 
 
-@patch('perma.models.base.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_null_effective_timestamp_treated_as_applied(post, process, paying_user, spoof_pp_response_subscription):
     # A null link_limit_effective_timestamp (e.g. a legacy Perma Payments row)
     # must not crash the usage-plan read on the None <= now comparison; it is
@@ -430,7 +425,7 @@ def test_user_link_creation_denied_when_frozen(get_links_remaining, nonpaying_us
     assert get_links_remaining.call_count == 0
 
 
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 @patch('perma.models.LinkUser.get_subscription', autospec=True)
 def test_user_link_creation_allowed_checks_cached_if_pp_down(get_subscription, is_active, paying_user):
     get_subscription.side_effect = PermaPaymentsCommunicationException
@@ -464,8 +459,8 @@ def test_user_link_creation_denied_if_no_subscription_and_over_limit(get_subscri
 
 
 @patch('perma.models.LinkUser.links_remaining_in_period', autospec=True)
-@patch('perma.models.base.subscription_is_active', autospec=True)
-@patch('perma.models.base.subscription_has_problem', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_has_problem', autospec=True)
 @patch('perma.models.LinkUser.get_subscription', autospec=True)
 def test_user_link_creation_disallowed_if_subscription_inactive_and_over_limit(get_subscription, has_problem, is_active, links_remaining_in_period, paying_user):
     get_subscription.return_value = sentinel.subscription
@@ -480,8 +475,8 @@ def test_user_link_creation_disallowed_if_subscription_inactive_and_over_limit(g
 
 
 @patch('perma.models.LinkUser.links_remaining_in_period', autospec=True)
-@patch('perma.models.base.subscription_is_active', autospec=True)
-@patch('perma.models.base.subscription_has_problem', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_has_problem', autospec=True)
 @patch('perma.models.LinkUser.get_subscription', autospec=True)
 def test_user_link_creation_allowed_if_subscription_inactive_and_under_limit(get_subscription, has_problem, is_active, links_remaining_in_period, paying_user):
     get_subscription.return_value = sentinel.subscription
@@ -496,7 +491,7 @@ def test_user_link_creation_allowed_if_subscription_inactive_and_under_limit(get
 
 
 @patch('perma.models.LinkUser.links_remaining_in_period', autospec=True)
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 @patch('perma.models.LinkUser.get_subscription', autospec=True)
 def test_user_link_creation_allowed_if_subscription_active_and_under_limit(get_subscription, is_active, links_remaining_in_period, paying_user):
     get_subscription.return_value = sentinel.subscription
@@ -510,7 +505,7 @@ def test_user_link_creation_allowed_if_subscription_active_and_under_limit(get_s
 
 
 @patch('perma.models.LinkUser.links_remaining_in_period', autospec=True)
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 @patch('perma.models.LinkUser.get_subscription', autospec=True)
 def test_user_link_creation_disallowed_if_subscription_active_and_under_limit(get_subscription, is_active, links_remaining_in_period, paying_user):
     get_subscription.return_value = sentinel.subscription
@@ -554,7 +549,7 @@ def test_registrar_link_creation_denied_when_frozen(get_subscription, nonpaying_
     assert get_subscription.call_count == 0
 
 
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 @patch('perma.models.Registrar.get_subscription', autospec=True)
 def test_registrar_link_creation_allowed_checks_cached_if_pp_down(get_subscription, is_active, paying_registrar):
     get_subscription.side_effect = PermaPaymentsCommunicationException
@@ -573,8 +568,8 @@ def test_registrar_link_creation_disallowed_if_no_subscription(get_subscription,
     get_subscription.assert_called_once_with(paying_registrar)
 
 
-@patch('perma.models.base.subscription_is_active', autospec=True)
-@patch('perma.models.base.subscription_has_problem', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_has_problem', autospec=True)
 @patch('perma.models.Registrar.get_subscription', autospec=True)
 def test_registrar_link_creation_disallowed_if_subscription_inactive(get_subscription, has_problem, is_active, paying_registrar):
     get_subscription.return_value = sentinel.subscription
@@ -585,7 +580,7 @@ def test_registrar_link_creation_disallowed_if_subscription_inactive(get_subscri
     is_active.assert_called_once_with(sentinel.subscription)
 
 
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 @patch('perma.models.Registrar.get_subscription', autospec=True)
 def test_registrar_link_creation_allowed_if_subscription_active(get_subscription, is_active, paying_registrar):
     get_subscription.return_value = sentinel.subscription
@@ -639,7 +634,7 @@ def test_annotate_tier_monthly_no_subscription_mid_month(customers):
         assert tier['next_payment'] == next_month
 
 
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 def test_annotate_tier_monthly_no_subscription_last_of_month(is_active, customers):
     is_active.return_value = True
 
@@ -698,7 +693,7 @@ def test_annotate_tier_change_disallowed_with_inactive_annual_subscription(custo
             assert tier['type'] == 'unavailable'
 
 
-@patch('perma.models.base.subscription_is_active', autospec=True)
+@patch('perma.models.customer.subscription_is_active', autospec=True)
 def test_annotate_tier_change_disallowed_with_pending_downgrade(is_active, customers):
     is_active.return_value = True
 
@@ -1187,7 +1182,7 @@ def test_subscription_is_active_with_expired_canceled(expired_cancelled_subscrip
 # crediting users for one-time purchases
 #
 
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_credit_for_purchased_links_increments_for_all(post, paying_user, spoof_pp_response_no_subscription_two_purchases):
     post.return_value.ok = True
 
@@ -1198,7 +1193,7 @@ def test_credit_for_purchased_links_increments_for_all(post, paying_user, spoof_
     assert credited == 60
 
 
-@patch('perma.models.base.requests.post', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
 def test_credit_for_purchased_links_reverses_if_acknowledgment_fails(post, paying_user, spoof_pp_response_no_subscription_two_purchases):
     post.return_value.ok = False
 
@@ -1214,10 +1209,10 @@ def test_credit_for_purchased_links_reverses_if_acknowledgment_fails(post, payin
 # Bonus packages info
 #
 
-@patch.object(perma.models.base, 'datetime')
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.datetime')
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_get_bonus_packages(prep, mock_datetime, paying_user):
-    perma.models.base.datetime.utcnow.return_value = GENESIS
+    mock_datetime.utcnow.return_value = GENESIS
     prep.return_value.decode.return_value = sentinel.string
 
     packages = paying_user.get_bonus_packages()

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -221,7 +221,7 @@ def test_no_payment_message_for_unrecognized_params(client, user_without_subscri
     assert b'alert-block' not in response.content
 
 
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_subscribe_form_if_no_standing_subscription(prepped, client, user_without_subscription_or_purchase_history):
     user = user_without_subscription_or_purchase_history
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')
@@ -346,7 +346,7 @@ def test_update_page_if_no_standing_subscription(client, user_without_subscripti
 
 
 @patch('perma.views.user_settings.prep_for_perma_payments', autospec=True)
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_update_page_if_standing_subscription(model_prepped, view_prepped, client, user_with_monthly_subscription):
     user = user_with_monthly_subscription
     model_prepped.return_value = bytes(str(sentinel.model_prepped), 'utf-8')
@@ -374,7 +374,7 @@ def test_update_page_if_standing_subscription(model_prepped, view_prepped, clien
 
 
 @patch('perma.views.user_settings.prep_for_perma_payments', autospec=True)
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_update_page_if_downgrade_scheduled(model_prepped, view_prepped, client, user_with_scheduled_downgrade):
     user = user_with_scheduled_downgrade
     model_prepped.return_value = bytes(str(sentinel.model_prepped), 'utf-8')
@@ -417,7 +417,7 @@ def test_update_page_if_subscription_on_hold(prepped, client, user_with_on_hold_
 
 # Subscriptions, Registrar Users
 
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_registrar_user_nonpaying_registrar(prepped, client, registrar_user_from_nonpaying_registrar):
     user = registrar_user_from_nonpaying_registrar
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')
@@ -442,7 +442,7 @@ def test_registrar_user_nonpaying_registrar(prepped, client, registrar_user_from
     assert response.content.count(prepped.return_value) == individual_tier_count + bonus_package_count
 
 
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_paying_registrar_user_sees_both_subscribe_forms(prepped, client, registrar_user_from_paying_registrar_without_subscription):
     user = registrar_user_from_paying_registrar_without_subscription
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')
@@ -466,7 +466,7 @@ def test_paying_registrar_user_sees_both_subscribe_forms(prepped, client, regist
     assert response.content.count(prepped.return_value) == tier_count + bonus_package_count
 
 
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_paying_registrar_user_sees_subscriptions_independently(prepped, client, registrar_user_from_registrar_with_monthly_subscription):
     user = registrar_user_from_registrar_with_monthly_subscription
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')
@@ -496,7 +496,7 @@ def test_paying_registrar_user_sees_subscriptions_independently(prepped, client,
     assert response.content.count(b'<input type="hidden" name="account_type"') == 1
 
 
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_paying_registrar_user_sees_only_allowed_monthly_tier(prepped, client, registrar_user_from_paying_registrar_without_subscription):
     user = registrar_user_from_paying_registrar_without_subscription
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')
@@ -514,7 +514,7 @@ def test_paying_registrar_user_sees_only_allowed_monthly_tier(prepped, client, r
     assert b'<span>Annual plan' not in response.content
 
 
-@patch('perma.models.base.prep_for_perma_payments', autospec=True)
+@patch('perma.models.customer.prep_for_perma_payments', autospec=True)
 def test_paying_registrar_user_sees_only_allowed_annual_tier(prepped, client, registrar_user_from_paying_registrar_without_subscription):
     user = registrar_user_from_paying_registrar_without_subscription
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -137,7 +137,7 @@ def settings_tools(request):
 @user_passes_test_or_403(lambda user: user.can_view_usage_plan())
 def settings_usage_plan(request):
     accounts = []
-    purchase_history = {}
+
     # Status messages for redirects back from the payments app after checkout,
     # e.g. settings/usage-plan/?subscription=success.
     payment_status_level = payment_status_message = None
@@ -183,7 +183,6 @@ def settings_usage_plan(request):
         'update_url': reverse('settings_subscription_update'),
         'accounts': accounts,
         'links_remaining': request.user.get_links_remaining(),
-        'purchase_history': purchase_history,
         'bonus_packages': request.user.get_bonus_packages(),
         'billing_encrypted_data': prep_for_perma_payments({
             'customer_pk': request.user.pk,

--- a/perma_web/perma/views/user_settings.py
+++ b/perma_web/perma/views/user_settings.py
@@ -179,27 +179,22 @@ def settings_usage_plan(request):
     context = {
         'this_page': 'settings_usage_plan',
         'purchase_url': settings.PAYMENTS_APP_URLS['purchase'],
+        'billing_portal_url': settings.PAYMENTS_APP_URLS['billing'],
         'subscribe_url': settings.PAYMENTS_APP_URLS['subscribe'],
         'update_url': reverse('settings_subscription_update'),
         'accounts': accounts,
         'links_remaining': request.user.get_links_remaining(),
         'purchase_history': purchase_history,
         'bonus_packages': request.user.get_bonus_packages(),
+        'billing_encrypted_data': prep_for_perma_payments({
+            'customer_pk': request.user.pk,
+            'customer_type': 'Individual',
+            'timestamp': timezone.now().timestamp(),
+        }).decode('utf-8'),
         'display_cybersource_freeze_message': waffle.switch_is_active('display_cybersource_freeze_message'),
         'payment_status_level': payment_status_level,
         'payment_status_message': payment_status_message,
     }
-
-    # The "Billing and Purchase History" button posts straight to the payments
-    # app, like the bonus package buttons do. This section is about personal links,
-    # so the customer is always the LinkUser, never their registrar.
-    if not request.user.nonpaying:
-        context['billing_portal_url'] = settings.PAYMENTS_APP_URLS['billing']
-        context['billing_encrypted_data'] = prep_for_perma_payments({
-            'customer_pk': request.user.pk,
-            'customer_type': 'Individual',
-            'timestamp': timezone.now().timestamp(),
-        }).decode('utf-8')
 
     grandfathered = request.user.grandfathered or (
         request.user.is_registrar_user() and request.user.registrar.grandfathered


### PR DESCRIPTION
This PR does two closely related things, both to improve the legibility of Perma's codebase as pertains to paying customers.

It is easiest to read commit-by-commit; recommended if the overall diff feels overwhelming.

First, it extracts the `Customer` abstract class out into its own submodule in `models`. Why? Well, to be perfectly honest: because I -keep looking for it there- every time I want to find that logic, ever since the refactor that split up models.py into submodules lol. It's been many months, so at this point, I take this as evidence that that's a good idea 😄. Second, for consistency with the rest of the repo, it moves the small amount of remaining "helper" logic out of `models/base.py` into a `models/utils.py`. These are both stylistic; I do think helpful, but equal parts taste and substance.

Then, it refactors the templating of the main page that Perma's paying users interact with: the Usage Plan page. That page started off small and got more and more complex over the intervening decade, until during the Cybersource -> Stripe transition, it became totally unmanageable, as all complained 😂 . This PR switches it from a single, highly complex template with lots and lots of nesting and `if/then/else` to one simple base template, and then a series of includes.

The base template is nice and short:
```
{% extends "settings-layout.html" %}
{% block title %} | Settings{% endblock %}
{% block dashboardContent %}

  {% if payment_status_message %}
    <div class="alert alert-{{ payment_status_level }} alert-block">{{ payment_status_message }}</div>
  {% endif %}

  {% for account in accounts %}
    {% with subscription=account.subscription %}
      {% with customer=account.customer %}
        {% with customer_type=customer.customer_type %}

          {% if customer_type == 'Registrar' %}
            <h2 class="body-ah">Registrar Subscription &mdash; {{ customer.name }}</h2>
          {% else %}
            <h2 class="body-ah">Personal Subscription</h2>
          {% endif %}

          {% if not subscription %}
            {% include 'includes/subscription-purchase.html' %}
          {% else %}
            {% include 'includes/subscription-details.html' %}
          {% endif %}

        {% endwith %}
      {% endwith %}
    {% endwith %}
  {% endfor %}

  {% if request.user.can_purchase_bonus_links %}
    {% include 'includes/bonus-links-purchase.html' %}
  {% endif %}

{% endblock %}
```
That's it! 

The includes also make use of reusable components, like `subscription-definition.html`, for improved consistency: in the original mammoth template, there was a fair bit of near-duplication, with subtle details differing. By extracting these bits of logic into reusable files, those differences are both reduced and made easier to spot... which will smooth the way for future UI improvements. 

Finally, this PR includes a small bug fix, the problem uncovered by the refactoring (which I think proves the refactoring was worth it!). This simpler templating made it clear that, in the old setup, it would have in theory been possible for a non-paying, "unlimited" user to purchase (unnecessary) bonus links. In reality... no such user was presented with that option, but this PR adds code that removes the possibility.

Screenshots forthcoming but: everything should look exactly the same as before, no changes 😁 