### PR TITLE
dont increment counts in the case of a deleted resaved link

### DIFF
--- a/perma_web/perma/signals.py
+++ b/perma_web/perma/signals.py
@@ -9,13 +9,15 @@ from .models import Link
 @receiver(pre_save, sender=Link)
 def update_link_count(sender, instance, **kwargs):
     try:
-        # get an existing link
-        loaded_link = sender.objects.get(pk=instance.pk)
+        # include user deleted links, so we don't hit the new link signal when a link is deleted and later saved
+        loaded_link = sender.objects.all_with_deleted().get(pk=instance.pk)
+        if loaded_link.user_deleted and instance.user_deleted:
+            return
 
         def decrement_link_count(loaded_link):
             # minus one from user's organization and related registar
             if loaded_link.organization:
-                if  loaded_link.organization.link_count > 0:
+                if loaded_link.organization.link_count > 0:
                     loaded_link.organization.link_count -= 1
                     loaded_link.organization.save()
 

--- a/perma_web/perma/tests/test_link_count_caching.py
+++ b/perma_web/perma/tests/test_link_count_caching.py
@@ -7,26 +7,29 @@ def test_link_count_do_not_increment_after_saving_a_deleted_link(org_user, link_
         submitted_url="http://example.com",
         organization=organization,
     )
+    org_user.refresh_from_db()
+    organization.refresh_from_db()
+    registrar.refresh_from_db()
+    assert org_user.link_count == 1
+    assert organization.link_count == 1
+    assert registrar.link_count == 1
     link.safe_delete() 
-    link.save() # user should have 0 links now
+    link.save()
 
-    # get the link counts before the link is saved again
     org_user.refresh_from_db()
     organization.refresh_from_db()
     registrar.refresh_from_db()
-    user_count = org_user.link_count
-    org_count = organization.link_count
-    registrar_count = registrar.link_count
+    assert org_user.link_count == 0
+    assert organization.link_count == 0
+    assert registrar.link_count == 0
 
-    link.save() # user should still have 0 links
-
-    # get the link counts after the link is saved again
+    link.save()
     org_user.refresh_from_db()
     organization.refresh_from_db()
     registrar.refresh_from_db()
-    assert org_user.link_count == user_count
-    assert organization.link_count == org_count
-    assert registrar.link_count == registrar_count
+    assert org_user.link_count == 0
+    assert organization.link_count == 0
+    assert registrar.link_count == 0
 
 
 def test_link_count_regular_user(link_user, link_factory):

--- a/perma_web/perma/tests/test_link_count_caching.py
+++ b/perma_web/perma/tests/test_link_count_caching.py
@@ -1,3 +1,34 @@
+def test_link_count_do_not_increment_after_saving_a_deleted_link(org_user, link_factory):
+    """ Re-saving a user-deleted link must not count it as a new link """
+    organization = org_user.organizations.first()
+    registrar = organization.registrar
+    link = link_factory(
+        created_by=org_user,
+        submitted_url="http://example.com",
+        organization=organization,
+    )
+    link.safe_delete() 
+    link.save() # user should have 0 links now
+
+    # get the link counts before the link is saved again
+    org_user.refresh_from_db()
+    organization.refresh_from_db()
+    registrar.refresh_from_db()
+    user_count = org_user.link_count
+    org_count = organization.link_count
+    registrar_count = registrar.link_count
+
+    link.save() # user should still have 0 links
+
+    # get the link counts after the link is saved again
+    org_user.refresh_from_db()
+    organization.refresh_from_db()
+    registrar.refresh_from_db()
+    assert org_user.link_count == user_count
+    assert organization.link_count == org_count
+    assert registrar.link_count == registrar_count
+
+
 def test_link_count_regular_user(link_user, link_factory):
     """ We do some link count tallying on save """
     link_count = link_user.link_count


### PR DESCRIPTION
This PR modifies the link pre-save signal to include user-deleted links in the initial link filtering. Otherwise, a previously user-deleted link is treated as a new link, which inflates the user, org, and registrar link numbers (if set). 

This is not a very common case, I think, but I thought it still needed addressing in the greater link counts rethinking effort.

**To reproduce:**

Create a link: User's link count should increment
Delete it: User's link count should decrement
Go to admin and save the link without any changes: User's link count increments. (Work is to fix this).