### PR TITLE
Remove purchase history relics

### DIFF
--- a/perma_web/conftest.py
+++ b/perma_web/conftest.py
@@ -755,54 +755,20 @@ def expired_cancelled_subscription():
 
 
 @pytest.fixture
-def no_purchase_history():
-    return {'purchases': [], 'total_links': 0}
-
-
-@pytest.fixture
-def some_purchase_history():
-    return {
-        'purchases': [
-            {'link_quantity': 10, 'date': GENESIS},
-            {'link_quantity': 3, 'date': GENESIS}
-        ],
-        'total_links': 13
-    }
-
-
-@pytest.fixture
-def user_without_subscription_or_purchase_history(mocker, link_user, no_purchase_history):
+def user_without_subscription(mocker, link_user):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
 
     get_subscription.return_value = None
-    get_purchase_history.return_value = no_purchase_history
 
     yield link_user
 
     get_subscription.assert_called_once_with(link_user)
 
 @pytest.fixture
-def user_without_subscription_with_purchase_history(mocker, link_user, some_purchase_history):
+def user_with_monthly_subscription(mocker, link_user, current_monthly_subscription):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
-
-    get_subscription.return_value = None
-    get_purchase_history.return_value = some_purchase_history
-
-    yield link_user
-
-    get_subscription.assert_called_once_with(link_user)
-    get_purchase_history.assert_called_once_with(link_user)
-
-
-@pytest.fixture
-def user_with_monthly_subscription(mocker, link_user, current_monthly_subscription, no_purchase_history):
-    get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
 
     get_subscription.return_value = current_monthly_subscription
-    get_purchase_history.return_value = no_purchase_history
 
     yield link_user
 
@@ -810,12 +776,10 @@ def user_with_monthly_subscription(mocker, link_user, current_monthly_subscripti
 
 
 @pytest.fixture
-def user_with_scheduled_downgrade(mocker, link_user, current_monthly_subscription_with_scheduled_downgrade, no_purchase_history):
+def user_with_scheduled_downgrade(mocker, link_user, current_monthly_subscription_with_scheduled_downgrade):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
 
     get_subscription.return_value = current_monthly_subscription_with_scheduled_downgrade
-    get_purchase_history.return_value = no_purchase_history
 
     yield link_user
 
@@ -823,12 +787,10 @@ def user_with_scheduled_downgrade(mocker, link_user, current_monthly_subscriptio
 
 
 @pytest.fixture
-def user_with_on_hold_subscription(mocker, link_user, on_hold_monthly_subscription, no_purchase_history):
+def user_with_on_hold_subscription(mocker, link_user, on_hold_monthly_subscription):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
 
     get_subscription.return_value = on_hold_monthly_subscription
-    get_purchase_history.return_value = no_purchase_history
 
     yield link_user
 
@@ -836,13 +798,11 @@ def user_with_on_hold_subscription(mocker, link_user, on_hold_monthly_subscripti
 
 
 @pytest.fixture
-def registrar_user_from_nonpaying_registrar(mocker, registrar_user, no_purchase_history):
+def registrar_user_from_nonpaying_registrar(mocker, registrar_user):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
     registrar_get_subscription = mocker.patch('perma.models.Registrar.get_subscription', autospec=True)
 
     get_subscription.return_value = None
-    get_purchase_history.return_value = no_purchase_history
 
     yield registrar_user
 
@@ -851,13 +811,11 @@ def registrar_user_from_nonpaying_registrar(mocker, registrar_user, no_purchase_
 
 
 @pytest.fixture
-def registrar_user_from_paying_registrar_without_subscription(mocker, paying_registrar_user, no_purchase_history):
+def registrar_user_from_paying_registrar_without_subscription(mocker, paying_registrar_user):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
     registrar_get_subscription = mocker.patch('perma.models.Registrar.get_subscription', autospec=True)
 
     get_subscription.return_value = None
-    get_purchase_history.return_value = no_purchase_history
     registrar_get_subscription.return_value = None
 
     yield paying_registrar_user
@@ -867,13 +825,11 @@ def registrar_user_from_paying_registrar_without_subscription(mocker, paying_reg
 
 
 @pytest.fixture
-def registrar_user_from_paying_registrar_with_personal_subscription(mocker, paying_registrar_user, current_monthly_subscription, no_purchase_history):
+def registrar_user_from_paying_registrar_with_personal_subscription(mocker, paying_registrar_user, current_monthly_subscription):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
     registrar_get_subscription = mocker.patch('perma.models.Registrar.get_subscription', autospec=True)
 
     get_subscription.return_value = current_monthly_subscription
-    get_purchase_history.return_value = no_purchase_history
     registrar_get_subscription.return_value = None
 
     yield paying_registrar_user
@@ -882,13 +838,11 @@ def registrar_user_from_paying_registrar_with_personal_subscription(mocker, payi
 
 
 @pytest.fixture
-def registrar_user_from_registrar_with_monthly_subscription(mocker, paying_registrar_user, current_monthly_unlimited_subscription, no_purchase_history):
+def registrar_user_from_registrar_with_monthly_subscription(mocker, paying_registrar_user, current_monthly_unlimited_subscription):
     get_subscription = mocker.patch('perma.models.LinkUser.get_subscription', autospec=True)
-    get_purchase_history = mocker.patch('perma.models.LinkUser.get_purchase_history', autospec=True)
     registrar_get_subscription = mocker.patch('perma.models.Registrar.get_subscription', autospec=True)
 
     get_subscription.return_value = None
-    get_purchase_history.return_value = no_purchase_history
     registrar_get_subscription.return_value = current_monthly_unlimited_subscription
 
     yield paying_registrar_user

--- a/perma_web/perma/models/customer.py
+++ b/perma_web/perma/models/customer.py
@@ -32,11 +32,6 @@ FIELDS_REQUIRED_FROM_PERMA_PAYMENTS = {
         'customer_type',
         'subscription',
         'purchases'
-    ],
-    'get_purchase_history': [
-        'customer_pk',
-        'customer_type',
-        'purchase_history'
     ]
 }
 
@@ -134,51 +129,6 @@ class CustomerModel(models.Model):
         if self.customer_type != 'Registrar':
             return None
         return (getattr(self, 'name', '') or '').strip() or None
-
-    @sensitive_variables()
-    def get_purchase_history(self):
-        if self.nonpaying:
-            return None
-
-        try:
-            r = requests.post(
-                settings.PAYMENTS_APP_URLS['purchase_history'],
-                timeout=settings.PERMA_PAYMENTS_TIMEOUT,
-                data={
-                    'encrypted_data': prep_for_perma_payments({
-                        'timestamp': datetime.utcnow().timestamp(),
-                        'customer_pk':  self.pk,
-                        'customer_type': self.customer_type
-                    })
-                }
-            )
-            assert r.ok, r.status_code
-        except (requests.RequestException, AssertionError, ImproperlyConfigured) as e:
-            msg = f"Communication with Perma-Payments failed: {e}"
-            if settings.PERMA_PAYMENTS_IN_MAINTENANCE:
-                logger.info(msg)
-            else:
-                logger.error(msg)
-            raise PermaPaymentsCommunicationException(msg)
-
-        post_data = process_perma_payments_transmission(r.json(), FIELDS_REQUIRED_FROM_PERMA_PAYMENTS['get_purchase_history'])
-
-        if post_data['customer_pk'] != self.pk or post_data['customer_type'] != self.customer_type:
-            msg = "Unexpected response from Perma-Payments."
-            logger.error(msg)
-            raise InvalidTransmissionException(msg)
-
-        return {
-            'purchases': [
-                {
-                    'link_quantity': item['link_quantity'],
-                    'date': pp_date_from_post(item['date']),
-                    'reference_number': item['reference_number']
-                } for item in post_data['purchase_history']
-            ],
-            'total_links': sum(int(purchase['link_quantity']) for purchase in post_data['purchase_history'])
-        }
-
 
     @sensitive_variables()
     def get_subscription(self):

--- a/perma_web/perma/settings/utils/post_processing.py
+++ b/perma_web/perma/settings/utils/post_processing.py
@@ -104,7 +104,6 @@ def post_process_settings(settings):
     assert 'STRIPE_PAYMENTS_APP_INTERNAL_URL' in settings and settings['STRIPE_PAYMENTS_APP_INTERNAL_URL'] is not None, "Set DJANGO__STRIPE_PAYMENTS_APP_INTERNAL_URL env var!"
     settings['PAYMENTS_APP_URLS'] = {
         'purchase': f"{settings['STRIPE_PAYMENTS_APP_EXTERNAL_URL']}/purchase/",
-        'purchase_history': f"{settings['STRIPE_PAYMENTS_APP_INTERNAL_URL']}/purchase-history/",
         'acknowledge_purchase': f"{settings['STRIPE_PAYMENTS_APP_INTERNAL_URL']}/acknowledge-purchase/",
         'subscribe': f"{settings['STRIPE_PAYMENTS_APP_EXTERNAL_URL']}/subscribe/",
         'subscription_status': f"{settings['STRIPE_PAYMENTS_APP_INTERNAL_URL']}/subscription/",

--- a/perma_web/perma/tests/test_views_user_settings.py
+++ b/perma_web/perma/tests/test_views_user_settings.py
@@ -186,8 +186,8 @@ def test_regular_user_can_see_usage_plan_page(client, link_user):
     assert response.status_code == 200
 
 
-def test_payment_success_message_shown_after_redirect(client, user_without_subscription_or_purchase_history):
-    client.force_login(user_without_subscription_or_purchase_history)
+def test_payment_success_message_shown_after_redirect(client, user_without_subscription):
+    client.force_login(user_without_subscription)
     response = client.get(reverse('settings_usage_plan') + '?subscription=success', secure=True)
 
     assert response.status_code == 200
@@ -195,8 +195,8 @@ def test_payment_success_message_shown_after_redirect(client, user_without_subsc
     assert b'Your subscription has been created.' in response.content
 
 
-def test_downgrade_canceled_message_shown_after_redirect(client, user_without_subscription_or_purchase_history):
-    client.force_login(user_without_subscription_or_purchase_history)
+def test_downgrade_canceled_message_shown_after_redirect(client, user_without_subscription):
+    client.force_login(user_without_subscription)
     response = client.get(reverse('settings_usage_plan') + '?change=canceled', secure=True)
 
     assert response.status_code == 200
@@ -204,8 +204,8 @@ def test_downgrade_canceled_message_shown_after_redirect(client, user_without_su
     assert b'Your scheduled downgrade has been canceled.' in response.content
 
 
-def test_payment_canceled_message_shown_as_info_after_redirect(client, user_without_subscription_or_purchase_history):
-    client.force_login(user_without_subscription_or_purchase_history)
+def test_payment_canceled_message_shown_as_info_after_redirect(client, user_without_subscription):
+    client.force_login(user_without_subscription)
     response = client.get(reverse('settings_usage_plan') + '?purchase=canceled', secure=True)
 
     assert response.status_code == 200
@@ -213,8 +213,8 @@ def test_payment_canceled_message_shown_as_info_after_redirect(client, user_with
     assert b'Link purchase checkout was canceled. You were not charged.' in response.content
 
 
-def test_no_payment_message_for_unrecognized_params(client, user_without_subscription_or_purchase_history):
-    client.force_login(user_without_subscription_or_purchase_history)
+def test_no_payment_message_for_unrecognized_params(client, user_without_subscription):
+    client.force_login(user_without_subscription)
     response = client.get(reverse('settings_usage_plan') + '?subscription=bogus&foo=success', secure=True)
 
     assert response.status_code == 200
@@ -222,8 +222,8 @@ def test_no_payment_message_for_unrecognized_params(client, user_without_subscri
 
 
 @patch('perma.models.customer.prep_for_perma_payments', autospec=True)
-def test_subscribe_form_if_no_standing_subscription(prepped, client, user_without_subscription_or_purchase_history):
-    user = user_without_subscription_or_purchase_history
+def test_subscribe_form_if_no_standing_subscription(prepped, client, user_without_subscription):
+    user = user_without_subscription
     prepped.return_value = bytes(str(sentinel.prepped), 'utf-8')
 
     client.force_login(user)
@@ -235,10 +235,10 @@ def test_subscribe_form_if_no_standing_subscription(prepped, client, user_withou
 
     individual_tier_count = len(settings.TIERS['Individual'])
     bonus_package_count = len(settings.BONUS_PACKAGES)
-    purchase_history_form = 1
+    billing_portal_form = 1
     assert response.content.count(b'<form class="purchase-form') == bonus_package_count
     assert response.content.count(b'<form class="upgrade-form') == individual_tier_count
-    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == individual_tier_count + bonus_package_count + purchase_history_form
+    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == individual_tier_count + bonus_package_count + billing_portal_form
 
 
 def test_manage_button_and_subscription_info_present_if_standing_subscription(client, user_with_monthly_subscription):
@@ -254,11 +254,8 @@ def test_manage_button_and_subscription_info_present_if_standing_subscription(cl
     assert response.content.count(b'<input type="hidden" name="account_type"') == 1
 
 
-def test_billing_portal_button_present(client, mocker, link_user, no_purchase_history):
+def test_billing_portal_button_present(client, mocker, link_user):
     mocker.patch('perma.models.LinkUser.get_subscription', autospec=True, return_value=None)
-    mocker.patch(
-        'perma.models.LinkUser.get_purchase_history', autospec=True, return_value=no_purchase_history
-    )
     link_user.bonus_links = 7
     link_user.save()
 
@@ -309,8 +306,8 @@ def test_apology_page_displayed_if_perma_payments_is_down(get_subscription, clie
     get_subscription.assert_called_once_with(link_user)
 
 
-def test_update_page_if_no_standing_subscription(client, user_without_subscription_or_purchase_history):
-    user = user_without_subscription_or_purchase_history
+def test_update_page_if_no_standing_subscription(client, user_without_subscription):
+    user = user_without_subscription
 
     client.force_login(user)
     response = client.post(
@@ -408,13 +405,13 @@ def test_registrar_user_nonpaying_registrar(prepped, client, registrar_user_from
 
     individual_tier_count = len(settings.TIERS['Individual'])
     bonus_package_count = len(settings.BONUS_PACKAGES)
-    purchase_history_form = 1
+    billing_portal_form = 1
     assert b'Get More Personal Links' in response.content
     assert b'Purchase a personal subscription' in response.content
     assert f'Purchase a subscription for {user.registrar.name}'.encode() not in response.content
     assert response.content.count(b'<form class="purchase-form') == bonus_package_count
     assert response.content.count(b'<form class="upgrade-form') == individual_tier_count
-    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == individual_tier_count + bonus_package_count + purchase_history_form
+    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == individual_tier_count + bonus_package_count + billing_portal_form
     assert response.content.count(prepped.return_value) == individual_tier_count + bonus_package_count
 
 
@@ -432,13 +429,13 @@ def test_paying_registrar_user_sees_both_subscribe_forms(prepped, client, regist
     # all tiers should be offered, both individual and registrar-level
     tier_count = len(settings.TIERS['Individual']) + len(settings.TIERS['Registrar'])
     bonus_package_count = len(settings.BONUS_PACKAGES)
-    purchase_history_form = 1
+    billing_portal_form = 1
     assert b'Get More Personal Links' in response.content
     assert b'Purchase a personal subscription' in response.content
     assert f'Purchase a subscription for {user.registrar.name}'.encode() in response.content
     assert response.content.count(b'<form class="purchase-form') == bonus_package_count
     assert response.content.count(b'<form class="upgrade-form') == tier_count
-    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == tier_count + bonus_package_count + purchase_history_form
+    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == tier_count + bonus_package_count + billing_portal_form
     assert response.content.count(prepped.return_value) == tier_count + bonus_package_count
 
 
@@ -457,13 +454,13 @@ def test_paying_registrar_user_sees_subscriptions_independently(prepped, client,
 
     individual_tier_count = len(settings.TIERS['Individual'])
     bonus_package_count = len(settings.BONUS_PACKAGES)
-    purchase_history_form = 1
+    billing_portal_form = 1
     assert b'Get More Personal Links' in response.content
     assert b'Purchase a personal subscription' in response.content
     assert b'Purchase a subscription for Test Firm' not in response.content
     assert response.content.count(b'<form class="purchase-form') == bonus_package_count
     assert response.content.count(b'<form class="upgrade-form') == individual_tier_count
-    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == individual_tier_count + bonus_package_count + purchase_history_form
+    assert response.content.count(b'<input type="hidden" name="encrypted_data"') == individual_tier_count + bonus_package_count + billing_portal_form
     assert response.content.count(prepped.return_value) == individual_tier_count + bonus_package_count
 
     assert b'Rate' in response.content


### PR DESCRIPTION
See LIL-5641.

Purchase history is viewed through the Stripe portal now, and the payments route is deleted, so this PR removes anything the purchase history uses: the get_purchase_history method, its response contract entry, the URL config, and the test fixtures. 

Also, two renames so a repo search for "purchase_history" comes back clean: 

1. The test fixture `user_without_subscription_or_purchase_history` -> `user_without_subscription` 
2. The test variable`purchase_history_form` -> `billing_portal_form` (it was always counting the billing portal button, which stays).

Note: tasks/merge_accounts.py still references the removed method. Per team discussion it stays for now (it never runs and the broken reference is harmless)