### PR TITLE
Read pending_change from perma payments directly

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -963,7 +963,8 @@ def spoof_pp_response_subscription():
                 "paid_through": "1970-01-21T00:00:00.000000Z",
                 "link_limit_effective_timestamp": "1970-01-21T00:00:00.000000Z",
                 "link_limit": "unlimited",
-                "reference_number": "PERMA-1237-6200"
+                "reference_number": "PERMA-1237-6200",
+                "pending_change": None
             },
             "purchases": []
         }
@@ -983,7 +984,14 @@ def spoof_pp_response_subscription_with_pending_change():
                 "paid_through": "9999-01-21T00:00:00.000000Z",
                 "link_limit_effective_timestamp": "9999-01-21T00:00:00.000000Z",
                 "link_limit": "unlimited",
-                "reference_number": "PERMA-1237-6201"
+                "reference_number": "PERMA-1237-6201",
+                # until LIL-5426 stage 3, payments also reports a pending change
+                # by overlaying it on the fields above, so include both here
+                "pending_change": {
+                    "rate": "9999.99",
+                    "link_limit": "unlimited",
+                    "effective": "9999-01-21T00:00:00.000000Z"
+                }
             },
             "purchases": []
         }

--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -985,8 +985,9 @@ def spoof_pp_response_subscription_with_pending_change():
                 "link_limit_effective_timestamp": "9999-01-21T00:00:00.000000Z",
                 "link_limit": "unlimited",
                 "reference_number": "PERMA-1237-6201",
-                # until LIL-5426 stage 3, payments also reports a pending change
-                # by overlaying it on the fields above, so include both here
+                # the tier values above deliberately differ from the pending
+                # change, so tests can prove the tier fields are not applied
+                # to the customer while a change is pending
                 "pending_change": {
                     "rate": "9999.99",
                     "link_limit": "unlimited",

--- a/perma_web/perma/models/customer.py
+++ b/perma_web/perma/models/customer.py
@@ -242,13 +242,21 @@ class CustomerModel(models.Model):
         self.cached_subscription_status = post_data['subscription']['status']
         self.cached_paid_through = pp_date_from_post(post_data['subscription']['paid_through'])
 
-        pending_change = None
-        # Perma Payments should always supply an effective timestamp, but the
-        # field is nullable there, so a missing value would raise on the
-        # comparison below (None <= datetime). Treat a missing timestamp as
-        # already applied: show the returned tier as current with no pending
-        # change, rather than 500 the usage-plan page.
-        if subscription_change_effective is None or subscription_change_effective <= timezone.now():
+        # Perma Payments tells us about scheduled downgrades directly now (see
+        # LIL-5426). If a change is pending, leave the local tier fields as they
+        # are, since they already match the current tier. If the field is missing
+        # we're talking to an older payments build and nothing is pending.
+        pending_change = post_data['subscription'].get('pending_change')
+        if pending_change:
+            pending_change = {
+                'rate': pending_change['rate'],
+                'link_limit': pending_change['link_limit'],
+                # downgrades can't switch between monthly and annual billing,
+                # so the pending change keeps the subscription's frequency
+                'frequency': post_data['subscription']['frequency'],
+                'effective': pp_date_from_post(pending_change['effective']),
+            }
+        else:
             self.link_limit_period = post_data['subscription']['frequency']
             self.cached_subscription_rate = Decimal(post_data['subscription']['rate'])
             if post_data['subscription']['link_limit'] == 'unlimited':
@@ -256,13 +264,6 @@ class CustomerModel(models.Model):
             else:
                 self.unlimited = False
                 self.link_limit = int(post_data['subscription']['link_limit'])
-        else:
-            pending_change = {
-                'rate': post_data['subscription']['rate'],
-                'link_limit': post_data['subscription']['link_limit'],
-                'frequency': post_data['subscription']['frequency'],
-                'effective': subscription_change_effective
-            }
         self.save(update_fields=['in_trial', 'cached_subscription_started', 'cached_subscription_status', 'cached_paid_through', 'cached_subscription_rate', 'unlimited', 'link_limit', 'link_limit_period'])
         self.refresh_from_db()
 

--- a/perma_web/perma/models/customer.py
+++ b/perma_web/perma/models/customer.py
@@ -242,11 +242,10 @@ class CustomerModel(models.Model):
         self.cached_subscription_status = post_data['subscription']['status']
         self.cached_paid_through = pp_date_from_post(post_data['subscription']['paid_through'])
 
-        # Perma Payments tells us about scheduled downgrades directly now (see
-        # LIL-5426). If a change is pending, leave the local tier fields as they
-        # are, since they already match the current tier. If the field is missing
-        # we're talking to an older payments build and nothing is pending.
-        pending_change = post_data['subscription'].get('pending_change')
+        # Perma Payments reports any scheduled downgrade in pending_change.
+        # While one is pending, leave the local tier fields alone: they
+        # already hold the current tier.
+        pending_change = post_data['subscription']['pending_change']
         if pending_change:
             pending_change = {
                 'rate': pending_change['rate'],

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -200,28 +200,13 @@ def test_get_subscription_happy_path_with_pending_change(post, process, paying_u
 @patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
 @patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_null_effective_timestamp_treated_as_applied(post, process, paying_user, spoof_pp_response_subscription):
-    # A null link_limit_effective_timestamp (e.g. a legacy Perma Payments row)
-    # must not crash the usage-plan read; the returned tier is applied as
-    # current, with no pending change.
+    # link_limit_effective_timestamp is nullable on the payments side, so a
+    # null must not crash the usage-plan read. The returned tier is applied
+    # as current, with no pending change.
     post.return_value.status_code = 200
     customer = paying_user
     response = spoof_pp_response_subscription(customer)
     response['subscription']['link_limit_effective_timestamp'] = None
-    process.return_value = response
-    subscription = customer.get_subscription()
-    assert subscription['pending_change'] is None
-    assert subscription['status'] == response['subscription']['status']
-
-
-@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
-@patch('perma.models.customer.requests.post', autospec=True)
-def test_get_subscription_tolerates_missing_pending_change_field(post, process, paying_user, spoof_pp_response_subscription):
-    # an older payments build won't send pending_change at all; treat that
-    # as no pending change instead of blowing up
-    post.return_value.status_code = 200
-    customer = paying_user
-    response = spoof_pp_response_subscription(customer)
-    del response['subscription']['pending_change']
     process.return_value = response
     subscription = customer.get_subscription()
     assert subscription['pending_change'] is None

--- a/perma_web/perma/tests/test_models.py
+++ b/perma_web/perma/tests/test_models.py
@@ -185,10 +185,10 @@ def test_get_subscription_happy_path_with_pending_change(post, process, paying_u
             'paid_through': pp_date_from_post('9999-01-21T00:00:00.000000Z'),
             'reference_number': response['subscription']['reference_number'],
             'pending_change': {
-                'rate': response['subscription']['rate'],
-                'link_limit': response['subscription']['link_limit'],
+                'rate': response['subscription']['pending_change']['rate'],
+                'link_limit': response['subscription']['pending_change']['link_limit'],
                 'frequency': response['subscription']['frequency'],
-                'effective': pp_date_from_post(response['subscription']['link_limit_effective_timestamp'])
+                'effective': pp_date_from_post(response['subscription']['pending_change']['effective'])
             }
         }
         assert str(customer.link_limit) != response['subscription']['link_limit']
@@ -201,12 +201,27 @@ def test_get_subscription_happy_path_with_pending_change(post, process, paying_u
 @patch('perma.models.customer.requests.post', autospec=True)
 def test_get_subscription_null_effective_timestamp_treated_as_applied(post, process, paying_user, spoof_pp_response_subscription):
     # A null link_limit_effective_timestamp (e.g. a legacy Perma Payments row)
-    # must not crash the usage-plan read on the None <= now comparison; it is
-    # treated as already applied, with no pending change.
+    # must not crash the usage-plan read; the returned tier is applied as
+    # current, with no pending change.
     post.return_value.status_code = 200
     customer = paying_user
     response = spoof_pp_response_subscription(customer)
     response['subscription']['link_limit_effective_timestamp'] = None
+    process.return_value = response
+    subscription = customer.get_subscription()
+    assert subscription['pending_change'] is None
+    assert subscription['status'] == response['subscription']['status']
+
+
+@patch('perma.models.customer.process_perma_payments_transmission', autospec=True)
+@patch('perma.models.customer.requests.post', autospec=True)
+def test_get_subscription_tolerates_missing_pending_change_field(post, process, paying_user, spoof_pp_response_subscription):
+    # an older payments build won't send pending_change at all; treat that
+    # as no pending change instead of blowing up
+    post.return_value.status_code = 200
+    customer = paying_user
+    response = spoof_pp_response_subscription(customer)
+    del response['subscription']['pending_change']
     process.return_value = response
     subscription = customer.get_subscription()
     assert subscription['pending_change'] is None


### PR DESCRIPTION
Step 2 of 3 for LIL-5426.

Perma infers scheduled downgrades when perma payments reports the future plan's values with a future effective date. As of yesterday, perma payments also states the downgrade in an explicit `pending_change` field (step 1, in prod). This PR switches perma to reading that field and drops the date inference.

While a downgrade is pending we still leave the local plan fields alone, same as before, just triggered by the explicit field instead of date math. If the field is ever missing (an older payments build), we treat it as no change pending rather than erroring.